### PR TITLE
Add .xslint.yml configuration file (rules, exclude, max-warnings)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,8 @@ Then: optionally add a rationale at `src/resources/motives/{xpath,corpus,validat
 
 Suppression by users: `xslint --suppress=<rule-substring>` (matches names from all validators and linters).
 
+Configuration by users: a `.xslint.yml` file (discovered by walking up from the working directory, or passed with `--config <path>`) can disable rules (`rules: {<exact-name>: off}`), re-grade severity (`warning`/`error`), skip files (`exclude:` globs), and set `max-warnings`. Command-line flags override the file; the file overrides the built-in defaults. Resolution lives in `src/config.js`; `src/xslint.js` folds `off` rules into the suppression list, filters excluded files, applies severity overrides to the collected defects, and resolves the effective `max-warnings`.
+
 ## Keeping Docs in Sync
 
 Any change to behavior — new logic, a new check or validator, a rename, a moved file, a changed flag or output — must update the documentation in the same change. Before finishing, check all three and fix whichever went stale:
@@ -119,7 +121,8 @@ A change that leaves any of these describing the old behavior is not done.
 
 | File | Role |
 |------|------|
-| `src/xslint.js` | Orchestrates file discovery and suppression, runs validators then linters, formats output |
+| `src/xslint.js` | Orchestrates file discovery, configuration, and suppression, runs validators then linters, formats output |
+| `src/config.js` | Resolves `.xslint.yml` (rule severities/`off`, exclude globs, `max-warnings`), found by walking up from the cwd or via `--config` |
 | `src/xsl-validator.js` | Builds the corpus from raw sources; reports each stylesheet that is not well-formed XML and leaves it out |
 | `src/xpath-validator.js` | Splits each corpus expression into the valid ones (kept for the expression linters) and the malformed ones (reported) |
 | `src/xpath-linter.js` | Loads `checks/xpath/*.yaml`, applies per-file XPath rules |

--- a/README.md
+++ b/README.md
@@ -75,6 +75,29 @@ If you want to suppress many checks, use `--suppress` as many times as you need:
 xslint --suppress=monolithic-design --suppress=short-names
 ```
 
+## Configuration
+
+Project-wide settings live in a `.xslint.yml` file, discovered by walking up
+from the current directory (or passed with `--config <path>`). Command-line
+flags override the file, and the file overrides the built-in defaults.
+
+```yaml
+# .xslint.yml
+rules:
+  template-match-short-names: off          # turn a check off
+  template-match-monolithic-design: error  # promote a warning to an error
+exclude:
+  - "test/resources/**"                     # globs to skip, relative to cwd
+max-warnings: 10                            # default for --max-warnings
+```
+
+- **`rules`** maps a check name to `off`, `warning`, or `error`. `off` disables
+  the check (like `--suppress`, but by exact name); `warning` and `error`
+  re-grade its severity.
+- **`exclude`** lists globs, relative to the working directory, whose matching
+  files are not linted.
+- **`max-warnings`** sets the default for the `--max-warnings` flag.
+
 ## Output
 
 Defects are written to stdout; progress and diagnostic logs go to stderr, so

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "colors": "1.4.0",
         "commander": "^15.0.0",
         "fontoxpath": "^3.34.0",
+        "minimatch": "^10.2.5",
         "patch-package": "^8.0.0",
         "yaml": "^2.7.0"
       },
@@ -672,45 +673,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@eslint/config-helpers": {
@@ -1491,29 +1453,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@stryker-mutator/core/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@stryker-mutator/core/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -1550,22 +1489,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@stryker-mutator/core/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/@stryker-mutator/instrumenter": {
       "version": "9.6.1",
@@ -1871,13 +1794,24 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2716,29 +2650,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2750,22 +2661,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/espree": {
@@ -3373,6 +3268,32 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/global-modules": {
@@ -4965,16 +4886,15 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5046,6 +4966,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/mocha/node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -5067,6 +4997,22 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/mocha/node_modules/string-width": {
       "version": "4.2.3",
@@ -6225,29 +6171,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/test-exclude/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/test-exclude/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -6274,22 +6197,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/test-exclude/node_modules/path-scurry": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "colors": "1.4.0",
     "commander": "^15.0.0",
     "fontoxpath": "^3.34.0",
+    "minimatch": "^10.2.5",
     "patch-package": "^8.0.0",
     "yaml": "^2.7.0"
   },

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const fs = require('fs')
+const path = require('node:path')
+const {yaml} = require('./helpers')
+const {logger} = require('./logger')
+
+/**
+ * Name of the project configuration file.
+ * @type {string}
+ */
+const NAME = '.xslint.yml'
+
+/**
+ * Severities a rule may be re-graded to, plus 'off' to disable it.
+ * @type {Array.<string>}
+ */
+const SEVERITIES = ['off', 'warning', 'error']
+
+/**
+ * Nearest configuration file, searching from given directory up to the root.
+ * @param {string} from - Directory to start the search in
+ * @return {string|null} - Path of the found file, or null when none exists
+ */
+const located = function(from) {
+  let dir = from
+  let found = null
+  while (!found) {
+    const candidate = path.join(dir, NAME)
+    if (fs.existsSync(candidate)) {
+      found = candidate
+    } else if (path.dirname(dir) === dir) {
+      break
+    } else {
+      dir = path.dirname(dir)
+    }
+  }
+  return found
+}
+
+/**
+ * Normalize the parsed YAML into the configuration the linter consumes,
+ * dropping and reporting any rule graded to an unknown severity.
+ * @param {object|null} raw - Parsed YAML, or null when there is no file
+ * @return {{rules: object, exclude: Array.<string>, maxWarnings: number|null}}
+ *  - Normalized configuration
+ */
+const normalized = function(raw) {
+  const rules = {}
+  for (const [name, severity] of Object.entries(raw && raw.rules || {})) {
+    if (SEVERITIES.includes(severity)) {
+      rules[name] = severity
+    } else {
+      logger.warn(
+        `Invalid severity '${severity}' for rule '${name}' in ${NAME}, ` +
+        `use one of ${SEVERITIES.join(', ')}`,
+      )
+    }
+  }
+  return {
+    rules: rules,
+    exclude: raw && Array.isArray(raw.exclude) ? raw.exclude : [],
+    maxWarnings: raw && Object.hasOwn(raw, 'max-warnings') ?
+      raw['max-warnings'] : null,
+  }
+}
+
+/**
+ * Resolve the configuration: the file named by '--config' when given, otherwise
+ * the nearest '.xslint.yml' from the working directory upward, otherwise the
+ * empty defaults so that no file means the previous behaviour.
+ * @param {string|undefined} explicit - Path from '--config', if any
+ * @param {string} from - Directory the search starts in
+ * @return {{rules: object, exclude: Array.<string>, maxWarnings: number|null}}
+ *  - Normalized configuration
+ */
+const configFrom = function(explicit, from = process.cwd()) {
+  const file = explicit ? path.resolve(from, explicit) : located(from)
+  let raw = null
+  if (file) {
+    raw = yaml.parsedFromFile(file)
+    logger.debug(`Configuration loaded from ${file}`)
+  }
+  return normalized(raw)
+}
+
+module.exports = {
+  configFrom,
+}

