### PR TITLE
Make the exit code severity-aware and add --max-warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ If you want to suppress many checks, use `--suppress` as many times as you need:
 xslint --suppress=monolithic-design --suppress=short-names
 ```
 
+## Exit code
+
+`xslint` exits non-zero when any `error`-severity defect is found. Warnings do
+not fail the run by default; to make them count, cap the allowed number with
+`--max-warnings`:
+
+```bash
+xslint --max-warnings=0    # any warning fails the run
+xslint --max-warnings=10   # more than ten warnings fails the run
+```
+
 ## Checks
 
 The full list of checks with descriptions and examples is available at

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,12 @@ program
   .helpOption('-?, --help', 'Print this help information')
   .option('--log-level <level>', 'Set log level', levels.INFO)
   .option(
+    '--max-warnings <n>',
+    'Number of warnings to allow before the exit code becomes non-zero ' +
+    '(-1 allows any number)',
+    (value) => parseInt(value, 10), -1,
+  )
+  .option(
     '--suppress <check>', 'Suppress some checks',
     (check, suppressions) => [...suppressions, check], [],
   )

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -142,7 +142,14 @@ const xslint = function(pths, options) {
         defect.name,
       )
     }
-    process.exit(1)
+    const errors = defects.filter((defect) => defect.severity === 'error')
+    const warnings = defects.filter((defect) => defect.severity === 'warning')
+    if (
+      errors.length > 0 ||
+      (options.maxWarnings >= 0 && warnings.length > options.maxWarnings)
+    ) {
+      process.exit(1)
+    }
   } else {
     logger.info(`No defects found`)
   }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -40,6 +40,21 @@ const runXslint = function(args, print = true) {
 }
 
 /**
+ * Helper to run xslint and report its exit code instead of its output.
+ * @param {Array.<string>} args - Array of args
+ * @return {number} Exit code
+ */
+const xslintStatus = function(args) {
+  let status = 0
+  try {
+    execCmd(`node ${path.resolve('./src/index.js')}`, args, true)
+  } catch (ex) {
+    status = ex.status
+  }
+  return status
+}
+
+/**
  * Helper to run xcop command line tool.
  * @param {string} arg - arg
  * @param {boolean} print - Capture logs
@@ -67,6 +82,7 @@ const cmdAvailable = function(cmd, print = true) {
 
 module.exports = {
   runXslint,
+  xslintStatus,
   runXcop,
   cmdAvailable,
 }

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {runXslint} = require('./helpers')
+const {runXslint, xslintStatus} = require('./helpers')
 const assert = require('assert')
 const version = require('../src/version')
 const path = require('path')
@@ -179,5 +179,42 @@ describe('xslint', function() {
       'good.xsl',
       'invalid-xpath-expression',
     ].forEach((str) => assert.ok(stdout.includes(str)))
+  })
+  it('should exit zero when only warnings are found', function() {
+    const status = xslintStatus([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+    ])
+    assert.equal(status, 0)
+  })
+  it('should exit one when warnings exceed the budget', function() {
+    const status = xslintStatus([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      '--max-warnings=0',
+    ])
+    assert.equal(status, 1)
+  })
+  it('should exit zero when warnings stay within the budget', function() {
+    const status = xslintStatus([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      '--max-warnings=10',
+    ])
+    assert.equal(status, 0)
+  })
+  it('should exit one when an error is found', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    fs.writeFileSync(
+      path.join(dir, 'broken.xsl'),
+      [
+        '<?xml version="1.0"?>',
+        '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">',
+        '  <xsl:template match="/">',
+        '    <result>',
+        '  </xsl:template>',
+        '</xsl:stylesheet>',
+      ].join('\n'),
+    )
+    const status = xslintStatus([dir, '--max-warnings=100'])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.equal(status, 1)
   })
 })


### PR DESCRIPTION
The tool exited non-zero whenever the defect list was non-empty, so a stylesheet with only `warning`-level findings failed the run exactly as one carrying `error`s. A project adopting xslint in CI broke on day one over stylistic warnings, with no way to ease in.

The exit code is now severity-aware: it stays non-zero when any `error` is found, and warnings are allowed by default. A new `--max-warnings <n>` caps how many warnings the run tolerates, defaulting to `-1` (unlimited):

```js
const errors = defects.filter((defect) => defect.severity === 'error')
const warnings = defects.filter((defect) => defect.severity === 'warning')
if (
  errors.length > 0 ||
  (options.maxWarnings >= 0 && warnings.length > options.maxWarnings)
) {
  process.exit(1)
}
```

All defects are still printed regardless — only the exit code changed. Four tests cover the matrix (warnings-only passes, an error fails even under a generous budget, `--max-warnings=0` fails on any warning, a budget of ten passes seven warnings) via a new `xslintStatus` helper that reports the exit code. The README documents the flag and the default.

Closes #264.
