### PR TITLE
Flag duplicate xsl:with-param name

### DIFF
--- a/src/resources/checks/xpath/template-match-duplicate-with-param-name.yaml
+++ b/src/resources/checks/xpath/template-match-duplicate-with-param-name.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+xpath: //xsl:with-param[@name = preceding-sibling::xsl:with-param/@name]
+severity: error
+message: A single call passes two xsl:with-param with the same @name. Each parameter can be supplied only once.

--- a/src/resources/motives/xpath/template-match-duplicate-with-param-name.md
+++ b/src/resources/motives/xpath/template-match-duplicate-with-param-name.md
@@ -1,0 +1,24 @@
+# Duplicate `xsl:with-param` name
+
+A single `xsl:call-template`, `xsl:apply-templates`, `xsl:apply-imports`, or
+`xsl:next-match` supplies each parameter at most once. Two `xsl:with-param`
+children with matching `@name` is a static error — the processor cannot tell
+which value to bind — and rejects the stylesheet.
+
+Incorrect:
+
+```xsl
+<xsl:call-template name="render">
+  <xsl:with-param name="colour" select="'red'"/>
+  <xsl:with-param name="colour" select="'blue'"/>
+</xsl:call-template>
+```
+
+Correct:
+
+```xsl
+<xsl:call-template name="render">
+  <xsl:with-param name="colour" select="'red'"/>
+  <xsl:with-param name="weight" select="'bold'"/>
+</xsl:call-template>
+```

--- a/test/resources/xpath-packs/template-match-distinct-with-param-names.yaml
+++ b/test/resources/xpath-packs/template-match-distinct-with-param-names.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: template-match-duplicate-with-param-name
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template name="render">
+      <xsl:param name="p" as="xs:string" select="'a'"/>
+      <xsl:param name="q" as="xs:string" select="'b'"/>
+      <xsl:value-of select="concat($p, $q)"/>
+    </xsl:template>
+    <xsl:template match="/objects/o">
+      <xsl:call-template name="render">
+        <xsl:with-param name="p" select="'a'"/>
+        <xsl:with-param name="q" select="'b'"/>
+      </xsl:call-template>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-packs/template-match-duplicate-with-param-name.yaml
+++ b/test/resources/xpath-packs/template-match-duplicate-with-param-name.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: template-match-duplicate-with-param-name
+found:
+  amount: 1
+  positions: [ [ 11, 7 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template name="render">
+      <xsl:param name="p" as="xs:string" select="'a'"/>
+      <xsl:value-of select="$p"/>
+    </xsl:template>
+    <xsl:template match="/objects/o">
+      <xsl:call-template name="render">
+        <xsl:with-param name="p" select="'a'"/>
+        <xsl:with-param name="p" select="'b'"/>
+      </xsl:call-template>
+    </xsl:template>
+  </xsl:stylesheet>


### PR DESCRIPTION
Fixes #200.

A single `xsl:call-template`, `xsl:apply-templates`, `xsl:apply-imports`, or
`xsl:next-match` supplies each parameter at most once. Two `xsl:with-param`
children with matching `@name` is a static error and the processor rejects the
stylesheet.

New per-file check `template-match-duplicate-with-param-name`
(`//xsl:with-param[@name = preceding-sibling::xsl:with-param/@name]`, severity
`error`). The `preceding-sibling` axis scopes the comparison to one call, so it
flags the second of two same-named with-params and never collides across calls.
Test packs cover a duplicated name (one defect) and two distinct names (none).