### PR TITLE
Parse each xpath rule once at load instead of per file

### DIFF
--- a/src/xpath-linter.js
+++ b/src/xpath-linter.js
@@ -9,8 +9,10 @@ const path = require('node:path')
 const {logger} = require('./logger')
 
 /**
- * Xpath packs, each identified by the name suppressions match against.
- * @type {Array.<{name: string, path: string}>}
+ * Xpath packs, each parsed once at load: the name suppressions match against
+ * and the rule the linter applies.
+ * @type {Array.<{name: string, xpath: string, severity: string,
+ *  message: string}>}
  */
 const PACKS = allFilesFrom(
   path.join(__dirname, 'resources', 'checks', 'xpath'),
@@ -18,7 +20,7 @@ const PACKS = allFilesFrom(
   name: pack.substring(
     pack.lastIndexOf(path.sep) + 1, pack.lastIndexOf('.yaml'),
   ),
-  path: pack,
+  ...yaml.parsedFromFile(pack),
 }))
 
 /**
@@ -57,12 +59,11 @@ const lintByXpath = function(corpus, suppressions = []) {
       if (suppressions.some((sup) => pack.name.includes(sup))) {
         continue
       }
-      const yml = yaml.parsedFromFile(pack.path)
-      for (const node of evaluateXpath(xsl, yml.xpath)) {
+      for (const node of evaluateXpath(xsl, pack.xpath)) {
         defects.push({
           name: pack.name,
-          severity: yml.severity,
-          message: yml.message,
+          severity: pack.severity,
+          message: pack.message,
           file: file,
           line: node.line,
           pos: node.pos,


### PR DESCRIPTION
`lintByXpath` re-read and re-parsed every rule from disk once per stylesheet, two loops deep, even though each pack's contents are identical across files. With 45 per-file packs, linting N stylesheets meant 45×N file reads and YAML parses.

The rule bodies never change during a run, so this parses each pack once at load — the way `xsl-validator.js` already resolves its single check up front — and reads from that in the loop:

```js
const PACKS = allFilesFrom(...).map((pack) => ({
  name: pack.substring(...),
  ...yaml.parsedFromFile(pack),
}))
```

No behaviour changes: the loop now reads `pack.xpath`/`pack.severity`/`pack.message` instead of re-parsing, and the full pack suite (271 tests) stays green. The redundant per-file I/O is gone.

Closes #256.
