### PR TITLE
bug(#119): pin eslint and tighten the rule set

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,16 +8,18 @@
 module.exports = function(grunt) {
   grunt.initConfig({
     eslint: {
-      target: ['Gruntfile.js', 'src/**/*.js', 'test/**/*.js']
+      target: [
+        'Gruntfile.js', 'src/**/*.js', 'test/**/*.js', 'scripts/**/*.js',
+      ],
     },
     mochacli: {
       test: {
         options: {
           files: ['test/**/*.test.js', '!test/resources/**'],
-          timeout: 10000
-        }
-      }
-    }
+          timeout: 10000,
+        },
+      },
+    },
   })
   grunt.loadNpmTasks('grunt-eslint')
   grunt.loadNpmTasks('grunt-mocha-cli')

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,8 @@ import { defineConfig } from "eslint/config";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
+import globals from "globals";
+import jsdoc from "eslint-plugin-jsdoc";
 import { FlatCompat } from "@eslint/eslintrc";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -17,44 +19,50 @@ const compat = new FlatCompat({
   allConfig: js.configs.all
 });
 
-export default defineConfig([{
-  extends: compat.extends("google"),
-  languageOptions: {
-    globals: {},
-    ecmaVersion: 2019,
-    sourceType: "script",
+export default defineConfig([
+  { ignores: ["eslint.config.mjs", "docs/**"] },
+  js.configs.recommended,
+  ...compat.extends("google"),
+  jsdoc.configs["flat/recommended-error"],
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      globals: { ...globals.node, ...globals.mocha },
+      ecmaVersion: 2022,
+      sourceType: "commonjs"
+    },
+    settings: {
+      jsdoc: {
+        tagNamePreference: { returns: "return" }
+      }
+    },
+    rules: {
+      "valid-jsdoc": "off",
+      "require-jsdoc": "off",
+      semi: ["error", "never"],
+      "comma-dangle": ["error", "always-multiline"],
+      indent: ["error", 2],
+      camelcase: ["error", { properties: "never" }],
+      "max-len": ["error", {
+        code: 80,
+        ignoreUrls: true,
+        ignoreStrings: true,
+        ignoreTemplateLiterals: true,
+        ignoreRegExpLiterals: true
+      }],
+      "jsdoc/no-undefined-types": [
+        "error",
+        { definedTypes: ["Document", "Node", "Element"] }
+      ],
+      "jsdoc/reject-any-type": "off"
+    }
   },
-  rules: {
-    semi: "off",
-    "comma-dangle": "off",
-    indent: ["error", 2],
-    camelcase: "off",
-    /**
-    * Excluded valid-jsdoc.
-    * @todo #119:45min Add valid-jsdoc
-    *  This rule was removed in ESLint v9.0.0 and replaced by the eslint-plugin-jsdoc equivalent.
-    *  https://eslint.org/docs/latest/rules/valid-jsdoc
-    *  We have to use this rule here.
-    * @type {string[]}
-    */
-    "valid-jsdoc": "off",
-    /**
-    * Excluded require-jsdoc.
-    * @todo #119:45min Add require-jsdoc
-    *  This rule was removed in ESLint v9.0.0 and replaced by the eslint-plugin-jsdoc equivalent.
-    *  https://eslint.org/docs/latest/rules/require-jsdoc
-    *  We have to use this rule here.
-    * @type {string[]}
-    */
-    "require-jsdoc": "off",
-    /**
-    * Incorrect length of line.
-    * @todo #119:15min Reduce max-len to 80
-    *  We have to reduce max-len to 80 here to check length of lines in code.
-    *  @type {string[]}
-    */
-    "max-len": ["error", {
-      code: 300,
-    }],
-  },
-}]);
+  {
+    files: ["src/**/*.js"],
+    rules: {
+      "jsdoc/require-jsdoc": ["error", {
+        require: { FunctionDeclaration: true, FunctionExpression: true }
+      }]
+    }
+  }
+]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,10 @@
         "xslint": "src/index.js"
       },
       "devDependencies": {
+        "eslint": "^9.39.4",
         "eslint-config-google": "^0.14.0",
+        "eslint-plugin-jsdoc": "^63.0.5",
+        "globals": "^17.6.0",
         "grunt": "^1.6.1",
         "grunt-cli": "^1.5.0",
         "grunt-eslint": "^26.0.0",
@@ -31,6 +34,33 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.87.0.tgz",
+      "integrity": "sha512-mFXZloZMzuJZXSHUmAFu/pXTk0ZJTJBluuAkrvbzidpTN8W6F2bpRFuedSH+85kbdlRLJqc+gfN+kD3JOLJK5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9",
+        "@typescript-eslint/types": "^8.59.4",
+        "comment-parser": "1.4.7",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~7.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -173,6 +203,19 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -320,6 +363,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -333,6 +389,20 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -443,6 +513,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/argparse": {
@@ -768,6 +848,16 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -800,9 +890,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1028,6 +1118,66 @@
         "eslint": ">=5.16.0"
       }
     },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "63.0.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.5.tgz",
