### PR TITLE
bug(#154): rewrite all violation messages to follow a consistent two-sentence pattern

### DIFF
--- a/src/resources/checks/template-match-are-you-confusing-variable-and-node.yaml
+++ b/src/resources/checks/template-match-are-you-confusing-variable-and-node.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //xsl:apply-templates[some $var in ancestor::xsl:template[1]//xsl:variable satisfies (($var << .) and (starts-with(@select, concat($var/@name, '/')) or @select=$var/@name))]
 severity: warning
-message: You might be confusing a variable reference with a node reference.
+message: A variable name is used bare as a node selector. Use $name syntax to reference the variable.

--- a/src/resources/checks/template-match-blank-nested-if.yaml
+++ b/src/resources/checks/template-match-blank-nested-if.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //xsl:if[(count(*) = 1) and (count(xsl:if) = 1)]
 severity: warning
-message: Recommended to combine nested 'xsl:if' nodes into single one joining conditions with 'and' operator.
+message: "A nested xsl:if inside another xsl:if is prohibited. Combine conditions with 'and' into a single xsl:if."

--- a/src/resources/checks/template-match-can-use-abbreviated-axis-specifier.yaml
+++ b/src/resources/checks/template-match-can-use-abbreviated-axis-specifier.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //*[@*[contains(., "child::") or contains(., "attribute::") or contains(., "parent::")]]
 severity: warning
-message: "Using the lengthy axis specifiers like child::, attribute:: or parent::node(). The abbreviation for parent::node() is .. . Instead of child::node use this node. The attribute axis attribute:: can be abbreviated by @. "
+message: Verbose axis specifiers child::, attribute::, or parent::node() are used. Replace them with the node name alone, @, or .. respectively.

--- a/src/resources/checks/template-match-empty-content-in-instructions.yaml
+++ b/src/resources/checks/template-match-empty-content-in-instructions.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //*[name()='xsl:for-each' or name()='xsl:if' or name()='xsl:otherwise' or name()='xsl:when'][count(node()) = count(text()) and normalize-space() = ""]
 severity: warning
-message: Don't use empty content for instructions like 'xsl:for-each' 'xsl:if' 'xsl:when' etc.
+message: An instruction element such as xsl:for-each, xsl:if, or xsl:when has no content. Add content or remove the empty element.

--- a/src/resources/checks/template-match-function-template-complexity.yaml
+++ b/src/resources/checks/template-match-function-template-complexity.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //(xsl:template | xsl:function)[count(.//xsl:*) > 50]
 severity: warning
-message: The function or template's size/complexity is high. There is need for refactoring the code.
+message: The function or template contains more than 50 XSLT elements. Split it into smaller, focused units.

--- a/src/resources/checks/template-match-incorrect-use-of-boolean-constants.yaml
+++ b/src/resources/checks/template-match-incorrect-use-of-boolean-constants.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //*[@*[(contains(., 'true') and not(contains(., 'true()'))) or (contains(., 'false') and not(contains(., 'false()')))]]
 severity: warning
-message: Incorrectly using the boolean constants as 'true' or 'false'. Use true() instead of 'true', and false() instead of 'false'.
+message: "Boolean constants 'true' and 'false' are non-empty strings, not booleans. Use true() and false() instead."

--- a/src/resources/checks/template-match-monolithic-design.yaml
+++ b/src/resources/checks/template-match-monolithic-design.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: /xsl:stylesheet[count(//xsl:template | //xsl:function) = 1]
 severity: warning
-message: Using a single template/function in the stylesheet. You can modularize the code.
+message: The stylesheet contains only one template or function. Extract logic into separate, focused templates.

--- a/src/resources/checks/template-match-name-starts-with-numeric.yaml
+++ b/src/resources/checks/template-match-name-starts-with-numeric.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //*[name()='xsl:variable' or name()='xsl:template'][@name][contains('0123456789', substring(@name, 1, 1))] | //xsl:function[@name][contains('0123456789', substring(substring-after(@name, ":"), 1, 1))]
 severity: warning
-message: The variable/function/template name starts with a numeric character.
+message: A variable, function, or template name starts with a digit, which is invalid in XPath. Rename it to start with a letter.

--- a/src/resources/checks/template-match-not-creating-element-correctly.yaml
+++ b/src/resources/checks/template-match-not-creating-element-correctly.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //xsl:element[not(contains(@name, '$') or (contains(@name, '(') and contains(@name, ')')) or (contains(@name, '{') and contains(@name, '}')) or (@namespace))]
 severity: warning
-message: Creating an element node using the xsl:element instruction when could have been possible directly
+message: xsl:element is used with a static name. Use a literal result element instead.

--- a/src/resources/checks/template-match-not-using-output.yaml
+++ b/src/resources/checks/template-match-not-using-output.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: /xsl:stylesheet[count(xsl:output) = 0]
 severity: error
-message: The mandatory 'xsl:output' instruction is not used.
+message: The xsl:output instruction is missing. Declare it to specify the serialization format explicitly.

--- a/src/resources/checks/template-match-not-using-schema-types.yaml
+++ b/src/resources/checks/template-match-not-using-schema-types.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: /xsl:stylesheet[@version = '2.0'][not(some $x in .//@* satisfies contains($x, 'xs:'))]
 severity: warning
-message: The stylesheet is not using any of the built-in Schema types (xs:string etc.), when working in XSLT 2.0 mode.
+message: No built-in Schema types are used in XSLT 2.0 mode. Declare variable types with xs:string, xs:integer, or similar.

--- a/src/resources/checks/template-match-null-output-from-stylesheet.yaml
+++ b/src/resources/checks/template-match-null-output-from-stylesheet.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: /xsl:stylesheet//xsl:template[starts-with(@match, '/')][(count(*) = count(xsl:variable)) and (normalize-space(string-join(text(), '')) = '')]
 severity: warning
-message: The stylesheet is not generating any useful output. Please relook at the stylesheet logic.
+message: The root template contains only variable declarations and produces no output. Add instructions that write to the result tree.

--- a/src/resources/checks/template-match-output-method-xml.yaml
+++ b/src/resources/checks/template-match-output-method-xml.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: /xsl:stylesheet/xsl:output[@method = 'xml'][//xsl:template[starts-with(@match, '/') and (count (.//html | .//HTML) > 0)]]
 severity: warning
-message: Using the output method 'xml' when generating HTML code.
+message: "xsl:output declares method='xml' while the root template generates HTML elements. Change the method to 'html'."

--- a/src/resources/checks/template-match-setting-value-of-variable-incorrectly.yaml
+++ b/src/resources/checks/template-match-setting-value-of-variable-incorrectly.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //xsl:variable[(count(*) = 1) and (count(xsl:value-of) = 1)]
 severity: warning
-message: Assign value to a variable using the 'select' syntax if assigning a string value.
+message: A variable is assigned via a nested xsl:value-of instead of the select attribute. Use select syntax instead.

--- a/src/resources/checks/template-match-short-names.yaml
+++ b/src/resources/checks/template-match-short-names.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //*[name()="xsl:variable" or name()="xsl:template"][string-length(@name) = 1] | //xsl:function[string-length(substring-after(@name, ":")) = 1]
 severity: warning
-message: Using a single character name for variable/function/template. Use meaningful names for these features.
+message: A variable, function, or template has a single-character name. Use a descriptive name that reveals intent.

--- a/src/resources/checks/template-match-starts-with-double-slash.yaml
+++ b/src/resources/checks/template-match-starts-with-double-slash.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //xsl:template[starts-with(@match, '//')]
 severity: warning
-message: It's not recommended to start 'match' attribute of 'xsl:template' element with '//'
+message: The match attribute of xsl:template starts with //, which scans the entire document tree. Use a more specific pattern.

--- a/src/resources/checks/template-match-stylesheet-has-no-templates.yaml
+++ b/src/resources/checks/template-match-stylesheet-has-no-templates.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: /xsl:stylesheet[count(xsl:template)=0]
 severity: error
-message: Add templates to the stylesheet.
+message: The stylesheet has no xsl:template elements and produces no output. Add at least one template.

--- a/src/resources/checks/template-match-too-many-small-templates.yaml
+++ b/src/resources/checks/template-match-too-many-small-templates.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: /xsl:stylesheet[count(//xsl:template[count(*) < 3]) >= 10]
 severity: warning
-message: Too many low granular templates in the stylesheet (10 or more).
+message: The stylesheet has 10 or more templates with fewer than 3 child elements. Merge related small templates to reduce fragmentation.

--- a/src/resources/checks/template-match-unused-function-template-parameter.yaml
+++ b/src/resources/checks/template-match-unused-function-template-parameter.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //(xsl:function | xsl:template)/xsl:param[not(some $x in ..//(node() | @*) satisfies contains($x, concat('$', @name)))]
 severity: warning
-message: Function or template parameter is unused in the function/template body.
+message: A parameter is declared but never referenced in the function or template body. Remove it or use it.

--- a/src/resources/checks/template-match-unused-function.yaml
+++ b/src/resources/checks/template-match-unused-function.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //xsl:function[not(some $x in //(@match | @select) satisfies contains($x, @name))]
 severity: warning
-message: Stylesheet functions are unused.
+message: A stylesheet function is never called in any match or select expression. Remove it or call it.

--- a/src/resources/checks/template-match-unused-named-template.yaml
+++ b/src/resources/checks/template-match-unused-named-template.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //xsl:template[not(@match)][@name][not(//xsl:call-template/@name = @name)]
 severity: warning
-message: Named templates in stylesheet are unused.
+message: A named template is never invoked via xsl:call-template. Remove it or call it.

--- a/src/resources/checks/template-match-unused-variable.yaml
+++ b/src/resources/checks/template-match-unused-variable.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //xsl:variable[every $x in (//xsl:variable/../*//@*) satisfies not(contains($x, concat('$', @name)))]
 severity: warning
-message: Variable is unused in the stylesheet.
+message: A variable is declared but never referenced by $name in the stylesheet. Remove it or use it.

--- a/src/resources/checks/template-match-use-choose-without-otherwise.yaml
+++ b/src/resources/checks/template-match-use-choose-without-otherwise.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //xsl:choose[(count(xsl:otherwise) = 0)]
 severity: warning
-message: Recommended to use 'xsl:otherwise' in 'xsl:choose'.
+message: xsl:choose has no xsl:otherwise branch. Add xsl:otherwise to handle unmatched cases explicitly.

--- a/src/resources/checks/template-match-use-double-slash.yaml
+++ b/src/resources/checks/template-match-use-double-slash.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //xsl:template[not(starts-with(@match, '//')) and contains(@match, '//')]
 severity: warning
-message: It's not recommended to use 'match' attribute of 'xsl:template' element with '//'
+message: The match attribute of xsl:template contains //, which triggers a full document scan. Use a more specific path.

--- a/src/resources/checks/template-match-use-node-set-extension.yaml
+++ b/src/resources/checks/template-match-use-node-set-extension.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: /xsl:stylesheet[@version = "2.0"]//*[contains(@select, ":node-set")]
 severity: warning
-message: Don't use node-set extension function if using XSLT 2.0.
+message: The node-set() extension function is unnecessary in XSLT 2.0. Query the variable directly without it.

--- a/src/resources/checks/template-match-use-single-option-for-choose.yaml
+++ b/src/resources/checks/template-match-use-single-option-for-choose.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //xsl:choose[(count(*) = 1)]
 severity: warning
-message: Recommended to use more than one option in 'xsl:choose'. Use 'xsl:if' for single option instead.
+message: xsl:choose contains only one xsl:when branch. Replace it with xsl:if.

--- a/src/resources/checks/template-match-using-disable-output-escaping.yaml
+++ b/src/resources/checks/template-match-using-disable-output-escaping.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //*[@disable-output-escaping = "yes"]
 severity: warning
-message: Have set the disable-output-escaping attribute to 'yes'. Please relook at the stylesheet logic.
+message: "disable-output-escaping='yes' is set, which produces implementation-defined output. Use xsl:copy-of or literal elements instead."

--- a/src/resources/checks/template-match-using-namespace-axis.yaml
+++ b/src/resources/checks/template-match-using-namespace-axis.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //*[(@match | @select)[contains(., 'namespace::')][/xsl:stylesheet/@version = '2.0']]
 severity: warning
-message: Using the deprecated namespace axis, when working in XSLT 2.0 mode. If you need information about the in-scope namespaces of an element should use the functions fn:in-scope-prefixes and fn:namespace-uri-for-prefix.
+message: "The namespace:: axis is deprecated in XSLT 2.0. Use fn:in-scope-prefixes() and fn:namespace-uri-for-prefix() instead."

--- a/src/resources/checks/template-match-using-not-outermost-stylesheet.yaml
+++ b/src/resources/checks/template-match-using-not-outermost-stylesheet.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: /xsl:stylesheet//xsl:stylesheet
 severity: error
-message: \'xsl:stylesheet\' must be the outermost element. Please relook at the stylesheet logic.
+message: xsl:stylesheet is nested inside another element. It must be the outermost element of the document.

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -28,13 +28,13 @@ describe('xslint', function() {
     const expected = [
       'Processed files: 1',
       'Defects found: 7',
-      '(26:9) Don\'t use empty content for instructions like \'xsl:for-each\' \'xsl:if\' \'xsl:when\' etc. (template-match-empty-content-in-instructions)',
-      '(27:9) Don\'t use empty content for instructions like \'xsl:for-each\' \'xsl:if\' \'xsl:when\' etc. (template-match-empty-content-in-instructions)',
-      '(6:1) The stylesheet is not using any of the built-in Schema types (xs:string etc.), when working in XSLT 2.0 mode. (template-match-not-using-schema-types)',
-      '(16:3) Assign value to a variable using the \'select\' syntax if assigning a string value. (template-match-setting-value-of-variable-incorrectly)',
-      '(16:3) Using a single character name for variable/function/template. Use meaningful names for these features. (template-match-short-names)',
-      '(31:3) It\'s not recommended to start \'match\' attribute of \'xsl:template\' element with \'//\' (template-match-starts-with-double-slash)',
-      '(39:3) Named templates in stylesheet are unused. (template-match-unused-named-template)',
+      '(26:9) An instruction element such as xsl:for-each, xsl:if, or xsl:when has no content. Add content or remove the empty element. (template-match-empty-content-in-instructions)',
+      '(27:9) An instruction element such as xsl:for-each, xsl:if, or xsl:when has no content. Add content or remove the empty element. (template-match-empty-content-in-instructions)',
+      '(6:1) No built-in Schema types are used in XSLT 2.0 mode. Declare variable types with xs:string, xs:integer, or similar. (template-match-not-using-schema-types)',
+      '(16:3) A variable is assigned via a nested xsl:value-of instead of the select attribute. Use select syntax instead. (template-match-setting-value-of-variable-incorrectly)',
+      '(16:3) A variable, function, or template has a single-character name. Use a descriptive name that reveals intent. (template-match-short-names)',
+      '(31:3) The match attribute of xsl:template starts with //, which scans the entire document tree. Use a more specific pattern. (template-match-starts-with-double-slash)',
+      '(39:3) A named template is never invoked via xsl:call-template. Remove it or call it. (template-match-unused-named-template)',
     ]
     expected.forEach((str) => assert.ok(stdout.includes(str)))
   })


### PR DESCRIPTION
## Summary

- Each message now follows a strict two-sentence pattern: **[What is wrong.]** **[What must be done.]**
- Removed weak language: "Recommended", "You might be", "Please relook", "You can", "Don't"
- Fixed formatting issues: missing periods, trailing spaces, inconsistent capitalisation
- Updated the one integration test that asserted exact message strings

## Test plan

- [x] All 150 tests pass (`grunt`)

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)