### PR TITLE
Repoint README badges to the xslint repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 CLI application for checking the quality of XSL.
 
-[![DevOps By Rultor.com](https://www.rultor.com/b/objectionary/phino)](https://www.rultor.com/p/objectionary/phino)
+[![DevOps By Rultor.com](https://www.rultor.com/b/maxonfjvipon/xslint)](https://www.rultor.com/p/maxonfjvipon/xslint)
 
 [![npm](https://img.shields.io/npm/v/@maxonfjvipon/xslint.svg?style=flat)](https://www.npmjs.com/package/@maxonfjvipon/xslint)
 [![grunt](https://github.com/maxonfjvipon/xslint/actions/workflows/grunt.yml/badge.svg)](https://github.com/maxonfjvipon/xslint/actions/workflows/grunt.yml)
 [![PDD status](http://www.0pdd.com/svg?name=maxonfjvipon/xslint)](http://www.0pdd.com/p?name=maxonfjvipon/xslint)
 [![Hits-of-Code](https://hitsofcode.com/github/maxonfjvipon/xslint)](https://hitsofcode.com/view/github/maxonfjvipon/xslint)
-[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/maxonfjvipon/eo2js/blob/master/LICENSE.txt)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/maxonfjvipon/xslint/blob/master/LICENSE.txt)
 
 ## Installation
 


### PR DESCRIPTION
The header carried two badges copied from another project and never repointed. The Rultor badge rendered the build status of `objectionary/phino`, and the License badge linked into `maxonfjvipon/eo2js` rather than this repository.

Both now point at `maxonfjvipon/xslint`:

```markdown
[![DevOps By Rultor.com](https://www.rultor.com/b/maxonfjvipon/xslint)](https://www.rultor.com/p/maxonfjvipon/xslint)
```

so a visitor sees this project's own status and lands on its own license file.

Closes #254.
