### PR TITLE
Add changelog, contributing, security, and GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Report a defect in xslint
+labels: bug
+---
+
+# Bug report
+
+## What happens
+
+<!-- A clear description of the defect. -->
+
+## How to reproduce
+
+<!-- The stylesheet or command that triggers it, and the exact steps. -->
+
+## What you expected
+
+<!-- What should have happened instead. -->
+
+## Environment
+
+- xslint version:
+- Node.js version:
+- Operating system:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest a new check or capability for xslint
+labels: enhancement
+---
+
+# Feature request
+
+## The problem
+
+<!-- What is missing or awkward today. -->
+
+## The proposal
+
+<!-- What you would like xslint to do. For a new check, give an example of the
+XSL that should be flagged and why. -->
+
+## Alternatives
+
+<!-- Other approaches you considered, if any. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+# Pull request
+
+## What does this change
+
+<!-- Describe the change and why it is needed. -->
+
+## Related issue
+
+<!-- Reference the issue this closes, e.g. "Closes #123". -->
+
+## Checklist
+
+- [ ] `npm test` passes locally
+- [ ] Tests cover the change
+- [ ] Documentation is updated when behaviour changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this project are documented in this file. The format is
+based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
+project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Entries for releases before this file was introduced record their npm
+publication date only; detailed notes begin with the Unreleased section.
+
+## Unreleased
+
+- Parse each XPath rule once at load instead of once per file (#256).
+- Compute each tokenizer probe once per position (#255).
+- Apply the schema-type and node-set rules to XSLT 3.0 stylesheets (#259).
+- Make the exit code severity-aware and add `--max-warnings` (#264).
+- Send logs to stderr and defects to stdout, and add `--quiet` (#263).
+- Add round-trip and offset property tests for the tokenizer (#267).
+- Point the README badges at this repository (#254).
+
+## 0.0.6 - 2026-06-29
+
+- Published to npm.
+
+## 0.0.5 - 2026-03-26
+
+- Published to npm.
+
+## 0.0.4 - 2026-03-12
+
+- Published to npm.
+
+## 0.0.3 - 2025-01-22
+
+- Published to npm.
+
+## 0.0.2 - 2025-01-22
+
+- Published to npm.
+
+## 0.0.1 - 2025-01-07
+
+- First release to npm.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+Thanks for considering a contribution to xslint. Fork the repository, make your
+changes on a branch, and open a pull request against `master`. We review and
+merge changes that keep the build green and respect the project's quality
+standards, following these
+[guidelines](https://www.yegor256.com/2014/04/15/github-guidelines.html).
+
+## Before you open a pull request
+
+Make sure the full build passes:
+
+```bash
+npm test
+```
+
+This runs the test suite and ESLint through Grunt.
+
+## Adding a linter rule
+
+New per-file rules live in `src/resources/checks/xpath`, and cross-file rules in
+`src/resources/checks/corpus`, each with a matching test pack under
+`test/resources`. The validators in `src/resources/checks/validation` and the
+formatting checks in `src/resources/checks/format` are fixed in code; their YAML
+only tunes severity and message. Regenerate the documentation site with:
+
+```bash
+npx grunt docs
+```
+
+## Requirements
+
+You need [Node.js](https://nodejs.org/en) and
+[npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+installed.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ YAML only tunes severity and message. Regenerate the documentation site with
 
 You will need [npm] and [node] installed
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow and
+[CHANGELOG.md](CHANGELOG.md) for release notes.
+
 [npm]: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
 [node]: https://nodejs.org/en
 [guidelines]: https://www.yegor256.com/2014/04/15/github-guidelines.html

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Supported versions
+
+The latest published version of `@maxonfjvipon/xslint` receives security fixes.
+
+## Reporting a vulnerability
+
+Please do not open a public issue for a security problem. Instead, email the
+details to <mtrunnikov@gmail.com>. Include the affected version, a description
+of the issue, and, where possible, steps to reproduce it. You can expect a
+reply within a few days and an update once the report has been assessed.


### PR DESCRIPTION
For a general-purpose linter, a newcomer expects a few files that were missing. This adds them:

- `CHANGELOG.md` in Keep a Changelog format, reconciled with the npm releases `0.0.1`–`0.0.6` by date, with the current unreleased work listed by issue.
- `CONTRIBUTING.md` lifting the workflow the README already describes.
- `SECURITY.md` with a private disclosure address.
- `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`, plus `.github/PULL_REQUEST_TEMPLATE.md`.

The README links the new contributing and changelog docs. All of it is plain Markdown, so REUSE covers it through the existing `**/*.md` annotation and markdownlint passes with the repo config.

`CODE_OF_CONDUCT.md` is deliberately left out: it is an opinionated choice better made by the owner than defaulted in.

Closes #268.
