### PR TITLE
bug(#134): validate XPath expressions and XSL well-formedness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,19 +21,26 @@ npx mocha test/xslint.test.js --grep "sentence"  # Run tests matching a pattern
 
 ## Architecture
 
-**xslint** is a CLI linter for XSL stylesheets. It finds `.xsl` files, parses them all into a *corpus* of XML documents, runs each linter over the whole corpus, and reports defects.
+**xslint** is a CLI linter for XSL stylesheets. It runs in two stages: **validators** first establish that the input is valid (each stylesheet is well-formed XML, and every XPath expression compiles), then **linters** run over the stylesheets that pass, catching stylistic, semantic, and logical problems. A stylesheet that does not parse is reported once and left out of the corpus, so one broken file never hides the feedback on the rest.
 
-Linting flow:
+Flow:
 ```text
 src/index.js (CLI, commander.js)
-  → src/xslint.js (file discovery, corpus building, suppression, stdout output)
-    → src/xpath-linter.js (per-file rules)   → src/resources/checks/xpath/*.yaml
+  → src/xslint.js (file discovery, suppression, run order, stdout output)
+    VALIDATORS (is it valid?)
+    → src/xsl-validator.js (XML well-formedness) builds the corpus from the
+        parseable files          → src/resources/checks/validation/malformed-stylesheet.yaml
+    → src/xpath-validator.js (XPath compilability, over the corpus)
+                                 → src/resources/checks/validation/invalid-xpath-expression.yaml
+    LINTERS (is it good?)
+    → src/xpath-linter.js (per-file rules)    → src/resources/checks/xpath/*.yaml
     → src/corpus-linter.js (cross-file rules) → src/resources/checks/corpus/*.yaml
-        both evaluate via src/xpath.js (fontoxpath environment:
-        prefixes, custom functions, node/string evaluators)
+        all (except xsl-validator) evaluate via src/xpath.js (fontoxpath
+        environment: prefixes, custom functions, node/string evaluators,
+        expression validator)
 ```
 
-Every linter has the same shape — `(corpus, suppressions) => defects`, where `corpus` is `[{file, xsl}]` and each defect is tagged with its `file`. `xpath-linter` loops the corpus applying file-local rules; `corpus-linter` reasons across files (e.g. a named template defined in one file but invoked from another is *not* flagged as unused). The two linters do not depend on each other — both depend only on `src/xpath.js`.
+Validators run before linters so the linters reason only over valid input. Most components share the shape `(corpus, suppressions) => defects`, where `corpus` is `[{file, xsl}]` and each defect is tagged with its `file`: `xpath-validator` parses each XPath expression and flags the ones the processor cannot parse; `xpath-linter` loops the corpus applying file-local rules; `corpus-linter` reasons across files (e.g. a named template defined in one file but invoked from another is *not* flagged as unused). The exception is `xsl-validator`, which *builds* the corpus — it takes `(sources, suppressions)` (raw `{file, content}`) and returns `{corpus, defects}`, since the corpus everything else consumes does not exist until well-formedness is checked. None of them depend on each other — each depends only on `src/xpath.js` (and `src/helpers.js`).
 
 **Per-file rule format** (`src/resources/checks/xpath/<name>.yaml`):
 ```yaml
@@ -51,11 +58,22 @@ message: <human-readable explanation>
 ```
 A `declaration` node is a defect only when its `@name` appears in no `usage` value anywhere in the corpus.
 
+**Validator check format** (`src/resources/checks/validation/<name>.yaml`):
+```yaml
+severity: warning|error
+message: <human-readable explanation>
+```
+A validator carries no XPath rule — its detection logic lives in code, and the YAML supplies only the defect's `severity` and `message`. Two validators live here: `malformed-stylesheet` (`src/xsl-validator.js`, XML well-formedness) and `invalid-xpath-expression` (`src/xpath-validator.js`, XPath compilability). The latter parses every bare-XPath-expression attribute (`select`, `test`, `use`, `value`, `group-by`, `group-adjacent`, plus the XSLT 3.0 `key`, `initial-value`, `xpath`, `context-item`, `with-params`, `namespace-context`) via `isValid` (`src/xpath.js`), which compiles with fontoxpath (the same engine that runs the rules) under a resolver where every prefix resolves, so only genuine syntax errors fail — unknown prefixes and custom functions do not. Pattern attributes (`match`, `count`, `from`, `group-starting-with`, `group-ending-with`), attribute value templates, and sequence types (`as`) are deliberately not validated as expressions. Each validator reads its own YAML by name (it does not scan the directory), so adding one validator's YAML never feeds another's logic.
+
 XPath uses namespace prefix `xsl:` → `http://www.w3.org/1999/XSL/Transform` and `xslint:` → custom functions (`src/xpath.js`).
 
 **Per-file test pack** (`test/resources/xpath-packs/<name>.yaml`): `pack`, `found.amount`, `found.positions: [[line, col], ...]`, single `input`. Auto-discovered by `test/xpath-linter.test.js`.
 
 **Corpus test pack** (`test/resources/corpus-packs/<name>.yaml`): `pack`, `found.amount`, `found.positions: [[fileIndex, line, col], ...]`, multiple `inputs: [ ... ]`. Auto-discovered by `test/corpus-linter.test.js`.
+
+**XPath validator test pack** (`test/resources/xpath-validator-packs/<name>.yaml`): `pack`, `found.amount`, `found.positions: [[line, col], ...]`, single `input`. Auto-discovered by `test/xpath-validator.test.js`. The XSL validator is tested separately in `test/xsl-validator.test.js` with inline `{file, content}` sources (well-formed and malformed), and the end-to-end gating (parseable files linted, malformed ones reported and skipped) in `test/xslint.test.js` over a temp directory.
+
+**xcop formatting** — `test/xcop.test.js` extracts the inline XSL from every pack directory holding *well-formed* fixtures (`xpath-packs`, `corpus-packs`, `xpath-validator-packs`), re-serializes it, and runs [xcop](https://github.com/yegor256/xcop) over it to verify the fixtures are well-formatted XML (skipped when `xcop` is not installed). The XML validator's malformed fixtures are deliberately not xcop-checked. A new pack directory of well-formed fixtures must be added to its `PACKS` list, or it goes unchecked.
 
 ## Adding a New Rule
 
@@ -67,19 +85,34 @@ Cross-file rule:
 1. Create `src/resources/checks/corpus/<rule-name>.yaml` with `declaration`, `usage`, `severity`, `message`.
 2. Create `test/resources/corpus-packs/<rule-name>.yaml` with matching `pack`, `found`, `inputs`.
 
-Then: optionally add a rationale at `src/resources/motives/{xpath,corpus}/<rule-name>.md`, run `npm test`, and regenerate the doc site with `npx grunt docs`.
+Validators are not extended this way: their logic is fixed in `src/xsl-validator.js` and `src/xpath-validator.js`, and their `src/resources/checks/validation/<name>.yaml` files only tune `severity` and `message`.
 
-Suppression by users: `xslint --suppress=<rule-substring>` (matches names from both linters).
+Then: optionally add a rationale at `src/resources/motives/{xpath,corpus,validation}/<rule-name>.md`, run `npm test`, and regenerate the doc site with `npx grunt docs`. A brand-new pack directory of well-formed fixtures must also be registered in `test/xcop.test.js` so its inline XSL is formatting-checked.
+
+Suppression by users: `xslint --suppress=<rule-substring>` (matches names from all validators and linters).
+
+## Keeping Docs in Sync
+
+Any change to behavior — new logic, a new check or validator, a rename, a moved file, a changed flag or output — must update the documentation in the same change. Before finishing, check all three and fix whichever went stale:
+
+- **`README.md`** — user-facing: installation, usage, the validators/linters overview, the contribution notes.
+- **`CLAUDE.md`** (this file) — architecture: the flow diagram, the `(corpus, suppressions) => defects` shapes, the check/validator formats, the test-pack layout, and the Key Files table.
+- **The docs site** — generated from `src/resources/checks/*` and `src/resources/motives/*`; regenerate with `npx grunt docs`. A new kind also needs wiring in `scripts/generate-docs.js`.
+
+A change that leaves any of these describing the old behavior is not done.
 
 ## Key Files
 
 | File | Role |
 |------|------|
-| `src/xslint.js` | Orchestrates file discovery, builds the corpus, validates suppressions, invokes linters, formats output |
+| `src/xslint.js` | Orchestrates file discovery and suppression, runs validators then linters, formats output |
+| `src/xsl-validator.js` | Builds the corpus from raw sources; reports each stylesheet that is not well-formed XML and leaves it out |
+| `src/xpath-validator.js` | Parses each XPath expression in the corpus and flags the ones that do not compile |
 | `src/xpath-linter.js` | Loads `checks/xpath/*.yaml`, applies per-file XPath rules |
 | `src/corpus-linter.js` | Loads `checks/corpus/*.yaml`, applies cross-file rules over the corpus |
-| `src/xpath.js` | Shared fontoxpath environment: prefixes, custom functions, node/string evaluators |
+| `src/xpath.js` | Shared fontoxpath environment: prefixes, custom functions, node/string evaluators, expression validator (`isValid`) |
 | `src/helpers.js` | XML parsing (`@xmldom/xmldom`), YAML parsing, file recursion |
 | `src/logger.js` | 4-level logger (debug/info/warning/error) |
 | `scripts/generate-docs.js` | Builds the `docs/` site from checks + motives (`npx grunt docs`) |
 | `test/helpers.js` | `runXslint` / `runXcop` test utilities |
+| `test/xcop.test.js` | Runs xcop over the inline XSL of every pack directory; register new pack dirs here |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ src/index.js (CLI, commander.js)
     VALIDATORS (is it valid?)
     → src/xsl-validator.js (XML well-formedness) builds the corpus from the
         parseable files          → src/resources/checks/validation/malformed-stylesheet.yaml
-    → src/xpath-validator.js (XPath compilability, over the corpus)
+    → src/xpath-validator.js (XPath syntax, over the corpus)
                                  → src/resources/checks/validation/invalid-xpath-expression.yaml
     LINTERS (is it good?)
     → src/xpath-linter.js (per-file rules)    → src/resources/checks/xpath/*.yaml
@@ -63,7 +63,7 @@ A `declaration` node is a defect only when its `@name` appears in no `usage` val
 severity: warning|error
 message: <human-readable explanation>
 ```
-A validator carries no XPath rule — its detection logic lives in code, and the YAML supplies only the defect's `severity` and `message`. Two validators live here: `malformed-stylesheet` (`src/xsl-validator.js`, XML well-formedness) and `invalid-xpath-expression` (`src/xpath-validator.js`, XPath compilability). The latter parses every bare-XPath-expression attribute (`select`, `test`, `use`, `value`, `group-by`, `group-adjacent`, plus the XSLT 3.0 `key`, `initial-value`, `xpath`, `context-item`, `with-params`, `namespace-context`) via `isValid` (`src/xpath.js`), which compiles with fontoxpath (the same engine that runs the rules) under a resolver where every prefix resolves, so only genuine syntax errors fail — unknown prefixes and custom functions do not. Pattern attributes (`match`, `count`, `from`, `group-starting-with`, `group-ending-with`), attribute value templates, and sequence types (`as`) are deliberately not validated as expressions. Each validator reads its own YAML by name (it does not scan the directory), so adding one validator's YAML never feeds another's logic.
+A validator carries no XPath rule — its detection logic lives in code, and the YAML supplies only the defect's `severity` and `message`. Two validators live here: `malformed-stylesheet` (`src/xsl-validator.js`, XML well-formedness) and `invalid-xpath-expression` (`src/xpath-validator.js`, XPath syntax). The latter parses every bare-XPath-expression attribute (`select`, `test`, `use`, `value`, `group-by`, `group-adjacent`, plus the XSLT 3.0 `key`, `initial-value`, `xpath`, `context-item`, `with-params`, `namespace-context`) via `isValid` (`src/xpath.js`), which compiles with fontoxpath (the same engine that runs the rules) under a resolver where every prefix resolves, so only genuine syntax errors fail — unknown prefixes and custom functions do not. Pattern attributes (`match`, `count`, `from`, `group-starting-with`, `group-ending-with`), attribute value templates, and sequence types (`as`) are deliberately not validated as expressions. Each validator reads its own YAML by name (it does not scan the directory), so adding one validator's YAML never feeds another's logic.
 
 XPath uses namespace prefix `xsl:` → `http://www.w3.org/1999/XSL/Transform` and `xslint:` → custom functions (`src/xpath.js`).
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,23 @@ xslint --suppress=monolithic-design --suppress=short-names
 The full list of checks with descriptions and examples is available at
 [maxonfjvipon.github.io/xslint][checks].
 
-Checks come in two kinds:
+xslint runs in two stages. **Validators** first establish that the input is
+valid; **linters** then run over the stylesheets that pass, catching
+stylistic, semantic, and logical problems. A stylesheet that does not parse is
+reported once and skipped, so one broken file never hides the feedback on the
+rest.
+
+Validators:
+
+- **XML well-formedness** — a stylesheet that is not well-formed XML is
+  reported and excluded from linting.
+- **XPath compilability** — every bare XPath expression (in `select`, `test`,
+  `use`, `value`, `group-by`, `group-adjacent`, and the XSLT 3.0 `key`,
+  `initial-value`, `xpath`, `context-item`, `with-params`,
+  `namespace-context`) is parsed; the ones the processor cannot parse are
+  reported.
+
+Linters:
 
 - **Per-file** checks evaluate one stylesheet at a time (most checks).
 - **Cross-file** checks reason across all the stylesheets you lint together.
@@ -98,9 +114,11 @@ before sending us your pull request please make sure all your tests pass:
 npm test
 ```
 
-New checks live in `src/resources/checks/xpath` (per-file) or
-`src/resources/checks/corpus` (cross-file), each with a matching test pack
-in `test/resources`. Regenerate the documentation site with `npx grunt docs`.
+New linter rules live in `src/resources/checks/xpath` (per-file) or
+`src/resources/checks/corpus` (cross-file), each with a matching test pack in
+`test/resources`. The validators in `src/resources/checks/validation` are fixed
+in code; their YAML only tunes severity and message. Regenerate the
+documentation site with `npx grunt docs`.
 
 You will need [npm] and [node] installed
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Validators:
 
 - **XML well-formedness** — a stylesheet that is not well-formed XML is
   reported and excluded from linting.
-- **XPath compilability** — every bare XPath expression (in `select`, `test`,
+- **XPath syntax** — every bare XPath expression (in `select`, `test`,
   `use`, `value`, `group-by`, `group-adjacent`, and the XSLT 3.0 `key`,
   `initial-value`, `xpath`, `context-item`, `with-params`,
   `namespace-context`) is parsed; the ones the processor cannot parse are

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -14,7 +14,7 @@ const CHECKS = path.join(__dirname, '..', 'src', 'resources', 'checks')
 const MOTIVES = path.join(__dirname, '..', 'src', 'resources', 'motives')
 const DOCS = path.join(__dirname, '..', 'docs')
 const CHECKS_DIR = path.join(DOCS, 'checks')
-const KINDS = ['xpath', 'corpus']
+const KINDS = ['xpath', 'corpus', 'validation']
 
 const CSS = `
   * { box-sizing: border-box; }
@@ -101,10 +101,16 @@ const severityBadge = (severity) => {
 
 const escaped = (xpath) => xpath.replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
-const expressions = (kind, lint) => kind === 'corpus' ?
-  `<code class="xpath">declaration: ${escaped(lint.declaration)}</code>
-    <code class="xpath">usage: ${escaped(lint.usage)}</code>` :
-  `<code class="xpath">${escaped(lint.xpath)}</code>`
+const expressions = (kind, lint) => {
+  if (kind === 'corpus') {
+    return `<code class="xpath">declaration: ${escaped(lint.declaration)}</code>
+    <code class="xpath">usage: ${escaped(lint.usage)}</code>`
+  }
+  if (kind === 'validation') {
+    return `<code class="xpath">verified by the parser, not an XPath rule</code>`
+  }
+  return `<code class="xpath">${escaped(lint.xpath)}</code>`
+}
 
 const generate = function() {
   const checks = KINDS.flatMap((kind) => allFilesFrom(path.join(CHECKS, kind))

--- a/src/resources/checks/validation/invalid-xpath-expression.yaml
+++ b/src/resources/checks/validation/invalid-xpath-expression.yaml
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+severity: error
+message: An XPath expression is malformed and cannot be parsed. Fix its syntax.

--- a/src/resources/checks/validation/malformed-stylesheet.yaml
+++ b/src/resources/checks/validation/malformed-stylesheet.yaml
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+severity: error
+message: The stylesheet is not well-formed XML and cannot be parsed. Fix its syntax.

--- a/src/resources/motives/validation/invalid-xpath-expression.md
+++ b/src/resources/motives/validation/invalid-xpath-expression.md
@@ -1,0 +1,30 @@
+# Invalid XPath expression
+
+An attribute carrying a bare XPath expression — `select`, `test`, `use`,
+`value`, `group-by`, `group-adjacent`, or the XSLT 3.0 `key`, `initial-value`,
+`xpath`, `context-item`, `with-params`, `namespace-context` — must hold an
+expression the processor can parse. A malformed expression breaks the
+transformation at runtime, so the sooner it surfaces the better. Only the
+expression syntax is checked, not its formatting; pattern attributes such as
+`match` and attribute value templates are left to other checks.
+
+The expression is parsed by the same engine that evaluates the rules, so it is
+valid here exactly when the processor would accept it. Every prefix resolves
+while parsing, so an unknown prefix or a custom function is never mistaken for
+a syntax error: only genuine syntax mistakes are reported.
+
+Incorrect (`==` is not an XPath operator):
+
+```xsl
+<xsl:if test="foo(a) == 'hello'">
+  <xsl:value-of select="."/>
+</xsl:if>
+```
+
+Correct:
+
+```xsl
+<xsl:if test="foo(a) = 'hello'">
+  <xsl:value-of select="."/>
+</xsl:if>
+```

--- a/src/resources/motives/validation/malformed-stylesheet.md
+++ b/src/resources/motives/validation/malformed-stylesheet.md
@@ -1,0 +1,29 @@
+# Malformed stylesheet
+
+A stylesheet that is not well-formed XML cannot be parsed into a document, so
+nothing downstream can reason about it. It is reported once, and then skipped:
+the other checks run only over the stylesheets that parse, so one broken file
+never hides the feedback on the rest.
+
+This is the first validator in the pipeline — validators establish that the
+input is parseable, and the linters that follow assume it.
+
+Incorrect:
+
+```xsl
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:template match="/">
+    <result>
+  </xsl:template>
+</xsl:stylesheet>
+```
+
+Correct:
+
+```xsl
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:template match="/">
+    <result/>
+  </xsl:template>
+</xsl:stylesheet>
+```

--- a/src/xpath-validator.js
+++ b/src/xpath-validator.js
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {nodes, isValid} = require('./xpath')
+const {yaml} = require('./helpers')
+const path = require('node:path')
+const {logger} = require('./logger')
+
+/**
+ * Name of the check this validator owns.
+ * @type {string}
+ */
+const CHECK = 'invalid-xpath-expression'
+
+/**
+ * Defect metadata of the check.
+ * @type {{severity: string, message: string}}
+ */
+const META = yaml.parsedFromFile(
+  path.join(__dirname, 'resources', 'checks', 'validation', `${CHECK}.yaml`),
+)
+
+/**
+ * Names of the checks this validator owns.
+ * @type {Array.<string>}
+ */
+const names = [CHECK]
+
+/**
+ * Attribute nodes that carry a bare Xpath expression, scoped to XSLT elements
+ * so literal result elements are left alone. Pattern attributes (match, count,
+ * from, group-starting-with, group-ending-with), attribute value templates,
+ * and sequence types (as) are not expressions and stay out.
+ * @type {string}
+ */
+const EXPRESSIONS =
+  '//xsl:*/@*[local-name() = (' +
+  '"select", "test", "use", "value", "group-by", "group-adjacent", ' +
+  '"key", "initial-value", "xpath", "context-item", "with-params", ' +
+  '"namespace-context")]'
+
+/**
+ * Validate every Xpath expression in the corpus. An attribute is a defect when
+ * its value cannot be parsed by the engine that would run it.
+ * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
+ * @param {Array.<string>} suppressions - Array of suppressed checks
+ * @return {{name: string, severity: string, message: string, file: string,
+ *  line: number, pos: number}[]} - Defects found
+ */
+const validate = function(corpus, suppressions = []) {
+  logger.debug(`Xpath validation started`)
+  const defects = []
+  if (!suppressions.some((sup) => CHECK.includes(sup))) {
+    for (const {file, xsl} of corpus) {
+      for (const expression of nodes(xsl, EXPRESSIONS)) {
+        if (!isValid(expression.nodeValue)) {
+          defects.push({
+            name: CHECK,
+            severity: META.severity,
+            message: META.message,
+            file: file,
+            line: expression.lineNumber,
+            pos: expression.columnNumber,
+          })
+        }
+      }
+    }
+  }
+  logger.debug(`Found ${defects.length} invalid expressions`)
+  return defects
+}
+
+module.exports = {
+  validate,
+  names,
+}

--- a/src/xpath.js
+++ b/src/xpath.js
@@ -4,7 +4,8 @@
  */
 
 const {
-  evaluateXPathToNodes, evaluateXPathToStrings, registerCustomXPathFunction,
+  evaluateXPath, evaluateXPathToNodes, evaluateXPathToStrings,
+  compileXPathToJavaScript, registerCustomXPathFunction,
 } = require('fontoxpath')
 
 /**
@@ -14,11 +15,26 @@ const {
 const FUNCTIONS = 'https://github.com/maxonfjvipon/xslint'
 
 /**
+ * Standard prefixes bound in every Xpath expression. When validating, an
+ * unknown prefix must not be mistaken for a syntax error, so these resolve to
+ * their real URIs and any other prefix resolves to a placeholder.
+ * @type {object}
+ */
+const STANDARD = {
+  'xsl': 'http://www.w3.org/1999/XSL/Transform',
+  'xs': 'http://www.w3.org/2001/XMLSchema',
+  'fn': 'http://www.w3.org/2005/xpath-functions',
+  'map': 'http://www.w3.org/2005/xpath-functions/map',
+  'array': 'http://www.w3.org/2005/xpath-functions/array',
+  'math': 'http://www.w3.org/2005/xpath-functions/math',
+}
+
+/**
  * Prefixes.
  * @type {{xsl: string, xslint: string}}
  */
 const PREFIXES = {
-  'xsl': 'http://www.w3.org/1999/XSL/Transform',
+  'xsl': STANDARD.xsl,
   'xslint': FUNCTIONS,
 }
 
@@ -83,7 +99,29 @@ const strings = function(xsl, xpath) {
   )
 }
 
+/**
+ * Whether given Xpath expression is syntactically valid. The same engine that
+ * runs the rules parses it, so an expression is valid here exactly when the
+ * processor would accept it. Every prefix resolves, isolating syntax from
+ * unresolved-prefix errors.
+ * @param {string} xpath - Xpath expression
+ * @return {boolean} - True when the expression parses
+ */
+const isValid = function(xpath) {
+  let parses = true
+  try {
+    compileXPathToJavaScript(xpath, evaluateXPath.ALL_RESULTS_TYPE, {
+      namespaceResolver: (prefix) =>
+        Object.hasOwn(STANDARD, prefix) ? STANDARD[prefix] : FUNCTIONS,
+    })
+  } catch {
+    parses = false
+  }
+  return parses
+}
+
 module.exports = {
   nodes,
   strings,
+  isValid,
 }

--- a/src/xsl-validator.js
+++ b/src/xsl-validator.js
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {xml, yaml} = require('./helpers')
+const path = require('node:path')
+const {logger} = require('./logger')
+
+/**
+ * Name of the check this validator owns.
+ * @type {string}
+ */
+const CHECK = 'malformed-stylesheet'
+
+/**
+ * Defect metadata of the check.
+ * @type {{severity: string, message: string}}
+ */
+const META = yaml.parsedFromFile(
+  path.join(__dirname, 'resources', 'checks', 'validation', `${CHECK}.yaml`),
+)
+
+/**
+ * Names of the checks this validator owns.
+ * @type {Array.<string>}
+ */
+const names = [CHECK]
+
+/**
+ * Build the corpus from raw stylesheet sources, validating that each one is
+ * well-formed XML. A source that does not parse is reported as a defect and
+ * left out of the corpus, so the validators and linters that follow run only
+ * over the stylesheets that parse.
+ * @param {Array.<{file: string, content: string}>} sources - Raw stylesheets
+ * @param {Array.<string>} suppressions - Array of suppressed checks
+ * @return {{corpus: Array.<{file: string, xsl: Document}>, defects:
+ *  Array.<object>}} - Parsed corpus and defects for the unparseable sources
+ */
+const validate = function(sources, suppressions = []) {
+  logger.debug(`Xml validation started`)
+  const corpus = []
+  const defects = []
+  const suppressed = suppressions.some((sup) => CHECK.includes(sup))
+  for (const {file, content} of sources) {
+    try {
+      corpus.push({file: file, xsl: xml.parsedFromString(content)})
+    } catch {
+      if (!suppressed) {
+        defects.push({
+          name: CHECK,
+          severity: META.severity,
+          message: META.message,
+          file: file,
+          line: 1,
+          pos: 1,
+        })
+      }
+    }
+  }
+  logger.debug(`Found ${defects.length} malformed stylesheets`)
+  return {corpus: corpus, defects: defects}
+}
+
+module.exports = {
+  validate,
+  names,
+}

--- a/src/xsl-validator.js
+++ b/src/xsl-validator.js
@@ -35,7 +35,7 @@ const names = [CHECK]
  * @param {Array.<{file: string, content: string}>} sources - Raw stylesheets
  * @param {Array.<string>} suppressions - Array of suppressed checks
  * @return {{corpus: Array.<{file: string, xsl: Document}>, defects:
- *  Array.<object>}} - Parsed corpus and defects for the unparseable sources
+ *  Array.<object>}} - Parsed corpus and defects for the unparsable sources
  */
 const validate = function(sources, suppressions = []) {
   logger.debug(`Xml validation started`)

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -5,14 +5,28 @@
 
 const path = require('path')
 const fs = require('fs')
-const {allFilesFrom, xml} = require('./helpers')
+const {allFilesFrom} = require('./helpers')
+const {validate: validateXsls, names: xslChecks} = require('./xsl-validator')
+const {
+  validate: validateXpaths, names: xpathValidatorChecks,
+} = require('./xpath-validator')
 const {lintByXpath, names: xpathChecks} = require('./xpath-linter')
 const {lintByCorpus, names: corpusChecks} = require('./corpus-linter')
 const {logger} = require('./logger')
 const stdout = require('./stdout')
 
 /**
- * Linters, each given the whole corpus of parsed stylesheets.
+ * Validators, each given the corpus of well-formed stylesheets, run before the
+ * linters so the linters reason only over input known to be valid.
+ * @type {Array.<function(Array.<{file: string, xsl: Document}>,
+ *  Array.<string>): Array.<object>>}
+ */
+const VALIDATORS = [
+  validateXpaths,
+]
+
+/**
+ * Linters, each given the corpus of well-formed stylesheets.
  * @type {Array.<function(Array.<{file: string, xsl: Document}>,
  *  Array.<string>): Array.<object>>}
  */
@@ -22,10 +36,13 @@ const LINTERS = [
 ]
 
 /**
- * Names of every check across all linters, that suppressions match against.
+ * Names of every check across all validators and linters, that suppressions
+ * match against.
  * @type {Array.<string>}
  */
-const CHECKS = [...xpathChecks, ...corpusChecks]
+const CHECKS = [
+  ...xslChecks, ...xpathValidatorChecks, ...xpathChecks, ...corpusChecks,
+]
 
 /**
  * Deleting incorrect substring-suppressions from array of arguments
@@ -97,11 +114,14 @@ const xslint = function(pths, options) {
     }
   }
   logger.debug(`Found ${stylesheets.length} .xsl files to process`)
-  const corpus = stylesheets.map((stylesheet) => ({
+  const sources = stylesheets.map((stylesheet) => ({
     file: stylesheet,
-    xsl: xml.parsedFromFile(stylesheet),
+    content: fs.readFileSync(stylesheet, 'utf-8'),
   }))
-  const defects = []
+  const {corpus, defects} = validateXsls(sources, suppressions)
+  for (const validate of VALIDATORS) {
+    defects.push(...validate(corpus, suppressions))
+  }
   for (const lint of LINTERS) {
     defects.push(...lint(corpus, suppressions))
   }

--- a/test/resources/xpath-validator-packs/invalid-extra-attributes.yaml
+++ b/test/resources/xpath-validator-packs/invalid-extra-attributes.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: invalid-extra-attributes
+found:
+  amount: 7
+  positions: [ [ 3, 43 ], [ 5, 23 ], [ 7, 26 ], [ 9, 44 ], [ 9, 86 ], [ 9, 62 ], [ 9, 25 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+    <xsl:accumulator name="a" initial-value="1 +"/>
+    <xsl:template match="/">
+      <xsl:number value="1 +"/>
+      <xsl:map>
+        <xsl:map-entry key="1 +" select="."/>
+      </xsl:map>
+      <xsl:evaluate xpath="1 +" context-item="1 +" with-params="1 +" namespace-context="1 +"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-validator-packs/invalid-select-expression.yaml
+++ b/test/resources/xpath-validator-packs/invalid-select-expression.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: invalid-select-expression
+found:
+  amount: 1
+  positions: [ [ 4, 26 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="/">
+      <xsl:value-of select="1 +"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-validator-packs/invalid-test-expression.yaml
+++ b/test/resources/xpath-validator-packs/invalid-test-expression.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: invalid-test-expression
+found:
+  amount: 1
+  positions: [ [ 4, 18 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="/">
+      <xsl:if test="foo(  a) ==         'hello'   ">
+        <xsl:value-of select="."/>
+      </xsl:if>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-validator-packs/valid-expressions.yaml
+++ b/test/resources/xpath-validator-packs/valid-expressions.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: valid-expressions
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0">
+    <xsl:template match="/">
+      <xsl:if test="count(//o) = xs:integer(2)">
+        <xsl:value-of select="concat('a', 'b')"/>
+      </xsl:if>
+      <xsl:for-each-group select="//o" group-by="@id">
+        <xsl:value-of select="current-grouping-key()"/>
+      </xsl:for-each-group>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-validator-packs/valid-extra-attributes.yaml
+++ b/test/resources/xpath-validator-packs/valid-extra-attributes.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: valid-extra-attributes
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+    <xsl:accumulator name="a" initial-value="0"/>
+    <xsl:template match="/">
+      <xsl:number value="position()"/>
+      <xsl:map>
+        <xsl:map-entry key="'k'" select="1"/>
+      </xsl:map>
+      <xsl:evaluate xpath="$x" context-item="." with-params="map{}" namespace-context="."/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/xcop.test.js
+++ b/test/xcop.test.js
@@ -16,6 +16,7 @@ const {runXcop, cmdAvailable} = require('./helpers')
 const PACKS = [
   ...allFilesFrom(path.resolve(__dirname, 'resources', 'xpath-packs')),
   ...allFilesFrom(path.resolve(__dirname, 'resources', 'corpus-packs')),
+  ...allFilesFrom(path.resolve(__dirname, 'resources', 'xpath-validator-packs')),
 ]
 
 /**

--- a/test/xpath-validator.test.js
+++ b/test/xpath-validator.test.js
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {validate} = require('../src/xpath-validator')
+const {allFilesFrom, xml, yaml} = require('../src/helpers')
+const path = require('path')
+const assert = require('assert')
+
+/**
+ * Yaml xpath validator test packs.
+ * @type {Array<string>}
+ */
+const PACKS = allFilesFrom(
+  path.resolve(__dirname, 'resources', 'xpath-validator-packs'),
+)
+
+describe('xpath-validator', function() {
+  PACKS.forEach((pack) => {
+    const yml = yaml.parsedFromFile(pack)
+    const input = xml.parsedFromString(yml.input)
+    describe(`testing ${path.basename(pack)} pack`, function() {
+      it(`should find ${yml.found.amount} invalid expressions`, function() {
+        const defects = validate([{file: 'test.xsl', xsl: input}])
+        assert.equal(defects.length, yml.found.amount)
+        yml.found.positions.forEach((pos, index) => {
+          assert.equal(defects[index].line, pos[0])
+          assert.equal(defects[index].pos, pos[1])
+        })
+      })
+    })
+  })
+})

--- a/test/xsl-validator.test.js
+++ b/test/xsl-validator.test.js
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {validate} = require('../src/xsl-validator')
+const assert = require('assert')
+
+describe('xsl-validator', function() {
+  it('should keep a well-formed stylesheet in the corpus', function() {
+    const {corpus} = validate([
+      {file: 'good.xsl', content: '<a><b/></a>'},
+    ])
+    assert.equal(corpus[0].file, 'good.xsl')
+  })
+  it('should report a malformed stylesheet as a defect', function() {
+    const {defects} = validate([
+      {file: 'broken.xsl', content: '<a><b></a>'},
+    ])
+    assert.equal(defects[0].name, 'malformed-stylesheet')
+  })
+  it('should leave a malformed stylesheet out of the corpus', function() {
+    const {corpus} = validate([
+      {file: 'broken.xsl', content: '<a><b></a>'},
+    ])
+    assert.equal(corpus.length, 0)
+  })
+  it('should keep only the parseable stylesheets when sources are mixed',
+    function() {
+      const {corpus} = validate([
+        {file: 'good.xsl', content: '<a><b/></a>'},
+        {file: 'broken.xsl', content: '<a><b></a>'},
+      ])
+      assert.equal(corpus[0].file, 'good.xsl')
+    })
+  it('should report one defect per malformed stylesheet when mixed',
+    function() {
+      const {defects} = validate([
+        {file: 'good.xsl', content: '<a><b/></a>'},
+        {file: 'broken.xsl', content: '<a><b></a>'},
+      ])
+      assert.equal(defects.length, 1)
+    })
+  it('should not report a malformed stylesheet when its check is suppressed',
+    function() {
+      const {defects} = validate(
+        [{file: 'broken.xsl', content: '<a><b></a>'}],
+        ['malformed-stylesheet'],
+      )
+      assert.equal(defects.length, 0)
+    })
+})

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -7,6 +7,8 @@ const {runXslint} = require('./helpers')
 const assert = require('assert')
 const version = require('../src/version')
 const path = require('path')
+const fs = require('fs')
+const os = require('os')
 
 describe('xslint', function() {
   it('should print its own version', function() {
@@ -143,5 +145,39 @@ describe('xslint', function() {
     const stdout = runXslint([file, dir])
     assert.ok(stdout.includes(`File or directory ${path.resolve(process.cwd(), file)} does not exist`))
     assert.ok(stdout.includes(`File or directory ${path.resolve(process.cwd(), dir)} does not exist`))
+  })
+  it('should lint the parseable stylesheets and report the malformed ones', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    fs.writeFileSync(
+      path.join(dir, 'good.xsl'),
+      [
+        '<?xml version="1.0"?>',
+        '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">',
+        '  <xsl:template match="/">',
+        '    <xsl:value-of select="1 +"/>',
+        '  </xsl:template>',
+        '</xsl:stylesheet>',
+      ].join('\n'),
+    )
+    fs.writeFileSync(
+      path.join(dir, 'bad.xsl'),
+      [
+        '<?xml version="1.0"?>',
+        '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">',
+        '  <xsl:template match="/">',
+        '    <result>',
+        '  </xsl:template>',
+        '</xsl:stylesheet>',
+      ].join('\n'),
+    )
+    const stdout = runXslint([dir])
+    fs.rmSync(dir, {recursive: true, force: true});
+    [
+      'Processed files: 2',
+      'bad.xsl(1:1)',
+      'malformed-stylesheet',
+      'good.xsl',
+      'invalid-xpath-expression',
+    ].forEach((str) => assert.ok(stdout.includes(str)))
   })
 })


### PR DESCRIPTION
Part of #134. Implements the **validity** half of the ticket — checking that XPath expressions are syntactically valid (and that stylesheets are well-formed XML). The **formatting** half (extra whitespace, redundant braces) remains a follow-up.

## What changed

xslint now runs in two stages: **validators** establish that the input is valid, then **linters** run over the stylesheets that pass.

- **`xsl-validator`** — builds the corpus from raw sources and reports each stylesheet that is not well-formed XML (`malformed-stylesheet`), leaving it out of linting. This also fixes a latent crash: a malformed `.xsl` previously aborted the whole run.
- **`xpath-validator`** — parses every bare-XPath-expression attribute (`select`, `test`, `use`, `value`, `group-by`, `group-adjacent`, and the XSLT 3.0 `key`, `initial-value`, `xpath`, `context-item`, `with-params`, `namespace-context`) with fontoxpath — the same engine that runs the rules — and reports the ones that do not compile (`invalid-xpath-expression`). A permissive resolver isolates genuine syntax errors from unknown prefixes and custom functions.
- **`xslint.js`** orchestrates validators then linters, merging defects.

Gating: a file that does not parse is reported once and skipped; the rest are still linted, so one broken file never hides feedback on the others.

## Deliberately out of scope (follow-ups)

- The **formatting** linter (whitespace, redundant parens) — the other half of #134.
- **Pattern** attributes (`match`, `count`, `from`, `group-starting-with`, `group-ending-with`) — a different grammar.
- **AVT** (`{…}`) expression validation.
- Per-expression lint gating (skip invalid expressions during linting) — no expression-level linter consumes it yet.

## Tests

199 passing. New: `xpath-validator` packs (valid/invalid across all attributes), `xsl-validator` unit tests (corpus partitioning + suppression), and an end-to-end gating test over a temp directory. Docs site regenerated (38 checks); README and CLAUDE.md updated, plus a "Keeping Docs in Sync" rule.