### PR TITLE
Require @name on xsl:with-param

### DIFF
--- a/src/resources/checks/xpath/template-match-with-param-without-name.yaml
+++ b/src/resources/checks/xpath/template-match-with-param-without-name.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+xpath: //xsl:with-param[not(@name)]
+severity: error
+message: xsl:with-param requires a @name attribute to bind the parameter it passes. Add one.

--- a/src/resources/motives/xpath/template-match-with-param-without-name.md
+++ b/src/resources/motives/xpath/template-match-with-param-without-name.md
@@ -1,0 +1,22 @@
+# Using `xsl:with-param` without @name
+
+`xsl:with-param` passes a value to a named parameter of the template, function,
+or mode it invokes. The @name attribute is what binds the value to that
+parameter, so it is required: without it the processor has no parameter to bind
+to and rejects the stylesheet.
+
+Incorrect:
+
+```xsl
+<xsl:call-template name="render">
+  <xsl:with-param select="'red'"/>
+</xsl:call-template>
+```
+
+Correct:
+
+```xsl
+<xsl:call-template name="render">
+  <xsl:with-param name="colour" select="'red'"/>
+</xsl:call-template>
+```

--- a/test/resources/xpath-packs/template-match-with-param-with-name.yaml
+++ b/test/resources/xpath-packs/template-match-with-param-with-name.yaml
@@ -1,25 +1,25 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: template-match-variable-or-param-without-name
+pack: template-match-with-param-without-name
 found:
-  amount: 3
-  positions: [ [ 5, 5 ], [ 9, 5 ], [ 14, 7, template-match-with-param-without-name ] ]
+  amount: 0
+  positions: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
     <xsl:output encoding="UTF-8" method="xml"/>
     <xsl:template name="ooo">
-      <xsl:param as="xs:string" select="ooo"/>
+      <xsl:param name="o1" as="xs:string" select="ooo"/>
       <p>$o1</p>
     </xsl:template>
     <xsl:template match="/objects/o/o[1]/o[2]">
-      <xsl:variable as="xs:string" select="ooo"/>
-      <p>ooo</p>
+      <xsl:variable name="qw" as="xs:string" select="ooo"/>
+      <xsl:copy-of select="$qw"/>
     </xsl:template>
     <xsl:template match="/objects/o/o[1]/o[3]">
       <xsl:call-template name="ooo">
-        <xsl:with-param select="'oooo2'"/>
+        <xsl:with-param name="o1" select="'oooo2'"/>
       </xsl:call-template>
     </xsl:template>
   </xsl:stylesheet>

--- a/test/resources/xpath-packs/template-match-with-param-without-name.yaml
+++ b/test/resources/xpath-packs/template-match-with-param-without-name.yaml
@@ -1,21 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: template-match-variable-or-param-without-name
+pack: template-match-with-param-without-name
 found:
-  amount: 3
-  positions: [ [ 5, 5 ], [ 9, 5 ], [ 14, 7, template-match-with-param-without-name ] ]
+  amount: 1
+  positions: [ [ 14, 7 ] ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
     <xsl:output encoding="UTF-8" method="xml"/>
     <xsl:template name="ooo">
-      <xsl:param as="xs:string" select="ooo"/>
+      <xsl:param name="o1" as="xs:string" select="ooo"/>
       <p>$o1</p>
     </xsl:template>
     <xsl:template match="/objects/o/o[1]/o[2]">
-      <xsl:variable as="xs:string" select="ooo"/>
-      <p>ooo</p>
+      <xsl:variable name="qw" as="xs:string" select="ooo"/>
+      <xsl:copy-of select="$qw"/>
     </xsl:template>
     <xsl:template match="/objects/o/o[1]/o[3]">
       <xsl:call-template name="ooo">


### PR DESCRIPTION
Fixes #214.

`xsl:with-param` binds a value to a named parameter of the template, function,
or mode it invokes, so its `@name` attribute is required — without it the
processor has no parameter to bind to and rejects the stylesheet.

New per-file check `template-match-with-param-without-name`
(`//xsl:with-param[not(@name)]`, severity `error`), mirroring the existing
`template-match-variable-or-param-without-name`. Test packs cover a nameless
with-param (one defect) and a named one (none); the sibling pack's fixture,
which already contained a nameless with-param, now records the extra defect.