### PR TITLE
bug(#12): check xsl:import sort order by @href

### DIFF
--- a/src/resources/checks/template-match-unsorted-imports.yaml
+++ b/src/resources/checks/template-match-unsorted-imports.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+xpath: //xsl:import[preceding-sibling::xsl:import/@href > @href]
+severity: warning
+message: The 'xsl:import' elements are not sorted alphabetically by '@href'. Sort imports to improve readability.

--- a/src/resources/motives/template-match-unsorted-imports.md
+++ b/src/resources/motives/template-match-unsorted-imports.md
@@ -1,0 +1,26 @@
+# Unsorted imports
+
+Unsorted `xsl:import` elements make it harder to scan for a specific import
+and increase the chance of missing duplicates.
+
+Incorrect:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:import href="/z.xsl"/>
+  <xsl:import href="/x.xsl"/>
+  <xsl:import href="/a.xsl"/>
+</xsl:stylesheet>
+```
+
+Correct:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:import href="/a.xsl"/>
+  <xsl:import href="/x.xsl"/>
+  <xsl:import href="/z.xsl"/>
+</xsl:stylesheet>
+```

--- a/test/resources/xpath-packs/template-match-sorted-imports.yaml
+++ b/test/resources/xpath-packs/template-match-sorted-imports.yaml
@@ -7,8 +7,16 @@ found:
   positions: [ ]
 input: |-
   <?xml version="1.0" encoding="UTF-8"?>
-  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="sorted-imports">
+    <xsl:output encoding="UTF-8" method="xml"/>
     <xsl:import href="/a.xsl"/>
     <xsl:import href="/x.xsl"/>
     <xsl:import href="/z.xsl"/>
+    <xsl:template match="/">
+      <xsl:variable name="items" as="xs:string" select="'hello'"/>
+      <xsl:value-of select="$items"/>
+    </xsl:template>
+    <xsl:template match="root">
+      <xsl:value-of select="."/>
+    </xsl:template>
   </xsl:stylesheet>

--- a/test/resources/xpath-packs/template-match-sorted-imports.yaml
+++ b/test/resources/xpath-packs/template-match-sorted-imports.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: template-match-unsorted-imports
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0" encoding="UTF-8"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:import href="/a.xsl"/>
+    <xsl:import href="/x.xsl"/>
+    <xsl:import href="/z.xsl"/>
+  </xsl:stylesheet>

--- a/test/resources/xpath-packs/template-match-unsorted-imports.yaml
+++ b/test/resources/xpath-packs/template-match-unsorted-imports.yaml
@@ -4,11 +4,19 @@
 pack: template-match-unsorted-imports
 found:
   amount: 2
-  positions: [ [ 4, 3 ], [ 5, 3 ] ]
+  positions: [ [ 5, 3 ], [ 6, 3 ] ]
 input: |-
   <?xml version="1.0" encoding="UTF-8"?>
-  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="unsorted-imports">
+    <xsl:output encoding="UTF-8" method="xml"/>
     <xsl:import href="/z.xsl"/>
     <xsl:import href="/x.xsl"/>
     <xsl:import href="/a.xsl"/>
+    <xsl:template match="/">
+      <xsl:variable name="items" as="xs:string" select="'hello'"/>
+      <xsl:value-of select="$items"/>
+    </xsl:template>
+    <xsl:template match="root">
+      <xsl:value-of select="."/>
+    </xsl:template>
   </xsl:stylesheet>

--- a/test/resources/xpath-packs/template-match-unsorted-imports.yaml
+++ b/test/resources/xpath-packs/template-match-unsorted-imports.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: template-match-unsorted-imports
+found:
+  amount: 2
+  positions: [ [ 4, 3 ], [ 5, 3 ] ]
+input: |-
+  <?xml version="1.0" encoding="UTF-8"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:import href="/z.xsl"/>
+    <xsl:import href="/x.xsl"/>
+    <xsl:import href="/a.xsl"/>
+  </xsl:stylesheet>


### PR DESCRIPTION
## Summary

- Adds `template-match-unsorted-imports` rule that warns when `<xsl:import>` elements are not sorted alphabetically by `@href`
- Adds motive doc with incorrect/correct XSL examples
- Adds two test fixtures: one with unsorted imports (2 violations) and one with sorted imports (0 violations)

Closes #12

## Test plan

- [ ] `npm test` passes with both new fixtures
- [ ] Running xslint against an XSL with unsorted imports produces a `warning`
- [ ] Running xslint against an XSL with sorted imports produces no output for this rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)