--- a/src/index.js
+++ b/src/index.js
@@ -20,11 +20,12 @@ program
   .helpOption('-?, --help', 'Print this help information')
   .option('--log-level <level>', 'Set log level', levels.INFO)
   .option('--quiet', 'Suppress informational logs, printing only defects', false)
+  .option('--config <path>', 'Path to a configuration file')
   .option(
     '--max-warnings <n>',
     'Number of warnings to allow before the exit code becomes non-zero ' +
     '(-1 allows any number)',
-    (value) => parseInt(value, 10), -1,
+    (value) => parseInt(value, 10),
   )
   .option(
     '--suppress <check>', 'Suppress some checks',

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -15,6 +15,8 @@ const {lintByCorpus, names: corpusChecks} = require('./corpus-linter')
 const {lintByFormat, names: formatChecks} = require('./xpath-format-linter')
 const {logger, levels} = require('./logger')
 const {out} = require('./output')
+const {configFrom} = require('./config')
+const {minimatch} = require('minimatch')
 
 /**
  * Linters, each given the corpus of well-formed stylesheets.
@@ -86,6 +88,18 @@ const xsls = function(pth) {
 }
 
 /**
+ * Whether a file matches any exclusion glob, compared as a path relative to the
+ * working directory in posix form so the patterns stay portable.
+ * @param {string} file - Absolute path of a stylesheet
+ * @param {Array.<string>} patterns - Exclusion globs from the configuration
+ * @return {boolean} - True when the file is excluded
+ */
+const excluded = function(file, patterns) {
+  const relative = path.relative(process.cwd(), file).split(path.sep).join('/')
+  return patterns.some((pattern) => minimatch(relative, pattern))
+}
+
+/**
  * Process cli options.
  * @param {{
  *  logLevel: string,
@@ -100,11 +114,25 @@ const processOptions = function(options) {
  * Entry point.
  * @param {Array.<string>} pths - Files or directories with .xsl to lint
  * @param {{
- *  logLevel: string
+ *  logLevel: string,
+ *  quiet: boolean,
+ *  suppress: Array.<string>,
+ *  maxWarnings: number|undefined,
+ *  config: string|undefined
  * }} options - CLI options
  */
 const xslint = function(pths, options) {
-  const suppressions = validatedSuppressions(options.suppress)
+  const config = configFrom(options.config)
+  for (const name of Object.keys(config.rules)) {
+    if (!CHECKS.includes(name)) {
+      logger.warn(`Rule '${name}' in configuration does not exist`)
+    }
+  }
+  const suppressions = [
+    ...validatedSuppressions(options.suppress),
+    ...Object.keys(config.rules).filter((name) => config.rules[name] === 'off'),
+  ]
+  const maxWarnings = options.maxWarnings ?? config.maxWarnings ?? -1
   processOptions(options)
   logger.info(`Directories and files to process: ${pths.join(', ')}`)
   pths = pths.map((pth) => path.resolve(process.cwd(), pth))
@@ -116,6 +144,7 @@ const xslint = function(pths, options) {
       stylesheets = [...stylesheets, ...xsls(pth)]
     }
   }
+  stylesheets = stylesheets.filter((file) => !excluded(file, config.exclude))
   logger.debug(`Found ${stylesheets.length} .xsl files to process`)
   const sources = stylesheets.map((stylesheet) => ({
     file: stylesheet,
@@ -129,6 +158,12 @@ const xslint = function(pths, options) {
   }
   for (const lint of EXPRESSION_LINTERS) {
     defects.push(...lint(expressions, suppressions))
+  }
+  for (const defect of defects) {
+    const override = config.rules[defect.name]
+    if (override === 'warning' || override === 'error') {
+      defect.severity = override
+    }
   }
   logger.info(`Processed files: ${stylesheets.length}`)
   if (defects.length > 0) {
@@ -147,7 +182,7 @@ const xslint = function(pths, options) {
     const warnings = defects.filter((defect) => defect.severity === 'warning')
     if (
       errors.length > 0 ||
-      (options.maxWarnings >= 0 && warnings.length > options.maxWarnings)
+      (maxWarnings >= 0 && warnings.length > maxWarnings)
     ) {
       process.exit(1)
     }

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {configFrom} = require('../src/config')
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+
+describe('config', function() {
+  it('returns empty defaults when there is no file', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-cfg-'))
+    const config = configFrom(undefined, dir)
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.deepStrictEqual(
+      config, {rules: {}, exclude: [], maxWarnings: null},
+    )
+  })
+  it('reads the rules from a file named explicitly', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-cfg-'))
+    const file = path.join(dir, 'custom.yml')
+    fs.writeFileSync(file, 'rules:\n  short-names: off\n')
+    const config = configFrom(file)
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.equal(config.rules['short-names'], 'off')
+  })
+  it('finds the nearest config walking up from a directory', function() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-cfg-'))
+    fs.writeFileSync(path.join(root, '.xslint.yml'), 'max-warnings: 5\n')
+    const nested = path.join(root, 'a', 'b')
+    fs.mkdirSync(nested, {recursive: true})
+    const config = configFrom(undefined, nested)
+    fs.rmSync(root, {recursive: true, force: true})
+    assert.equal(config.maxWarnings, 5)
+  })
+  it('parses the exclude globs into a list', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-cfg-'))
+    fs.writeFileSync(
+      path.join(dir, '.xslint.yml'), 'exclude:\n  - "a/**"\n  - "b/**"\n',
+    )
+    const config = configFrom(undefined, dir)
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.deepStrictEqual(config.exclude, ['a/**', 'b/**'])
+  })
+  it('drops a rule graded to an unknown severity', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-cfg-'))
+    fs.writeFileSync(
+      path.join(dir, '.xslint.yml'), 'rules:\n  short-names: bogus\n',
+    )
+    const config = configFrom(undefined, dir)
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.ok(!Object.hasOwn(config.rules, 'short-names'))
+  })
+})

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -242,4 +242,60 @@ describe('xslint', function() {
     ])
     assert.ok(!streams.stderr.includes('Processed files'))
   })
