### PR TITLE
added rule NotCreatingElementCorrectly

### DIFF
--- a/src/resources/template-match-not-creating-element-correctly.yaml
+++ b/src/resources/template-match-not-creating-element-correctly.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+xpath: //xsl:element[not(contains(@name, '$') or (contains(@name, '(') and contains(@name, ')')) or (contains(@name, '{') and contains(@name, '}')) or (@namespace))]
+severity: warning
+message: Creating an element node using the xsl:element instruction when could have been possible directly

--- a/test/resources/xpath-packs/template-match-creating-element-correctly.yaml
+++ b/test/resources/xpath-packs/template-match-creating-element-correctly.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: template-match-not-creating-element-correctly
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="o">
+      <div class="container"/>
+      <xsl:element name="{concat('xsl',':','template')}" />
+      <xsl:element name="xsl:html" namespace="http://www.w3.org/1999/xhtml"/>
+      <xsl:element name="{@ooo}"/>
+      <xsl:element name="{$ooo}"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-packs/template-match-not-creating-element-correctly.yaml
+++ b/test/resources/xpath-packs/template-match-not-creating-element-correctly.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: template-match-not-creating-element-correctly
+found:
+  amount: 1
+  positions: [ [ 3, 5 ] ]
+input: |-
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="o">
+      <xsl:element name="div">
+        <xsl:attribute name="class">container</xsl:attribute>
+      </xsl:element>
+    </xsl:template>
+  </xsl:stylesheet>


### PR DESCRIPTION
@maxonfjvipon please review
fixes #69

[here](https://stackoverflow.com/questions/12568962/what-is-the-difference-between-using-xslt-xslelement-and-declaring-elements-l)  I read:

> "a literal `<h1>` element will add to the result tree the namespace nodes that are in scope at that point in the stylesheet, whereas the `<xsl:element name="h1">` won't."

So, I decided to add (`@namespace`) as well. Would that be the right thing to do?
