### PR TITLE
Flag empty xsl:variable

### DIFF
--- a/src/resources/checks/xpath/template-match-empty-variable.yaml
+++ b/src/resources/checks/xpath/template-match-empty-variable.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+xpath: //xsl:variable[not(@select) and not(node())]
+severity: warning
+message: An empty xsl:variable binds the empty string for no reason. Give it a @select or some content, or remove it.

--- a/src/resources/motives/xpath/template-match-empty-variable.md
+++ b/src/resources/motives/xpath/template-match-empty-variable.md
@@ -1,0 +1,24 @@
+# Empty `xsl:variable`
+
+An `xsl:variable` gets its value either from a `@select` attribute or from the
+sequence constructor inside it. With neither, the variable binds to an empty
+string — almost always a mistake, and at best a confusing way to declare an
+empty value. State the value explicitly or drop the declaration.
+
+Incorrect:
+
+```xsl
+<xsl:variable name="greeting"/>
+```
+
+Correct:
+
+```xsl
+<xsl:variable name="greeting" select="'hello'"/>
+```
+
+or:
+
+```xsl
+<xsl:variable name="greeting">hello</xsl:variable>
+```

--- a/test/resources/xpath-packs/template-match-empty-variable.yaml
+++ b/test/resources/xpath-packs/template-match-empty-variable.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: template-match-empty-variable
+found:
+  amount: 1
+  positions: [ [ 9, 5 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template match="/objects/o/o[1]/o[1]">
+      <xsl:variable name="size" as="xs:string" select="'12pt'"/>
+      <xsl:copy-of select="$size"/>
+    </xsl:template>
+    <xsl:template match="/objects/o/o[1]/o[2]">
+      <xsl:variable name="qw"/>
+      <xsl:copy-of select="$qw"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-packs/template-match-non-empty-variable.yaml
+++ b/test/resources/xpath-packs/template-match-non-empty-variable.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: template-match-empty-variable
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template match="/objects/o/o[1]/o[1]">
+      <xsl:variable name="size" as="xs:string" select="'12pt'"/>
+      <xsl:copy-of select="$size"/>
+    </xsl:template>
+    <xsl:template match="/objects/o/o[1]/o[2]">
+      <xsl:variable name="qw" as="xs:string" select="'oo'"/>
+      <xsl:copy-of select="$qw"/>
+    </xsl:template>
+  </xsl:stylesheet>


### PR DESCRIPTION
Fixes #192.

An `xsl:variable` takes its value from either a `@select` attribute or its
sequence-constructor content. With neither, it binds the empty string — almost
always a mistake, and at best a confusing way to declare an empty value.

New per-file check `template-match-empty-variable`
(`//xsl:variable[not(@select) and not(node())]`, severity `warning`). Test
packs cover an empty variable (one defect) and a variable that carries a value
(none).