+  it('should disable a rule named off in the config file', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const cfg = path.join(dir, '.xslint.yml')
+    fs.writeFileSync(cfg, 'rules:\n  template-match-short-names: off\n')
+    const streams = xslintStreams([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      `--config=${cfg}`,
+    ])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.ok(!streams.stdout.includes('template-match-short-names'))
+  })
+  it('should fail when the config promotes a warning to an error', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const cfg = path.join(dir, '.xslint.yml')
+    fs.writeFileSync(cfg, 'rules:\n  template-match-short-names: error\n')
+    const status = xslintStatus([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      `--config=${cfg}`,
+    ])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.equal(status, 1)
+  })
+  it('should skip files matched by a config exclude glob', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const cfg = path.join(dir, '.xslint.yml')
+    fs.writeFileSync(cfg, 'exclude:\n  - "test/resources/**"\n')
+    const streams = xslintStreams([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      `--config=${cfg}`,
+    ])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.ok(streams.stderr.includes('Processed files: 0'))
+  })
+  it('should apply max-warnings from the config file', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const cfg = path.join(dir, '.xslint.yml')
+    fs.writeFileSync(cfg, 'max-warnings: 0\n')
+    const status = xslintStatus([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      `--config=${cfg}`,
+    ])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.equal(status, 1)
+  })
+  it('should let a command-line max-warnings override the config', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const cfg = path.join(dir, '.xslint.yml')
+    fs.writeFileSync(cfg, 'max-warnings: 0\n')
+    const status = xslintStatus([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      `--config=${cfg}`,
+      '--max-warnings=100',
+    ])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.equal(status, 0)
+  })
 })