+      "integrity": "sha512-AzI9bgKhV9li049/mIblX0c41DeWMMfH9qNsRasc+fAxwURRKChIp03Pk57M7UTf+Y6hifTJ89kQyCOoOLtEDw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.87.0",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.7",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.1",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.8.2",
+        "spdx-expression-parse": "^4.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -1128,9 +1278,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1595,9 +1745,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2162,6 +2312,23 @@
         "node": "*"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -2488,6 +2655,16 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -2974,6 +3151,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-deep-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -3137,6 +3321,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "node_modules/parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -3146,6 +3340,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/patch-package": {
       "version": "8.0.1",
@@ -3344,6 +3545,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -3418,9 +3632,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3498,6 +3712,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
@@ -3671,6 +3910,23 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -20,15 +20,18 @@
   "author": "maxonfjvipon",
   "license": "MIT",
   "dependencies": {
+    "@xmldom/xmldom": "^0.9.9",
     "colors": "1.4.0",
     "commander": "^15.0.0",
     "fontoxpath": "^3.34.0",
-    "@xmldom/xmldom": "^0.9.9",
-    "yaml": "^2.7.0",
-    "patch-package": "^8.0.0"
+    "patch-package": "^8.0.0",
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
+    "eslint": "^9.39.4",
     "eslint-config-google": "^0.14.0",
+    "eslint-plugin-jsdoc": "^63.0.5",
+    "globals": "^17.6.0",
     "grunt": "^1.6.1",
     "grunt-cli": "^1.5.0",
     "grunt-eslint": "^26.0.0",

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -137,7 +137,7 @@ ${indexRows}
 
   fs.writeFileSync(
     path.join(DOCS, 'index.html'),
-    page('xslint checks', indexBody, false)
+    page('xslint checks', indexBody, false),
   )
 
   for (const {name, lint, md} of checks) {
@@ -153,7 +153,7 @@ ${mdHtml}
 
     fs.writeFileSync(
       path.join(CHECKS_DIR, `${name}.html`),
-      page(name, checkBody, true)
+      page(name, checkBody, true),
     )
   }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -16,8 +16,8 @@ const parser = new DOMParser()
 
 /**
  * Get all the files recursively from given directory
- * @param {String} dir - Directory path
- * @return {Array.<String>} - Array of file in given directory
+ * @param {string} dir - Directory path
+ * @return {Array.<string>} - Array of file in given directory
  */
 const allFilesFrom = function(dir) {
   const files = fs.readdirSync(dir, {withFileTypes: true})
@@ -34,9 +34,9 @@ const allFilesFrom = function(dir) {
 
 /**
  * Read file content and parse it.
- * @param {String} type - Type of document
- * @param {function(str: String): any} fromString - Function that parses from string
- * @return {function(path: String): any} - Function that checks file and parses from string
+ * @param {string} type - Type of document
+ * @param {function(string): *} fromString - Parser from string
+ * @return {function(string): *} - Function that checks file and parses it
  */
 const fromFile = function(type, fromString) {
   return function(path) {
@@ -52,7 +52,7 @@ const fromFile = function(type, fromString) {
 
 /**
  * Parse XML from string.
- * @param {String} str - XML as string
+ * @param {string} str - XML as string
  * @return {Document} - Parsed XML as Document
  */
 const xmlFromString = function(str) {
@@ -67,7 +67,7 @@ const xmlFromString = function(str) {
 
 /**
  * Parse YAML from string.
- * @param {String} str - YAML as string
+ * @param {string} str - YAML as string
  * @return {any} - Parses YAML
  */
 const yamlFromString = function(str) {
@@ -84,10 +84,10 @@ module.exports = {
   allFilesFrom,
   xml: {
     parsedFromFile: fromFile('XML', xmlFromString),
-    parsedFromString: xmlFromString
+    parsedFromString: xmlFromString,
   },
   yaml: {
     parsedFromFile: fromFile('YAML', yamlFromString),
-    parsedFromString: yamlFromString
-  }
+    parsedFromString: yamlFromString,
+  },
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,11 +13,16 @@ program
   .name('xslint')
   .usage('path [options]')
   .summary('XSL Linter')
-  .description('XLS Linter (' + version.what + ' built on ' + version.when + ')')
+  .description(
+    'XLS Linter (' + version.what + ' built on ' + version.when + ')',
+  )
   .version(version.what, '-v, --version', 'Output the version number')
   .helpOption('-?, --help', 'Print this help information')
   .option('--log-level <level>', 'Set log level', levels.INFO)
-  .option('--suppress <check>', 'Suppress some checks', (check, suppressions) => [...suppressions, check], [])
+  .option(
+    '--suppress <check>', 'Suppress some checks',
+    (check, suppressions) => [...suppressions, check], [],
+  )
   .argument('[paths...]', 'paths to file or directory to process', ['.'])
   .action((path) => {
     xslint(path, program.opts())

--- a/src/logger.js
+++ b/src/logger.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const stdout = require('./stdout');
+const stdout = require('./stdout')
 
 /**
  * Log levels.
@@ -15,7 +15,7 @@ const LOG_LEVELS = {
   WARNING: 'warning',
   WARN: 'warn',
   ERROR: 'error',
-};
+}
 
 /**
  * Log levels as numbers.
@@ -29,36 +29,36 @@ const LEVELS = {
   [LOG_LEVELS.ERROR]: 3,
 }
 
-let current_level = LEVELS[LOG_LEVELS.INFO]
+let currentLevel = LEVELS[LOG_LEVELS.INFO]
 
 /**
  * Logger.
  * @type {{
- *  debug: function(msg: String, ...args: any)
- *  info: function(msg: String, ...args: any)
- *  warn: function(msg: String, ...args: any)
- *  error: function(msg: String, ...args: any)
- *  setLevel: function(level: string)
+ *  debug: function(string, ...*): void,
+ *  info: function(string, ...*): void,
+ *  warn: function(string, ...*): void,
+ *  error: function(string, ...*): void,
+ *  setLevel: function(string): void
  * }}
  */
 const logger = {
   debug: (msg, ...args) => {
-    if (current_level <= LEVELS[LOG_LEVELS.DEBUG]) {
+    if (currentLevel <= LEVELS[LOG_LEVELS.DEBUG]) {
       stdout.debug(msg, ...args)
     }
   },
   info: (msg, ...args) => {
-    if (current_level <= LEVELS[LOG_LEVELS.INFO]) {
+    if (currentLevel <= LEVELS[LOG_LEVELS.INFO]) {
       stdout.info(msg, ...args)
     }
   },
   warn: (msg, ...args) => {
-    if (current_level <= LEVELS[LOG_LEVELS.WARNING]) {
+    if (currentLevel <= LEVELS[LOG_LEVELS.WARNING]) {
       stdout.warn(msg, ...args)
     }
   },
   error: (msg, ...args) => {
-    if (current_level <= LEVELS[LOG_LEVELS.ERROR]) {
+    if (currentLevel <= LEVELS[LOG_LEVELS.ERROR]) {
       stdout.error(msg, ...args)
     }
   },
@@ -68,16 +68,16 @@ const logger = {
       logger.warn(
         [
           'The incorrect option --log-level provided: "%s".',
-          'Possible options are %s. The default log level "info" is set'
+          'Possible options are %s. The default log level "info" is set',
         ].join(' '),
         level,
-        Object.values(LOG_LEVELS).map((lvl) => `"${lvl}"`).join(', ')
+        Object.values(LOG_LEVELS).map((lvl) => `"${lvl}"`).join(', '),
       )
     } else {
-      current_level = LEVELS[level]
+      currentLevel = LEVELS[level]
       logger.debug(`Log level set to '${level}'`)
     }
-  }
+  },
 }
 
 module.exports = {

--- a/src/stdout.js
+++ b/src/stdout.js
@@ -3,16 +3,16 @@
  * SPDX-License-Identifier: MIT
  */
 
-const safe = require('colors/safe');
+const safe = require('colors/safe')
 
 /**
  * Stdout.
  * @type {{
- *  debug: function(msg: String, ...args: any)
- *  info: function(msg: String, ...args: any)
- *  warn: function(msg: String, ...args: any)
- *  warning: function(msg: String, ...args: any)
- *  error: function(msg: String, ...args: any)
+ *  debug: function(string, ...*): void,
+ *  info: function(string, ...*): void,
+ *  warn: function(string, ...*): void,
+ *  warning: function(string, ...*): void,
+ *  error: function(string, ...*): void
  * }}
  */
 const stdout = {
@@ -30,7 +30,7 @@ const stdout = {
   },
   error: (msg, ...args) => {
     console.log(`${safe.red('[ERROR]')} ${msg}`, ...args)
-  }
+  },
 }
 
 module.exports = stdout

--- a/src/version.js
+++ b/src/version.js
@@ -7,5 +7,5 @@
 // at the "release" pipeline:
 module.exports = {
   what: '0.0.0',
-  when: '0000-00-00'
+  when: '0000-00-00',
 }

--- a/src/xpath-linter.js
+++ b/src/xpath-linter.js
@@ -13,19 +13,19 @@ const {logger} = require('./logger')
  * @type {{xsl: string}}
  */
 const PREFIXES = {
-  'xsl': 'http://www.w3.org/1999/XSL/Transform'
+  'xsl': 'http://www.w3.org/1999/XSL/Transform',
 }
 
 /**
  * Xpath packs files paths.
- * @type {Array.<String>}
+ * @type {Array.<string>}
  */
-const PACKS = allFilesFrom(path.join(__dirname, 'resources', 'checks'));
+const PACKS = allFilesFrom(path.join(__dirname, 'resources', 'checks'))
 
 /**
  * Resolve prefix.
- * @param {String} prefix - Prefix itself
- * @return {null|String} - Resolved prefix
+ * @param {string} prefix - Prefix itself
+ * @return {null | string} - Resolved prefix
  */
 const resolvePrefix = function(prefix) {
   let spec = null
@@ -33,58 +33,68 @@ const resolvePrefix = function(prefix) {
     spec = PREFIXES[prefix]
   }
   return spec
-};
+}
 
 /**
  * Evaluate Xpath on given XSL and return found nodes.
  * @param {Document} xsl - XSL document parsed as {@link Document}
- * @param {String} xpath - Xpath
- * @return {{name: String, line: number, pos: number}[]} - All matching Nodes, in the order defined by the XPath.
+ * @param {string} xpath - Xpath
+ * @return {{name: string, line: number, pos: number}[]} - Matching
+ *  nodes in the order defined by the XPath
  */
-const evaluate_xpath = function(xsl, xpath) {
+const evaluateXpath = function(xsl, xpath) {
   return evaluateXPathToNodes(
-    xpath, xsl, null, {}, {namespaceResolver: resolvePrefix}
+    xpath, xsl, null, {}, {namespaceResolver: resolvePrefix},
   ).map((node) => ({
     name: node.nodeName,
     line: node.lineNumber,
-    pos: node.columnNumber
+    pos: node.columnNumber,
   }))
 }
 
 /**
  * Deleting incorrect substring-suppressions from array of arguments
- * @param {Array.<String>} suppressions - Array of suppressed checks
- * @return {Array.<String>} - Normalizing list of suppressions
+ * @param {Array.<string>} suppressions - Array of suppressed checks
+ * @return {Array.<string>} - Normalizing list of suppressions
  */
-const validated_suppressions = function(suppressions) {
+const validatedSuppressions = function(suppressions) {
   for (const sup of suppressions) {
     if (!PACKS.some((check) => check.includes(sup))) {
-      logger.warn(`Check with substring '${sup}' does not exist. Delete this '--suppress' or use another one.`)
+      logger.warn(
+        `Check with substring '${sup}' does not exist. ` +
+        `Delete this '--suppress' or use another one.`,
+      )
     }
   }
   if (suppressions.some((sup) => sup === '')) {
-    logger.warn('Empty suppress is incorrect. Delete this "--suppress" or use another one.')
-    suppressions = suppressions.filter((sup) => (sup) !== '');
+    logger.warn(
+      'Empty suppress is incorrect. ' +
+      'Delete this "--suppress" or use another one.',
+    )
+    suppressions = suppressions.filter((sup) => (sup) !== '')
   }
-  return suppressions;
+  return suppressions
 }
 
 /**
  * Lint given XSL by Xpath packs.
  * @param {Document} xsl - XSL document parsed as {@link Document}
- * @param {Array.<String>} suppressions - Array of suppressed checks
- * @return {{severity: string, message: string, line: number, pos: number}[]} - Defects found
+ * @param {Array.<string>} suppressions - Array of suppressed checks
+ * @return {{severity: string, message: string, line: number, pos: number}[]}
+ *  - Defects found
  */
-const lint_by_xpath = function(xsl, suppressions = []) {
+const lintByXpath = function(xsl, suppressions = []) {
   logger.debug(`Xpath linting started`)
   const defects = []
   for (const pack of PACKS) {
-    const name = pack.substring(pack.lastIndexOf(path.sep) + 1, pack.lastIndexOf('.yaml'))
+    const name = pack.substring(
+      pack.lastIndexOf(path.sep) + 1, pack.lastIndexOf('.yaml'),
+    )
     if (suppressions.some((sup) => name.includes(sup))) {
       continue
     }
     const yml = yaml.parsedFromFile(pack)
-    const nodes = evaluate_xpath(xsl, yml.xpath)
+    const nodes = evaluateXpath(xsl, yml.xpath)
     if (nodes.length > 0) {
       for (const node of nodes) {
         defects.push({
@@ -92,7 +102,7 @@ const lint_by_xpath = function(xsl, suppressions = []) {
           severity: yml.severity,
           message: yml.message,
           line: node.line,
-          pos: node.pos
+          pos: node.pos,
         })
       }
     }
@@ -102,7 +112,7 @@ const lint_by_xpath = function(xsl, suppressions = []) {
 }
 
 module.exports = {
-  lint_by_xpath,
-  evaluate_xpath,
-  validated_suppressions,
+  lintByXpath,
+  evaluateXpath,
+  validatedSuppressions,
 }

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -6,22 +6,22 @@
 const path = require('path')
 const fs = require('fs')
 const {allFilesFrom, xml} = require('./helpers')
-const {lint_by_xpath, validated_suppressions} = require('./xpath-linter')
+const {lintByXpath, validatedSuppressions} = require('./xpath-linter')
 const {logger} = require('./logger')
 const stdout = require('./stdout')
 
 /**
  * Linters.
- * @type {Array.<function(xsl: String): Array.<Object>>}
+ * @type {Array.<function(Document): Array.<object>>}
  */
 const LINTERS = [
-  lint_by_xpath,
+  lintByXpath,
 ]
 
 /**
  * Returns all .xsl files paths depending on provided path.
- * @param {String} pth - Path to certain file or directory where .xsl should be placed
- * @return {Array.<String>} - Array of .xsl files paths
+ * @param {string} pth - Path to a file or directory holding .xsl files
+ * @return {Array.<string>} - Array of .xsl files paths
  */
 const xsls = function(pth) {
   let files
@@ -39,22 +39,22 @@ const xsls = function(pth) {
  *  logLevel: string
  * }} options - CLI options
  */
-const process_options = function(options) {
+const processOptions = function(options) {
   logger.setLevel(options.logLevel)
 }
 
 /**
  * Entry point.
- * @param {Array.<String>} pths - Path to file or directory with .xsl files to lint
+ * @param {Array.<string>} pths - Files or directories with .xsl to lint
  * @param {{
  *  logLevel: string
  * }} options - CLI options
  */
 const xslint = function(pths, options) {
-  const suppressions = validated_suppressions(options.suppress)
-  process_options(options)
+  const suppressions = validatedSuppressions(options.suppress)
+  processOptions(options)
   logger.info(`Directories and files to process: ${pths.join(', ')}`)
-  pths = pths.map((pth) => path.resolve(process.cwd(), pth));
+  pths = pths.map((pth) => path.resolve(process.cwd(), pth))
   let stylesheets = []
   for (const pth of pths) {
     if (!fs.existsSync(pth)) {
@@ -66,21 +66,16 @@ const xslint = function(pths, options) {
   logger.debug(`Found ${stylesheets.length} .xsl files to process`)
   const defects = []
   for (const stylesheet of stylesheets) {
-    let xsl
-    try {
-      xsl = xml.parsedFromFile(stylesheet)
-    } catch (err) {
-      throw err
-    }
+    const xsl = xml.parsedFromFile(stylesheet)
     logger.debug(`Linting ${stylesheet}...`)
     for (const lint of LINTERS) {
       defects.push(
         ...lint(xsl, suppressions).map(
           (defect) => ({
             ...defect,
-            file: stylesheet
-          })
-        )
+            file: stylesheet,
+          }),
+        ),
       )
     }
   }
@@ -103,4 +98,4 @@ const xslint = function(pths, options) {
   }
 }
 
-module.exports = xslint;
+module.exports = xslint

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,33 +9,27 @@ const os = require('os')
 
 /**
  * Run the console command
- *
- * @param {String} command - Console Command
- * @param {Array.<String>} args - Arguments
+ * @param {string} command - Console Command
+ * @param {Array.<string>} args - Arguments
  * @param {boolean} print - Capture logs or not
  * @return {string} Stdout
  */
 const execCmd = function(command, args, print) {
-  try {
-    return execSync(
-      `${command} ${args.join(' ')}`,
-      {
-        timeout: 120000,
-        windowsHide: true,
-        stdio: print ? null : 'ignore'
-      }
-    ).toString()
-  } catch (ex) {
-    throw ex
-  }
+  return execSync(
+    `${command} ${args.join(' ')}`,
+    {
+      timeout: 120000,
+      windowsHide: true,
+      stdio: print ? null : 'ignore',
+    },
+  ).toString()
 }
 
 /**
  * Helper to run xslint command line tool.
- *
  * @param {Array.<string>} args - Array of args
- * @param {Boolean} print - Capture logs
- * @return {String} Stdout
+ * @param {boolean} print - Capture logs
+ * @return {string} Stdout
  */
 const runXslint = function(args, print = true) {
   try {
@@ -43,24 +37,22 @@ const runXslint = function(args, print = true) {
   } catch (ex) {
     return ex.stdout.toString()
   }
-};
+}
 
 /**
  * Helper to run xcop command line tool.
- *
- * @param {String} arg - arg
- * @param {Boolean} print - Capture logs
- * @return {String} Stdout
+ * @param {string} arg - arg
+ * @param {boolean} print - Capture logs
+ * @return {string} Stdout
  */
 const runXcop = function(arg, print = true) {
   return execCmd('xcop', [arg], print)
-};
+}
 
 /**
  * Helper to check if command is available in the system.
- *
- * @param {String} cmd - Command
- * @param {Boolean} print - Capture logs
+ * @param {string} cmd - Command
+ * @param {boolean} print - Capture logs
  * @return {boolean} - Result
  */
 const cmdAvailable = function(cmd, print = true) {
@@ -71,7 +63,7 @@ const cmdAvailable = function(cmd, print = true) {
   } catch {
     return false
   }
-};
+}
 
 module.exports = {
   runXslint,

--- a/test/xpath-linter.test.js
+++ b/test/xpath-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {evaluate_xpath, lint_by_xpath} = require('../src/xpath-linter')
+const {evaluateXpath, lintByXpath} = require('../src/xpath-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')
@@ -12,7 +12,7 @@ const fs = require('fs')
 
 /**
  * Yaml test packs.
- * @type {Array<String>}
+ * @type {Array<string>}
  */
 const PACKS = allFilesFrom(path.resolve(__dirname, 'resources', 'xpath-packs'))
 
@@ -26,18 +26,20 @@ describe('xpath-linter', function() {
     const other = yml.found.positions.filter((pos) => pos.length == 3).length
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount - other} defects by check ${yml.pack}`, function() {
-        const evaluated = evaluate_xpath(input, lint.xpath)
+        const evaluated = evaluateXpath(input, lint.xpath)
         assert.equal(
           evaluated.length,
           yml.found.amount - other,
         )
-        yml.found.positions.filter((pos) => pos.length == 2).forEach((pos, index) => {
-          assert.equal(evaluated[index].line, yml.found.positions[index][0])
-          assert.equal(evaluated[index].pos, yml.found.positions[index][1])
-        })
+        yml.found.positions
+          .filter((pos) => pos.length == 2)
+          .forEach((pos, index) => {
+            assert.equal(evaluated[index].line, yml.found.positions[index][0])
+            assert.equal(evaluated[index].pos, yml.found.positions[index][1])
+          })
       })
       it(`should find ${yml.found.amount} defects by all checks`, function() {
-        const defects = lint_by_xpath(input)
+        const defects = lintByXpath(input)
         assert.equal(defects.length, yml.found.amount)
         defects.forEach((defect, index) => {
           let severity = lint.severity
@@ -61,10 +63,10 @@ describe('xpath-linter', function() {
       if (cmdAvailable('xcop')) {
         it(`check format of xsl. should find 0 errors`, function() {
           const xsl = path.resolve(__dirname, 'temp.xsl')
-          fs.writeFileSync(xsl, `${input}\n`);
+          fs.writeFileSync(xsl, `${input}\n`)
           const stdout = runXcop(xsl)
           assert.ok(stdout.includes(`${xsl} looks good`))
-          fs.unlinkSync(xsl);
+          fs.unlinkSync(xsl)
         })
       }
     })

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -6,7 +6,7 @@
 const {runXslint} = require('./helpers')
 const assert = require('assert')
 const version = require('../src/version')
-const path = require('path');
+const path = require('path')
 
 describe('xslint', function() {
   it('should print its own version', function() {
@@ -42,7 +42,7 @@ describe('xslint', function() {
     const stdout = runXslint([
       'test/resources/xsl-packs/xsl-with-some-violations.xsl',
       '--suppress=empty-content-in-instructions',
-      '--suppress=template-match-starts-with-double-slash'
+      '--suppress=template-match-starts-with-double-slash',
     ]);
     ['Processed files: 1', 'Defects found: 4'].forEach((expected) => assert.ok(stdout.includes(expected)))
     const absented = [
@@ -58,33 +58,33 @@ describe('xslint', function() {
   it('should test all files', function() {
     const stdout = runXslint([
       'test/resources/xsl-packs/xsl-with-some-violations.xsl',
-      'test/resources/xsl-packs/xsl-with-no-violations.xsl'
+      'test/resources/xsl-packs/xsl-with-no-violations.xsl',
     ])
     const expected = [
       'test/resources/xsl-packs/xsl-with-some-violations.xsl',
       'test/resources/xsl-packs/xsl-with-no-violations.xsl',
     ]
     expected.forEach((str) => assert.ok(stdout.includes(str.split(path.sep).join('/'))))
-    assert.ok(stdout.includes('Processed files: 2'));
+    assert.ok(stdout.includes('Processed files: 2'))
   })
   it('should test all directories', function() {
     const stdout = runXslint([
       'test/resources/xsl-packs',
-      'test/resources/xsl-packs-2'
+      'test/resources/xsl-packs-2',
     ])
     const expected = [
       'test/resources/xsl-packs',
       'test/resources/xsl-packs-2',
     ]
     expected.forEach((str) => assert.ok(stdout.includes(`${path.resolve(process.cwd(), str)}`)))
-    assert.ok(stdout.includes('Processed files: 4'));
+    assert.ok(stdout.includes('Processed files: 4'))
   })
   it('should test all files and directories', function() {
     const stdout = runXslint([
       'test/resources/xsl-packs',
       'test/resources/xsl-packs-2/xsl-with-no-violations.xsl',
       'test/resources/xsl-packs-3',
-      'test/resources/xsl-packs-2/xsl-with-some-violations.xsl'
+      'test/resources/xsl-packs-2/xsl-with-some-violations.xsl',
     ])
     const expected = [
       'test/resources/xsl-packs',
@@ -93,17 +93,17 @@ describe('xslint', function() {
       'test/resources/xsl-packs-2/xsl-with-no-violations.xsl',
     ]
     expected.forEach((str) => assert.ok(stdout.includes(`${str.replace(/\\/g, '/')}`)))
-    assert.ok(stdout.includes('Processed files: 6'));
+    assert.ok(stdout.includes('Processed files: 6'))
   })
   it('should test default directory', function() {
     const stdout = runXslint([])
-    assert.ok(stdout.includes('Directories and files to process: .'));
-    assert.ok(stdout.includes('Processed files: 6'));
+    assert.ok(stdout.includes('Directories and files to process: .'))
+    assert.ok(stdout.includes('Processed files: 6'))
   })
   it('should test empty suppress', function() {
     const stdout = runXslint([
       'test/resources/xsl-packs/xsl-with-some-violations.xsl',
-      '--suppress='
+      '--suppress=',
     ])
     const expected = [
       'Processed files: 1',
@@ -123,25 +123,25 @@ describe('xslint', function() {
     const suppress='qwerty'
     const stdout = runXslint([
       'test/resources/xsl-packs/xsl-with-some-violations.xsl',
-      `--suppress=${suppress}`
+      `--suppress=${suppress}`,
     ])
     assert.ok(stdout.includes(`Check with substring '${suppress}' does not exist. Delete this '--suppress' or use another one.`))
   })
   it('should test non-existing directory', function() {
     const dir = 'non-existing-directory'
     const stdout = runXslint([dir])
-    assert.ok(stdout.includes(`File or directory ${path.resolve(process.cwd(), dir)} does not exist`));
+    assert.ok(stdout.includes(`File or directory ${path.resolve(process.cwd(), dir)} does not exist`))
   })
   it('should test non-existing file', function() {
     const file = 'non-existing-file.xsl'
     const stdout = runXslint([file])
-    assert.ok(stdout.includes(`File or directory ${path.resolve(process.cwd(), file)} does not exist`));
+    assert.ok(stdout.includes(`File or directory ${path.resolve(process.cwd(), file)} does not exist`))
   })
   it('should test non-existing file and directory', function() {
     const file = 'non-existing-file.xsl'
     const dir = 'non-existing-directory'
     const stdout = runXslint([file, dir])
-    assert.ok(stdout.includes(`File or directory ${path.resolve(process.cwd(), file)} does not exist`));
-    assert.ok(stdout.includes(`File or directory ${path.resolve(process.cwd(), dir)} does not exist`));
+    assert.ok(stdout.includes(`File or directory ${path.resolve(process.cwd(), file)} does not exist`))
+    assert.ok(stdout.includes(`File or directory ${path.resolve(process.cwd(), dir)} does not exist`))
   })
 })


### PR DESCRIPTION
Resolves #119.

## What

Pin `eslint` as a direct dev dependency and make the linter strict.

- **Pin eslint** (`^9.39.4`). It was only present transitively via
  `grunt-eslint`, so a stale install could silently disable the linter
  while `npm test` still passed its test half.
- Add `eslint:recommended`, `eslint-plugin-jsdoc` (recommended-error)
  and the Google ruleset on top of the existing config.
- Enforce the project's **existing** style rigorously rather than
  flipping it: `semi: never`, trailing commas, `camelCase`, 2-space
  indent, and an 80-column limit for **code** (strings, templates,
  URLs and regex are exempt so exact-match assertions and the CSS
  template are not mangled).
- Require JSDoc presence and validity on `src/` functions
  (`@return` honored via config; primitive types lowercased).
- Lint `scripts/` too.

## Cleanups the new rules surfaced

- Renamed the snake_case functions (`evaluate_xpath` -> `evaluateXpath`,
  `lint_by_xpath` -> `lintByXpath`, `validated_suppressions`,
  `process_options`, `current_level`).
- Fixed invalid `function(name: type)` JSDoc types.
- Dropped two useless `try/catch` wrappers.

## Verification

`npm test` is green locally: tests pass and the eslint task is clean.
The `grunt` workflow re-runs this across windows/ubuntu/macos x node
20 and 22 on this PR.

## Note

The `RedundantNamespaceDeclarations` work (#87) is on a separate branch.
It should merge after this one, since its new `in_scope_prefixes`
function needs the trivial rename to `inScopePrefixes` to satisfy the
new `camelcase` rule.
