### PR TITLE
Add round-trip and offset property tests for the tokenizer

### DIFF
--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -186,4 +186,44 @@ describe('tokens', function() {
       )
     })
   })
+  it('reconstructs every generated expression from its tokens', function() {
+    const pieces = [
+      'a', 'ns:n', '"x"', '\'a\'\'b\'', '(: c :)', '(: (:n:) :)', '123', '4.5',
+      '.5', '1e3', 'child::', 'descendant-or-self::', '@', ' ', '  ', '\t',
+      '\n', '//', '/', '(', ')', '[', ']', '*', '+', '-', '=', '!=', '<=',
+      '>=', '|', '||', 'and', 'or', 'div', 'mod', 'instance of', '$v', ',', ':',
+    ]
+    for (let count = 0; count < 500; count += 1) {
+      let expression = ''
+      const parts = 1 + Math.floor(Math.random() * 12)
+      for (let part = 0; part < parts; part += 1) {
+        expression += pieces[Math.floor(Math.random() * pieces.length)]
+      }
+      assert.equal(
+        tokenized(expression).map((token) => token.value).join(''),
+        expression,
+      )
+    }
+  })
+  it('positions generated expression tokens at contiguous offsets', function() {
+    const pieces = [
+      'a', 'ns:n', '"x"', '\'a\'\'b\'', '(: c :)', '(: (:n:) :)', '123', '4.5',
+      '.5', '1e3', 'child::', 'descendant-or-self::', '@', ' ', '  ', '\t',
+      '\n', '//', '/', '(', ')', '[', ']', '*', '+', '-', '=', '!=', '<=',
+      '>=', '|', '||', 'and', 'or', 'div', 'mod', 'instance of', '$v', ',', ':',
+    ]
+    for (let count = 0; count < 500; count += 1) {
+      let expression = ''
+      const parts = 1 + Math.floor(Math.random() * 12)
+      for (let part = 0; part < parts; part += 1) {
+        expression += pieces[Math.floor(Math.random() * pieces.length)]
+      }
+      let offset = 0
+      for (const token of tokenized(expression)) {
+        assert.equal(token.start, offset)
+        assert.ok(token.value.length > 0)
+        offset += token.value.length
+      }
+    }
+  })
 })


### PR DESCRIPTION
`tokens.js` was tested only by hand-picked examples, yet the lexer holds two invariants that any input must satisfy. This adds two property tests that generate hundreds of random XPath-like strings — built from tricky pieces like doubled quotes inside literals, nested comments, scientific-notation numbers, and axis names — and assert those invariants on every one.

The first checks that the tokens reconstruct the input: concatenating every `token.value` in order equals the original expression, since `tokenized` partitions the string and drops nothing. The second checks that offsets are contiguous and each token is non-empty: every `token.start` equals the running sum of prior token lengths.

Both hold for arbitrary input by construction — including malformed input such as an unterminated string or comment — so the tests are not flaky; a failure would signal a real boundary bug in one of the scanners. Generation is dependency-free (no fixture files, inline per test, matching the file's existing style).

Closes #267.
