### PR TITLE
Flag duplicate xsl:param name

### DIFF
--- a/src/resources/checks/xpath/template-match-duplicate-param-name.yaml
+++ b/src/resources/checks/xpath/template-match-duplicate-param-name.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+xpath: //xsl:param[@name = preceding-sibling::xsl:param/@name]
+severity: error
+message: Two xsl:param siblings share a @name. Each parameter of a template, function, or stylesheet must have a distinct name.

--- a/src/resources/motives/xpath/template-match-duplicate-param-name.md
+++ b/src/resources/motives/xpath/template-match-duplicate-param-name.md
@@ -1,0 +1,24 @@
+# Duplicate `xsl:param` name
+
+The parameters of a template, a stylesheet function, or the stylesheet itself
+form one namespace: each must have a distinct `@name`. Two parameters sharing a
+name is a static error — the processor cannot tell which one a reference binds
+to — and rejects the stylesheet.
+
+Incorrect:
+
+```xsl
+<xsl:template name="render">
+  <xsl:param name="size"/>
+  <xsl:param name="size"/>
+</xsl:template>
+```
+
+Correct:
+
+```xsl
+<xsl:template name="render">
+  <xsl:param name="width"/>
+  <xsl:param name="height"/>
+</xsl:template>
+```

--- a/test/resources/xpath-packs/template-match-distinct-param-names.yaml
+++ b/test/resources/xpath-packs/template-match-distinct-param-names.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: template-match-duplicate-param-name
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template name="render">
+      <xsl:param name="p1" as="xs:string" select="'a'"/>
+      <xsl:param name="p2" as="xs:string" select="'b'"/>
+      <xsl:value-of select="concat($p1, $p2)"/>
+    </xsl:template>
+    <xsl:template match="/objects/o">
+      <xsl:copy-of select="."/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-packs/template-match-duplicate-param-name.yaml
+++ b/test/resources/xpath-packs/template-match-duplicate-param-name.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: template-match-duplicate-param-name
+found:
+  amount: 1
+  positions: [ [ 6, 5 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template name="render">
+      <xsl:param name="p" as="xs:string" select="'a'"/>
+      <xsl:param name="p" as="xs:string" select="'b'"/>
+      <xsl:value-of select="$p"/>
+    </xsl:template>
+    <xsl:template match="/objects/o">
+      <xsl:copy-of select="."/>
+    </xsl:template>
+  </xsl:stylesheet>


### PR DESCRIPTION
Fixes #194.

The parameters of a template, a stylesheet function, or the stylesheet itself
share one namespace, so each must carry a distinct `@name`. Two parameters with
the same name is a static error and the processor rejects the stylesheet.

New per-file check `template-match-duplicate-param-name`
(`//xsl:param[@name = preceding-sibling::xsl:param/@name]`, severity `error`).
The `preceding-sibling` axis keeps the comparison scoped to one parent, so it
flags the second of two same-named params in a template, function, or
stylesheet, and never collides across scopes. Test packs cover a duplicated
name (one defect) and two distinct names (none).