### PR TITLE
bug(#134): tokenize XPath and flag redundant whitespace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,26 +21,30 @@ npx mocha test/xslint.test.js --grep "sentence"  # Run tests matching a pattern
 
 ## Architecture
 
-**xslint** is a CLI linter for XSL stylesheets. It runs in two stages: **validators** first establish that the input is valid (each stylesheet is well-formed XML, and every XPath expression compiles), then **linters** run over the stylesheets that pass, catching stylistic, semantic, and logical problems. A stylesheet that does not parse is reported once and left out of the corpus, so one broken file never hides the feedback on the rest.
+**xslint** is a CLI linter for XSL stylesheets. It runs in two stages: **validators** first establish that the input is valid (each stylesheet is well-formed XML, and every XPath expression compiles), then **linters** run over what passed — the well-formed stylesheets, and the XPath expressions that parse — catching stylistic, semantic, and logical problems. Each validator *partitions* its input: it hands the valid part to the next stage and reports the rest, so one broken file (or one malformed expression) never hides the feedback on the rest.
 
 Flow:
 ```text
 src/index.js (CLI, commander.js)
   → src/xslint.js (file discovery, suppression, run order, stdout output)
-    VALIDATORS (is it valid?)
-    → src/xsl-validator.js (XML well-formedness) builds the corpus from the
+    VALIDATORS (is it valid?) — each partitions its input, reporting the bad
+    → src/xsl-validator.js (XML well-formedness) builds the corpus of
         parseable files          → src/resources/checks/validation/malformed-stylesheet.yaml
-    → src/xpath-validator.js (XPath syntax, over the corpus)
-                                 → src/resources/checks/validation/invalid-xpath-expression.yaml
-    LINTERS (is it good?)
+    → src/xpath-validator.js (XPath syntax, over the corpus) keeps the valid
+        expressions              → src/resources/checks/validation/invalid-xpath-expression.yaml
+    LINTERS (is it good?) — over the corpus
     → src/xpath-linter.js (per-file rules)    → src/resources/checks/xpath/*.yaml
     → src/corpus-linter.js (cross-file rules) → src/resources/checks/corpus/*.yaml
-        all (except xsl-validator) evaluate via src/xpath.js (fontoxpath
-        environment: prefixes, custom functions, node/string evaluators,
-        expression validator)
+    EXPRESSION LINTERS (is it good?) — over the valid expressions
+    → src/xpath-format-linter.js (XPath formatting; tokenizes via
+        src/tokens.js)           → src/resources/checks/format/*.yaml
+        xsl-validator, xpath-validator, xpath-linter, corpus-linter evaluate
+        via src/xpath.js (fontoxpath environment: prefixes, custom functions,
+        node/string evaluators, expression validator); xpath-format-linter
+        instead tokenizes via src/tokens.js over the validator's expressions
 ```
 
-Validators run before linters so the linters reason only over valid input. Most components share the shape `(corpus, suppressions) => defects`, where `corpus` is `[{file, xsl}]` and each defect is tagged with its `file`: `xpath-validator` parses each XPath expression and flags the ones the processor cannot parse; `xpath-linter` loops the corpus applying file-local rules; `corpus-linter` reasons across files (e.g. a named template defined in one file but invoked from another is *not* flagged as unused). The exception is `xsl-validator`, which *builds* the corpus — it takes `(sources, suppressions)` (raw `{file, content}`) and returns `{corpus, defects}`, since the corpus everything else consumes does not exist until well-formedness is checked. None of them depend on each other — each depends only on `src/xpath.js` (and `src/helpers.js`).
+Validators run before linters so the linters reason only over valid input, and each validator *builds* the input the next stage consumes. `xsl-validator` takes `(sources, suppressions)` (raw `{file, content}`) and returns `{corpus, defects}` — the corpus of parseable `{file, xsl}` documents. `xpath-validator` takes that corpus and returns `{expressions, defects}` — the valid `{file, expression}` attribute nodes, with the malformed ones dropped and reported. The document linters share the shape `(corpus, suppressions) => defects`: `xpath-linter` loops the corpus applying file-local rules; `corpus-linter` reasons across files (e.g. a named template defined in one file but invoked from another is *not* flagged as unused). The expression linters share the shape `(expressions, suppressions) => defects`: `xpath-format-linter` tokenizes each valid expression (`src/tokens.js`) and flags redundant whitespace — it never re-checks validity, since the validator already filtered. No module imports another linter or validator: the document linters and `xpath-validator` depend on `src/xpath.js`, `xpath-format-linter` on `src/tokens.js`, all on `src/helpers.js`; the staging is wired only in `src/xslint.js`.
 
 **Per-file rule format** (`src/resources/checks/xpath/<name>.yaml`):
 ```yaml
@@ -63,7 +67,14 @@ A `declaration` node is a defect only when its `@name` appears in no `usage` val
 severity: warning|error
 message: <human-readable explanation>
 ```
-A validator carries no XPath rule — its detection logic lives in code, and the YAML supplies only the defect's `severity` and `message`. Two validators live here: `malformed-stylesheet` (`src/xsl-validator.js`, XML well-formedness) and `invalid-xpath-expression` (`src/xpath-validator.js`, XPath syntax). The latter parses every bare-XPath-expression attribute (`select`, `test`, `use`, `value`, `group-by`, `group-adjacent`, plus the XSLT 3.0 `key`, `initial-value`, `xpath`, `context-item`, `with-params`, `namespace-context`) via `isValid` (`src/xpath.js`), which compiles with fontoxpath (the same engine that runs the rules) under a resolver where every prefix resolves, so only genuine syntax errors fail — unknown prefixes and custom functions do not. Pattern attributes (`match`, `count`, `from`, `group-starting-with`, `group-ending-with`), attribute value templates, and sequence types (`as`) are deliberately not validated as expressions. Each validator reads its own YAML by name (it does not scan the directory), so adding one validator's YAML never feeds another's logic.
+A validator carries no XPath rule — its detection logic lives in code, and the YAML supplies only the defect's `severity` and `message`. Two validators live here: `malformed-stylesheet` (`src/xsl-validator.js`, XML well-formedness) and `invalid-xpath-expression` (`src/xpath-validator.js`, XPath syntax). The latter parses every bare-XPath-expression attribute (`select`, `test`, `use`, `value`, `group-by`, `group-adjacent`, plus the XSLT 3.0 `key`, `initial-value`, `xpath`, `context-item`, `with-params`, `namespace-context` — the `EXPRESSIONS` selector in `src/xpath-validator.js`) via `isValid` (`src/xpath.js`), which compiles with fontoxpath (the same engine that runs the rules) under a resolver where every prefix resolves, so only genuine syntax errors fail — unknown prefixes and custom functions do not. Pattern attributes (`match`, `count`, `from`, `group-starting-with`, `group-ending-with`), attribute value templates, and sequence types (`as`) are deliberately not validated as expressions. Each validator reads its own YAML by name (it does not scan the directory), so adding one validator's YAML never feeds another's logic.
+
+**Formatting check format** (`src/resources/checks/format/<name>.yaml`):
+```yaml
+severity: warning|error
+message: <human-readable explanation>
+```
+Like a validator, a formatting check carries no XPath rule — its detection logic lives in code (`src/xpath-format-linter.js`), and the YAML supplies only `severity` and `message`. The linter consumes the valid expressions the XPath validator kept (so it never re-checks validity) and tokenizes each with `src/tokens.js`, reasoning over the tokens; a malformed expression was already reported by the validator and dropped, so it is never nagged about its spacing. One check lives here: `redundant-whitespace` (a doubled space, or a space leading or trailing the expression; whitespace inside string literals and comments is left alone). `src/tokens.js` is the lexer — a positioned token stream (string, comment, whitespace, other) that preserves whitespace; it is the foundation a future full-fidelity parser grows on to reach structural checks (redundant parentheses, axis abbreviations).
 
 XPath uses namespace prefix `xsl:` → `http://www.w3.org/1999/XSL/Transform` and `xslint:` → custom functions (`src/xpath.js`).
 
@@ -73,7 +84,9 @@ XPath uses namespace prefix `xsl:` → `http://www.w3.org/1999/XSL/Transform` an
 
 **XPath validator test pack** (`test/resources/xpath-validator-packs/<name>.yaml`): `pack`, `found.amount`, `found.positions: [[line, col], ...]`, single `input`. Auto-discovered by `test/xpath-validator.test.js`. The XSL validator is tested separately in `test/xsl-validator.test.js` with inline `{file, content}` sources (well-formed and malformed), and the end-to-end gating (parseable files linted, malformed ones reported and skipped) in `test/xslint.test.js` over a temp directory.
 
-**xcop formatting** — `test/xcop.test.js` extracts the inline XSL from every pack directory holding *well-formed* fixtures (`xpath-packs`, `corpus-packs`, `xpath-validator-packs`), re-serializes it, and runs [xcop](https://github.com/yegor256/xcop) over it to verify the fixtures are well-formatted XML (skipped when `xcop` is not installed). The XML validator's malformed fixtures are deliberately not xcop-checked. A new pack directory of well-formed fixtures must be added to its `PACKS` list, or it goes unchecked.
+**XPath format test pack** (`test/resources/xpath-format-packs/<name>.yaml`): `pack`, `found.amount`, `found.positions: [[line, col], ...]`, single `input`. Auto-discovered by `test/xpath-format-linter.test.js`. The lexer is unit-tested separately in `test/tokens.test.js`.
+
+**xcop formatting** — `test/xcop.test.js` extracts the inline XSL from every pack directory holding *well-formed* fixtures (`xpath-packs`, `corpus-packs`, `xpath-validator-packs`, `xpath-format-packs`), re-serializes it, and runs [xcop](https://github.com/yegor256/xcop) over it to verify the fixtures are well-formatted XML (skipped when `xcop` is not installed). The XML validator's malformed fixtures are deliberately not xcop-checked. A new pack directory of well-formed fixtures must be added to its `PACKS` list, or it goes unchecked.
 
 ## Adding a New Rule
 
@@ -85,9 +98,9 @@ Cross-file rule:
 1. Create `src/resources/checks/corpus/<rule-name>.yaml` with `declaration`, `usage`, `severity`, `message`.
 2. Create `test/resources/corpus-packs/<rule-name>.yaml` with matching `pack`, `found`, `inputs`.
 
-Validators are not extended this way: their logic is fixed in `src/xsl-validator.js` and `src/xpath-validator.js`, and their `src/resources/checks/validation/<name>.yaml` files only tune `severity` and `message`.
+Validators and formatting checks are not extended this way: their logic is fixed in `src/xsl-validator.js`, `src/xpath-validator.js`, and `src/xpath-format-linter.js`, and their YAML (`checks/validation/<name>.yaml` and `checks/format/<name>.yaml`) only tunes `severity` and `message`.
 
-Then: optionally add a rationale at `src/resources/motives/{xpath,corpus,validation}/<rule-name>.md`, run `npm test`, and regenerate the doc site with `npx grunt docs`. A brand-new pack directory of well-formed fixtures must also be registered in `test/xcop.test.js` so its inline XSL is formatting-checked.
+Then: optionally add a rationale at `src/resources/motives/{xpath,corpus,validation,format}/<rule-name>.md`, run `npm test`, and regenerate the doc site with `npx grunt docs`. A brand-new pack directory of well-formed fixtures must also be registered in `test/xcop.test.js` so its inline XSL is formatting-checked.
 
 Suppression by users: `xslint --suppress=<rule-substring>` (matches names from all validators and linters).
 
@@ -107,9 +120,11 @@ A change that leaves any of these describing the old behavior is not done.
 |------|------|
 | `src/xslint.js` | Orchestrates file discovery and suppression, runs validators then linters, formats output |
 | `src/xsl-validator.js` | Builds the corpus from raw sources; reports each stylesheet that is not well-formed XML and leaves it out |
-| `src/xpath-validator.js` | Parses each XPath expression in the corpus and flags the ones that do not compile |
+| `src/xpath-validator.js` | Splits each corpus expression into the valid ones (kept for the expression linters) and the malformed ones (reported) |
 | `src/xpath-linter.js` | Loads `checks/xpath/*.yaml`, applies per-file XPath rules |
 | `src/corpus-linter.js` | Loads `checks/corpus/*.yaml`, applies cross-file rules over the corpus |
+| `src/xpath-format-linter.js` | Tokenizes the validator's valid expressions and flags formatting noise (`redundant-whitespace`) |
+| `src/tokens.js` | XPath lexer: positioned token stream (`TOKENS`: string, comment, whitespace, other) preserving whitespace |
 | `src/xpath.js` | Shared fontoxpath environment: prefixes, custom functions, node/string evaluators, expression validator (`isValid`) |
 | `src/helpers.js` | XML parsing (`@xmldom/xmldom`), YAML parsing, file recursion |
 | `src/logger.js` | 4-level logger (debug/info/warning/error) |

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ Linters:
   For example, a named template defined in one file but invoked from another
   (via `xsl:import`/`xsl:include`) is not reported as unused. Lint the whole
   project at once so these checks can see every caller.
+- **Formatting** checks read each XPath expression as a stream of tokens and
+  flag stylistic noise — currently redundant whitespace (a doubled space, or a
+  space leading or trailing the expression). Only expressions that already
+  parse are checked, so a malformed one is reported once by the validator and
+  never nagged about its spacing.
 
 ## How to Contribute
 
@@ -116,9 +121,10 @@ npm test
 
 New linter rules live in `src/resources/checks/xpath` (per-file) or
 `src/resources/checks/corpus` (cross-file), each with a matching test pack in
-`test/resources`. The validators in `src/resources/checks/validation` are fixed
-in code; their YAML only tunes severity and message. Regenerate the
-documentation site with `npx grunt docs`.
+`test/resources`. The validators in `src/resources/checks/validation` and the
+formatting checks in `src/resources/checks/format` are fixed in code; their
+YAML only tunes severity and message. Regenerate the documentation site with
+`npx grunt docs`.
 
 You will need [npm] and [node] installed
 

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -14,7 +14,7 @@ const CHECKS = path.join(__dirname, '..', 'src', 'resources', 'checks')
 const MOTIVES = path.join(__dirname, '..', 'src', 'resources', 'motives')
 const DOCS = path.join(__dirname, '..', 'docs')
 const CHECKS_DIR = path.join(DOCS, 'checks')
-const KINDS = ['xpath', 'corpus', 'validation']
+const KINDS = ['xpath', 'corpus', 'validation', 'format']
 
 const CSS = `
   * { box-sizing: border-box; }
@@ -108,6 +108,9 @@ const expressions = (kind, lint) => {
   }
   if (kind === 'validation') {
     return `<code class="xpath">verified by the parser, not an XPath rule</code>`
+  }
+  if (kind === 'format') {
+    return `<code class="xpath">checked over the tokens, not an XPath rule</code>`
   }
   return `<code class="xpath">${escaped(lint.xpath)}</code>`
 }

--- a/src/resources/checks/format/redundant-whitespace.yaml
+++ b/src/resources/checks/format/redundant-whitespace.yaml
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+severity: warning
+message: An XPath expression has redundant whitespace. Remove the extra spaces.

--- a/src/resources/motives/format/redundant-whitespace.md
+++ b/src/resources/motives/format/redundant-whitespace.md
@@ -1,0 +1,30 @@
+# Redundant whitespace
+
+A bare XPath expression should read cleanly. Whitespace that the processor
+ignores still costs the reader: a doubled space, a space hugging a parenthesis,
+or a stray space at the start or end of the expression all add noise without
+adding meaning. This check flags whitespace that can be removed without
+changing what the expression selects.
+
+A whitespace run is redundant when it is longer than a single space, or when it
+sits at the very start or end of the expression. Whitespace inside a string
+literal or a comment is left untouched — those spaces are part of the value the
+author wrote on purpose. The check runs only over expressions that already
+parse, so a malformed expression is reported once by the validator and never
+nagged about its spacing.
+
+Incorrect (a doubled space and a trailing space):
+
+```xsl
+<xsl:if test="foo(  a) = 'hello' ">
+  <xsl:value-of select="."/>
+</xsl:if>
+```
+
+Correct:
+
+```xsl
+<xsl:if test="foo(a) = 'hello'">
+  <xsl:value-of select="."/>
+</xsl:if>
+```

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,0 +1,155 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Token types a lexed expression is made of.
+ * @type {{STRING: string, COMMENT: string, WHITESPACE: string, OTHER: string}}
+ */
+const TOKENS = {
+  STRING: 'string',
+  COMMENT: 'comment',
+  WHITESPACE: 'whitespace',
+  OTHER: 'other',
+}
+
+/**
+ * Characters XPath treats as insignificant whitespace.
+ * @type {string}
+ */
+const WHITESPACE = ' \t\r\n'
+
+/**
+ * Quote characters that open a string literal.
+ * @type {string}
+ */
+const QUOTES = '"\''
+
+/**
+ * Whether a comment opens at given offset.
+ * @param {string} xpath - Xpath expression
+ * @param {number} at - Offset to test
+ * @return {boolean} - True when "(:" starts here
+ */
+const opensComment = function(xpath, at) {
+  return xpath[at] === '(' && xpath[at + 1] === ':'
+}
+
+/**
+ * Offset just past the string literal opening at given quote. A doubled quote
+ * inside the literal escapes the quote and does not end it.
+ * @param {string} xpath - Xpath expression
+ * @param {number} start - Offset of the opening quote
+ * @return {number} - Offset just past the closing quote
+ */
+const afterString = function(xpath, start) {
+  const quote = xpath[start]
+  let at = start + 1
+  while (at < xpath.length) {
+    if (xpath[at] === quote && xpath[at + 1] === quote) {
+      at += 2
+    } else if (xpath[at] === quote) {
+      at += 1
+      break
+    } else {
+      at += 1
+    }
+  }
+  return at
+}
+
+/**
+ * Offset just past the comment opening at given offset. Comments nest, so an
+ * inner "(:" must be balanced by its own ":)".
+ * @param {string} xpath - Xpath expression
+ * @param {number} start - Offset of the opening "(:"
+ * @return {number} - Offset just past the closing ":)"
+ */
+const afterComment = function(xpath, start) {
+  let at = start + 2
+  let depth = 1
+  while (at < xpath.length && depth > 0) {
+    if (opensComment(xpath, at)) {
+      depth += 1
+      at += 2
+    } else if (xpath[at] === ':' && xpath[at + 1] === ')') {
+      depth -= 1
+      at += 2
+    } else {
+      at += 1
+    }
+  }
+  return at
+}
+
+/**
+ * Offset just past the run of non-delimiter characters at given offset. The run
+ * stops at a quote, whitespace, or comment opener so those start their own
+ * token.
+ * @param {string} xpath - Xpath expression
+ * @param {number} start - Offset of the first character
+ * @return {number} - Offset just past the run
+ */
+const afterOther = function(xpath, start) {
+  let at = start
+  while (
+    at < xpath.length &&
+    !QUOTES.includes(xpath[at]) &&
+    !WHITESPACE.includes(xpath[at]) &&
+    !opensComment(xpath, at)
+  ) {
+    at += 1
+  }
+  return at
+}
+
+/**
+ * Offset just past the whitespace run at given offset.
+ * @param {string} xpath - Xpath expression
+ * @param {number} start - Offset of the first whitespace character
+ * @return {number} - Offset just past the run
+ */
+const afterWhitespace = function(xpath, start) {
+  let at = start
+  while (at < xpath.length && WHITESPACE.includes(xpath[at])) {
+    at += 1
+  }
+  return at
+}
+
+/**
+ * Split an XPath expression into positioned tokens, preserving whitespace and
+ * comments so formatting checks can reason over the original text. Each token
+ * carries its type, raw value, and the offset where it starts.
+ * @param {string} xpath - Xpath expression
+ * @return {Array.<{type: string, value: string, start: number}>} - Tokens
+ */
+const tokenized = function(xpath) {
+  const tokens = []
+  let at = 0
+  while (at < xpath.length) {
+    const start = at
+    let type
+    if (QUOTES.includes(xpath[at])) {
+      type = TOKENS.STRING
+      at = afterString(xpath, at)
+    } else if (opensComment(xpath, at)) {
+      type = TOKENS.COMMENT
+      at = afterComment(xpath, at)
+    } else if (WHITESPACE.includes(xpath[at])) {
+      type = TOKENS.WHITESPACE
+      at = afterWhitespace(xpath, at)
+    } else {
+      type = TOKENS.OTHER
+      at = afterOther(xpath, at)
+    }
+    tokens.push({type: type, value: xpath.slice(start, at), start: start})
+  }
+  return tokens
+}
+
+module.exports = {
+  tokenized,
+  TOKENS,
+}

--- a/src/xpath-format-linter.js
+++ b/src/xpath-format-linter.js
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {tokenized, TOKENS} = require('./tokens')
+const {yaml} = require('./helpers')
+const path = require('node:path')
+const {logger} = require('./logger')
+
+/**
+ * Name of the check this linter owns.
+ * @type {string}
+ */
+const CHECK = 'redundant-whitespace'
+
+/**
+ * Defect metadata of the check.
+ * @type {{severity: string, message: string}}
+ */
+const META = yaml.parsedFromFile(
+  path.join(__dirname, 'resources', 'checks', 'format', `${CHECK}.yaml`),
+)
+
+/**
+ * Names of the checks this linter owns.
+ * @type {Array.<string>}
+ */
+const names = [CHECK]
+
+/**
+ * Offsets of the redundant whitespace runs in an expression. A run is redundant
+ * when it is longer than one space, or leads or trails the expression; a run
+ * that wraps a line is left alone, and runs inside string literals or comments
+ * are never seen because the lexer keeps those whole.
+ * @param {string} expression - Xpath expression
+ * @return {Array.<number>} - Offsets where redundant runs start
+ */
+const redundancies = function(expression) {
+  const offsets = []
+  for (const token of tokenized(expression)) {
+    if (
+      token.type === TOKENS.WHITESPACE &&
+      !/[\r\n]/.test(token.value) &&
+      (token.start === 0 ||
+        token.start + token.value.length === expression.length ||
+        token.value.length > 1)
+    ) {
+      offsets.push(token.start)
+    }
+  }
+  return offsets
+}
+
+/**
+ * Lint the valid Xpath expressions for redundant whitespace. The expressions
+ * are already known to parse — the validator dropped the malformed ones — so
+ * this linter never re-checks validity, it only reasons over their tokens.
+ * @param {Array.<{file: string, expression: Node}>} expressions - Valid
+ *  expressions paired with the file they came from
+ * @param {Array.<string>} suppressions - Array of suppressed checks
+ * @return {{name: string, severity: string, message: string, file: string,
+ *  line: number, pos: number}[]} - Defects found
+ */
+const lintByFormat = function(expressions, suppressions = []) {
+  logger.debug(`Format linting started`)
+  const defects = []
+  if (!suppressions.some((sup) => CHECK.includes(sup))) {
+    for (const {file, expression} of expressions) {
+      for (const offset of redundancies(expression.nodeValue)) {
+        defects.push({
+          name: CHECK,
+          severity: META.severity,
+          message: META.message,
+          file: file,
+          line: expression.lineNumber,
+          pos: expression.columnNumber + 1 + offset,
+        })
+      }
+    }
+  }
+  logger.debug(`Found ${defects.length} redundant whitespace defects`)
+  return defects
+}
+
+module.exports = {
+  lintByFormat,
+  names,
+}

--- a/src/xpath-validator.js
+++ b/src/xpath-validator.js
@@ -42,34 +42,39 @@ const EXPRESSIONS =
   '"namespace-context")]'
 
 /**
- * Validate every Xpath expression in the corpus. An attribute is a defect when
- * its value cannot be parsed by the engine that would run it.
+ * Validate every Xpath expression in the corpus, splitting the valid ones out
+ * for the linters to consume from the malformed ones, which become defects.
+ * An expression that cannot be parsed by the engine that would run it is
+ * reported and dropped, so no linter ever reasons over broken input.
  * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
  * @param {Array.<string>} suppressions - Array of suppressed checks
- * @return {{name: string, severity: string, message: string, file: string,
- *  line: number, pos: number}[]} - Defects found
+ * @return {{expressions: Array.<{file: string, expression: Node}>, defects:
+ *  {name: string, severity: string, message: string, file: string,
+ *  line: number, pos: number}[]}} - Valid expressions and defects found
  */
 const validate = function(corpus, suppressions = []) {
   logger.debug(`Xpath validation started`)
+  const expressions = []
   const defects = []
-  if (!suppressions.some((sup) => CHECK.includes(sup))) {
-    for (const {file, xsl} of corpus) {
-      for (const expression of nodes(xsl, EXPRESSIONS)) {
-        if (!isValid(expression.nodeValue)) {
-          defects.push({
-            name: CHECK,
-            severity: META.severity,
-            message: META.message,
-            file: file,
-            line: expression.lineNumber,
-            pos: expression.columnNumber,
-          })
-        }
+  const suppressed = suppressions.some((sup) => CHECK.includes(sup))
+  for (const {file, xsl} of corpus) {
+    for (const expression of nodes(xsl, EXPRESSIONS)) {
+      if (isValid(expression.nodeValue)) {
+        expressions.push({file: file, expression: expression})
+      } else if (!suppressed) {
+        defects.push({
+          name: CHECK,
+          severity: META.severity,
+          message: META.message,
+          file: file,
+          line: expression.lineNumber,
+          pos: expression.columnNumber,
+        })
       }
     }
   }
   logger.debug(`Found ${defects.length} invalid expressions`)
-  return defects
+  return {expressions: expressions, defects: defects}
 }
 
 module.exports = {

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -12,18 +12,9 @@ const {
 } = require('./xpath-validator')
 const {lintByXpath, names: xpathChecks} = require('./xpath-linter')
 const {lintByCorpus, names: corpusChecks} = require('./corpus-linter')
+const {lintByFormat, names: formatChecks} = require('./xpath-format-linter')
 const {logger} = require('./logger')
 const stdout = require('./stdout')
-
-/**
- * Validators, each given the corpus of well-formed stylesheets, run before the
- * linters so the linters reason only over input known to be valid.
- * @type {Array.<function(Array.<{file: string, xsl: Document}>,
- *  Array.<string>): Array.<object>>}
- */
-const VALIDATORS = [
-  validateXpaths,
-]
 
 /**
  * Linters, each given the corpus of well-formed stylesheets.
@@ -36,12 +27,23 @@ const LINTERS = [
 ]
 
 /**
+ * Expression linters, each given the valid Xpath expressions the validator kept
+ * so they never reason over malformed input.
+ * @type {Array.<function(Array.<{file: string, expression: Node}>,
+ *  Array.<string>): Array.<object>>}
+ */
+const EXPRESSION_LINTERS = [
+  lintByFormat,
+]
+
+/**
  * Names of every check across all validators and linters, that suppressions
  * match against.
  * @type {Array.<string>}
  */
 const CHECKS = [
-  ...xslChecks, ...xpathValidatorChecks, ...xpathChecks, ...corpusChecks,
+  ...xslChecks, ...xpathValidatorChecks,
+  ...xpathChecks, ...corpusChecks, ...formatChecks,
 ]
 
 /**
@@ -119,11 +121,13 @@ const xslint = function(pths, options) {
     content: fs.readFileSync(stylesheet, 'utf-8'),
   }))
   const {corpus, defects} = validateXsls(sources, suppressions)
-  for (const validate of VALIDATORS) {
-    defects.push(...validate(corpus, suppressions))
-  }
+  const {expressions, defects: invalid} = validateXpaths(corpus, suppressions)
+  defects.push(...invalid)
   for (const lint of LINTERS) {
     defects.push(...lint(corpus, suppressions))
+  }
+  for (const lint of EXPRESSION_LINTERS) {
+    defects.push(...lint(expressions, suppressions))
   }
   logger.info(`Processed files: ${stylesheets.length}`)
   if (defects.length > 0) {

--- a/test/resources/xpath-format-packs/clean-expressions.yaml
+++ b/test/resources/xpath-format-packs/clean-expressions.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: clean-expressions
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+    <xsl:template match="/">
+      <xsl:value-of select="concat('a  b', 'c')"/>
+      <xsl:if test=". = 'hi'">
+        <xsl:value-of select="."/>
+      </xsl:if>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-format-packs/redundant-whitespace.yaml
+++ b/test/resources/xpath-format-packs/redundant-whitespace.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: redundant-whitespace
+found:
+  amount: 3
+  positions: [ [ 4, 31 ], [ 5, 27 ], [ 6, 29 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+    <xsl:template match="/">
+      <xsl:value-of select="foo(  a)"/>
+      <xsl:if test=". = 'hi' ">
+        <xsl:value-of select=" ."/>
+      </xsl:if>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-format-packs/skips-invalid-expression.yaml
+++ b/test/resources/xpath-format-packs/skips-invalid-expression.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: skips-invalid-expression
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+    <xsl:template match="/">
+      <xsl:if test="foo(  a) == 'hi'">
+        <xsl:value-of select="."/>
+      </xsl:if>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {tokenized, TOKENS} = require('../src/tokens')
+const assert = require('assert')
+
+describe('tokens', function() {
+  it('tokenizes a run of spaces as one whitespace token', function() {
+    assert.equal(
+      tokenized('a  b').find((token) => token.type === TOKENS.WHITESPACE).value,
+      '  ',
+    )
+  })
+  it('records the offset where a token starts', function() {
+    assert.equal(
+      tokenized('a  b').find((token) => token.type === TOKENS.WHITESPACE).start,
+      1,
+    )
+  })
+  it('keeps a string literal whole despite the spaces inside it', function() {
+    assert.ok(
+      tokenized('"a  b"').every((token) => token.type !== TOKENS.WHITESPACE),
+    )
+  })
+  it('keeps a comment whole despite the spaces inside it', function() {
+    assert.ok(
+      tokenized('(: a  b :)').every((token) => token.type !== TOKENS.WHITESPACE),
+    )
+  })
+  it('treats doubled quotes inside a literal as an escape', function() {
+    assert.equal(tokenized('"a""b"').length, 1)
+  })
+})

--- a/test/xcop.test.js
+++ b/test/xcop.test.js
@@ -17,6 +17,7 @@ const PACKS = [
   ...allFilesFrom(path.resolve(__dirname, 'resources', 'xpath-packs')),
   ...allFilesFrom(path.resolve(__dirname, 'resources', 'corpus-packs')),
   ...allFilesFrom(path.resolve(__dirname, 'resources', 'xpath-validator-packs')),
+  ...allFilesFrom(path.resolve(__dirname, 'resources', 'xpath-format-packs')),
 ]
 
 /**

--- a/test/xpath-format-linter.test.js
+++ b/test/xpath-format-linter.test.js
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {lintByFormat} = require('../src/xpath-format-linter')
+const {validate} = require('../src/xpath-validator')
+const {allFilesFrom, xml, yaml} = require('../src/helpers')
+const path = require('path')
+const assert = require('assert')
+
+/**
+ * Yaml xpath format linter test packs.
+ * @type {Array<string>}
+ */
+const PACKS = allFilesFrom(
+  path.resolve(__dirname, 'resources', 'xpath-format-packs'),
+)
+
+describe('xpath-format-linter', function() {
+  PACKS.forEach((pack) => {
+    const yml = yaml.parsedFromFile(pack)
+    const input = xml.parsedFromString(yml.input)
+    describe(`testing ${path.basename(pack)} pack`, function() {
+      it(`should find ${yml.found.amount} redundant whitespace runs`,
+        function() {
+          const {expressions} = validate([{file: 'test.xsl', xsl: input}])
+          const defects = lintByFormat(expressions)
+          assert.equal(defects.length, yml.found.amount)
+          yml.found.positions.forEach((pos, index) => {
+            assert.equal(defects[index].line, pos[0])
+            assert.equal(defects[index].pos, pos[1])
+          })
+        })
+    })
+  })
+})

--- a/test/xpath-validator.test.js
+++ b/test/xpath-validator.test.js
@@ -22,7 +22,7 @@ describe('xpath-validator', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} invalid expressions`, function() {
-        const defects = validate([{file: 'test.xsl', xsl: input}])
+        const {defects} = validate([{file: 'test.xsl', xsl: input}])
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])


### PR DESCRIPTION
Closes #134.

XPath formatting was not checked: an expression like `foo(  a) =  'hello'   ` passed silently. This adds a formatting stage that flags it.

## What's added

- **`src/tokens.js`** — a full-fidelity XPath lexer producing a positioned token stream (string, comment, whitespace, other) that preserves whitespace and exact offsets. fontoxpath's parser cannot be reused here: its AST normalizes away whitespace and carries no source positions, so a formatter needs its own lossless lexer.
- **`src/xpath-format-linter.js`** — the `redundant-whitespace` check: a doubled space, or a space leading or trailing the expression. Whitespace inside string literals and comments is left alone; a run that wraps a line is allowed.
- **`src/xpath-validator.js`** — refactored to return `{expressions, defects}`, handing the valid expressions to the new expression-linter stage so the linter never re-checks validity. Malformed expressions are reported once by the validator and never nagged about spacing.
- **`src/xslint.js`** — wires in the `EXPRESSION_LINTERS` stage fed by the validator's kept expressions.

The token stream is the foundation later structural checks (operator spacing, redundant parentheses, axis abbreviations) grow on, each as an additive layer.

## Tests & docs

- New: `test/tokens.test.js`, `test/xpath-format-linter.test.js`, and three packs (`clean-expressions`, `redundant-whitespace`, `skips-invalid-expression`).
- `README.md`, `CLAUDE.md`, `scripts/generate-docs.js`, and `test/xcop.test.js` kept in sync.
- `npm test` — 207 passing, ESLint clean.