### PR TITLE
Align xsl license headers with the xcop 0.11 comment format

### DIFF
--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: g4s8/xcop-action@master
+      - uses: g4s8/xcop-action@v1.3
         with:
           license: LICENSE.txt
           files: |

--- a/test/resources/reports/xsl-with-no-violations.xsl
+++ b/test/resources/reports/xsl-with-no-violations.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style">
   <xsl:output encoding="UTF-8" method="html"/>

--- a/test/resources/reports/xsl-with-some-violations.xsl
+++ b/test/resources/reports/xsl-with-some-violations.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style">
   <xsl:output encoding="UTF-8" method="html"/>

--- a/test/resources/stylesheets/xsl-with-no-violations.xsl
+++ b/test/resources/stylesheets/xsl-with-no-violations.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style">
   <xsl:output encoding="UTF-8" method="html"/>

--- a/test/resources/stylesheets/xsl-with-some-violations.xsl
+++ b/test/resources/stylesheets/xsl-with-some-violations.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style">
   <xsl:output encoding="UTF-8" method="html"/>

--- a/test/resources/templates/xsl-with-no-violations.xsl
+++ b/test/resources/templates/xsl-with-no-violations.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style">
   <xsl:output encoding="UTF-8" method="html"/>

--- a/test/resources/templates/xsl-with-some-violations.xsl
+++ b/test/resources/templates/xsl-with-some-violations.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style">
   <xsl:output encoding="UTF-8" method="html"/>


### PR DESCRIPTION
The `xcop` check went red on every pull request even though nothing in the stylesheets changed. The workflow uses `g4s8/xcop-action@master`, whose `Dockerfile` runs `gem install xcop` unpinned, and `xcop` released `0.10.0`–`0.11.0` on 2026-07-17 through 2026-07-22. Those releases changed the license-header comment format the tool expects: the body lines must now start at column zero (`* SPDX...`) rather than indented (` * SPDX...`). `master` last ran green on 2026-07-11 against `xcop` `0.9.0`, so the drift is upstream, not in this repo.

This aligns the six `.xsl` fixtures with the new format:

```xml
<!--
* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
* SPDX-License-Identifier: MIT
-->
```

Verified locally with `xcop 0.11.0` — all six report `looks good` — and `npm test` still passes with the violation counts unchanged, since only comment whitespace moved.

Follow-up worth considering separately: pin the action (or the `xcop` gem) so an unpinned upstream release cannot break CI again.