### PR DESCRIPTION
Until now the only way to influence xslint was command-line flags, so a team could not check its choices in, re-grade a rule's severity, or scope out paths. This adds a project configuration file.

`.xslint.yml` is discovered by walking up from the working directory, or named with `--config <path>`:

```yaml
rules:
  template-match-short-names: off          # turn a check off
  template-match-monolithic-design: error  # promote a warning to an error
exclude:
  - "test/resources/**"                     # globs to skip, relative to cwd
max-warnings: 10                            # default for --max-warnings
```

- `rules` maps an exact check name to `off`, `warning`, or `error`.
- `exclude` lists globs (matched with `minimatch`) whose files are skipped.
- `max-warnings` sets the default for the flag.

Precedence is the usual one — command-line flags override the file, the file overrides built-in defaults. It reuses the existing plumbing: `off` rules fold into the suppression list the linters already honour, severity overrides are a pass over the collected defects, and excludes filter file discovery. A new `src/config.js` resolves and validates the file (unknown severities and unknown rule names are reported); the linters are untouched.

`--max-warnings` lost its hard-coded `-1` default so the config value can take effect when the flag is absent; the resolved value is `flag ?? config ?? -1`, which keeps the existing exit-code tests passing.

Covered by a `config` unit spec (resolution, walk-up, defaults, invalid severity) and end-to-end tests for disabling, severity promotion, excludes, and the max-warnings precedence. README and CLAUDE.md document the file.

Closes #261.
