### PR TITLE
Complete .xslint.yml config: globs, log-level/quiet, exclude base, key validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Then: optionally add a rationale at `src/resources/motives/{xpath,corpus,validat
 
 Suppression by users: `xslint --suppress=<rule-substring>` (matches names from all validators and linters).
 
-Configuration by users: a `.xslint.yml` file (discovered by walking up from the working directory, or passed with `--config <path>`) can disable rules (`rules: {<exact-name>: off}`), re-grade severity (`warning`/`error`), skip files (`exclude:` globs), and set `max-warnings`. Command-line flags override the file; the file overrides the built-in defaults. Resolution lives in `src/config.js`; `src/xslint.js` folds `off` rules into the suppression list, filters excluded files, applies severity overrides to the collected defects, and resolves the effective `max-warnings`.
+Configuration by users: a `.xslint.yml` file (discovered by walking up from the working directory, or passed with `--config <path>`) can disable rules (`rules: {<name-or-glob>: off}`), re-grade severity (`warning`/`error`), skip files (`exclude:` globs, resolved relative to the config file's own directory), and set defaults for `max-warnings`, `log-level`, and `quiet`. Unknown top-level keys and rule patterns that match no check are reported. Command-line flags override the file; the file overrides the built-in defaults. Resolution lives in `src/config.js` (which also exposes the config's `base` directory); `src/xslint.js` expands each rule pattern against the check names, folds `off` rules into the suppression list, filters excluded files against `base`, applies severity overrides to the collected defects, and resolves the effective `max-warnings`/`log-level`/`quiet`.
 
 ## Keeping Docs in Sync
 

--- a/README.md
+++ b/README.md
@@ -84,19 +84,25 @@ flags override the file, and the file overrides the built-in defaults.
 ```yaml
 # .xslint.yml
 rules:
-  template-match-short-names: off          # turn a check off
-  template-match-monolithic-design: error  # promote a warning to an error
+  template-match-short-names: off       # turn one check off
+  "template-match-unused-*": error      # or a family, by glob
 exclude:
-  - "test/resources/**"                     # globs to skip, relative to cwd
-max-warnings: 10                            # default for --max-warnings
+  - "test/**"                           # globs to skip, relative to this file
+max-warnings: 10                        # default for --max-warnings
+log-level: info                         # default for --log-level
+quiet: false                            # default for --quiet
 ```
 
-- **`rules`** maps a check name to `off`, `warning`, or `error`. `off` disables
-  the check (like `--suppress`, but by exact name); `warning` and `error`
-  re-grade its severity.
-- **`exclude`** lists globs, relative to the working directory, whose matching
-  files are not linted.
-- **`max-warnings`** sets the default for the `--max-warnings` flag.
+- **`rules`** maps a check name — or a glob such as `template-match-*` — to
+  `off`, `warning`, or `error`. `off` disables the check (like `--suppress`);
+  `warning` and `error` re-grade its severity.
+- **`exclude`** lists globs, relative to the config file's own directory, whose
+  matching files are not linted.
+- **`max-warnings`**, **`log-level`**, and **`quiet`** set the defaults for the
+  matching command-line flags.
+
+Unknown top-level keys and rule names that match no check are reported so typos
+do not pass silently.
 
 ## Output
 

--- a/src/config.js
+++ b/src/config.js
@@ -21,6 +21,13 @@ const NAME = '.xslint.yml'
 const SEVERITIES = ['off', 'warning', 'error']
 
 /**
+ * Top-level keys the configuration understands. Anything else is a typo worth
+ * reporting rather than silently ignoring.
+ * @type {Array.<string>}
+ */
+const KEYS = ['rules', 'exclude', 'max-warnings', 'log-level', 'quiet']
+
+/**
  * Nearest configuration file, searching from given directory up to the root.
  * @param {string} from - Directory to start the search in
  * @return {string|null} - Path of the found file, or null when none exists
@@ -43,12 +50,18 @@ const located = function(from) {
 
 /**
  * Normalize the parsed YAML into the configuration the linter consumes,
- * dropping and reporting any rule graded to an unknown severity.
+ * reporting any unknown top-level key and any rule graded to an unknown
+ * severity rather than dropping them silently.
  * @param {object|null} raw - Parsed YAML, or null when there is no file
- * @return {{rules: object, exclude: Array.<string>, maxWarnings: number|null}}
- *  - Normalized configuration
+ * @return {{rules: object, exclude: Array.<string>, maxWarnings: number|null,
+ *  logLevel: string|null, quiet: boolean|null}} - Normalized configuration
  */
 const normalized = function(raw) {
+  for (const key of Object.keys(raw || {})) {
+    if (!KEYS.includes(key)) {
+      logger.warn(`Unknown key '${key}' in ${NAME}`)
+    }
+  }
   const rules = {}
   for (const [name, severity] of Object.entries(raw && raw.rules || {})) {
     if (SEVERITIES.includes(severity)) {
@@ -65,17 +78,21 @@ const normalized = function(raw) {
     exclude: raw && Array.isArray(raw.exclude) ? raw.exclude : [],
     maxWarnings: raw && Object.hasOwn(raw, 'max-warnings') ?
       raw['max-warnings'] : null,
+    logLevel: raw && Object.hasOwn(raw, 'log-level') ? raw['log-level'] : null,
+    quiet: raw && Object.hasOwn(raw, 'quiet') ? raw.quiet : null,
   }
 }
 
 /**
  * Resolve the configuration: the file named by '--config' when given, otherwise
  * the nearest '.xslint.yml' from the working directory upward, otherwise the
- * empty defaults so that no file means the previous behaviour.
+ * empty defaults so that no file means the previous behaviour. The 'base' is
+ * the directory the glob-based settings resolve against — where the file lives,
+ * or the search origin when there is no file.
  * @param {string|undefined} explicit - Path from '--config', if any
  * @param {string} from - Directory the search starts in
- * @return {{rules: object, exclude: Array.<string>, maxWarnings: number|null}}
- *  - Normalized configuration
+ * @return {{rules: object, exclude: Array.<string>, maxWarnings: number|null,
+ *  logLevel: string|null, quiet: boolean|null, base: string}} - Configuration
  */
 const configFrom = function(explicit, from = process.cwd()) {
   const file = explicit ? path.resolve(from, explicit) : located(from)
@@ -84,7 +101,7 @@ const configFrom = function(explicit, from = process.cwd()) {
     raw = yaml.parsedFromFile(file)
     logger.debug(`Configuration loaded from ${file}`)
   }
-  return normalized(raw)
+  return {...normalized(raw), base: file ? path.dirname(file) : from}
 }
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,6 @@
 const {program} = require('commander')
 const version = require('./version')
 const xslint = require('./xslint')
-const {levels} = require('./logger')
 
 program
   .name('xslint')
@@ -18,8 +17,8 @@ program
   )
   .version(version.what, '-v, --version', 'Output the version number')
   .helpOption('-?, --help', 'Print this help information')
-  .option('--log-level <level>', 'Set log level', levels.INFO)
-  .option('--quiet', 'Suppress informational logs, printing only defects', false)
+  .option('--log-level <level>', 'Set log level')
+  .option('--quiet', 'Suppress informational logs, printing only defects')
   .option('--config <path>', 'Path to a configuration file')
   .option(
     '--max-warnings <n>',

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -89,25 +89,28 @@ const xsls = function(pth) {
 
 /**
  * Whether a file matches any exclusion glob, compared as a path relative to the
- * working directory in posix form so the patterns stay portable.
+ * configuration's base directory in posix form so the patterns stay portable.
  * @param {string} file - Absolute path of a stylesheet
  * @param {Array.<string>} patterns - Exclusion globs from the configuration
+ * @param {string} base - Directory the globs resolve against
  * @return {boolean} - True when the file is excluded
  */
-const excluded = function(file, patterns) {
-  const relative = path.relative(process.cwd(), file).split(path.sep).join('/')
+const excluded = function(file, patterns, base) {
+  const relative = path.relative(base, file).split(path.sep).join('/')
   return patterns.some((pattern) => minimatch(relative, pattern))
 }
 
 /**
- * Process cli options.
- * @param {{
- *  logLevel: string,
- *  quiet: boolean
- * }} options - CLI options
+ * Set the log level, taking the command line first, then the configuration,
+ * then the default.
+ * @param {{logLevel: string|undefined, quiet: boolean|undefined}} options - CLI
+ *  options
+ * @param {{logLevel: string|null, quiet: boolean|null}} config - Configuration
  */
-const processOptions = function(options) {
-  logger.setLevel(options.quiet ? levels.WARNING : options.logLevel)
+const processOptions = function(options, config) {
+  const quiet = options.quiet ?? config.quiet ?? false
+  const level = options.logLevel ?? config.logLevel ?? levels.INFO
+  logger.setLevel(quiet ? levels.WARNING : level)
 }
 
 /**
@@ -123,17 +126,24 @@ const processOptions = function(options) {
  */
 const xslint = function(pths, options) {
   const config = configFrom(options.config)
-  for (const name of Object.keys(config.rules)) {
-    if (!CHECKS.includes(name)) {
-      logger.warn(`Rule '${name}' in configuration does not exist`)
+  const disabled = []
+  const overrides = {}
+  for (const [pattern, severity] of Object.entries(config.rules)) {
+    const matched = CHECKS.filter((check) => minimatch(check, pattern))
+    if (matched.length === 0) {
+      logger.warn(`Rule '${pattern}' in configuration does not exist`)
+    }
+    for (const check of matched) {
+      if (severity === 'off') {
+        disabled.push(check)
+      } else {
+        overrides[check] = severity
+      }
     }
   }
-  const suppressions = [
-    ...validatedSuppressions(options.suppress),
-    ...Object.keys(config.rules).filter((name) => config.rules[name] === 'off'),
-  ]
+  const suppressions = [...validatedSuppressions(options.suppress), ...disabled]
   const maxWarnings = options.maxWarnings ?? config.maxWarnings ?? -1
-  processOptions(options)
+  processOptions(options, config)
   logger.info(`Directories and files to process: ${pths.join(', ')}`)
   pths = pths.map((pth) => path.resolve(process.cwd(), pth))
   let stylesheets = []
@@ -144,7 +154,9 @@ const xslint = function(pths, options) {
       stylesheets = [...stylesheets, ...xsls(pth)]
     }
   }
-  stylesheets = stylesheets.filter((file) => !excluded(file, config.exclude))
+  stylesheets = stylesheets.filter(
+    (file) => !excluded(file, config.exclude, config.base),
+  )
   logger.debug(`Found ${stylesheets.length} .xsl files to process`)
   const sources = stylesheets.map((stylesheet) => ({
     file: stylesheet,
@@ -160,9 +172,8 @@ const xslint = function(pths, options) {
     defects.push(...lint(expressions, suppressions))
   }
   for (const defect of defects) {
-    const override = config.rules[defect.name]
-    if (override === 'warning' || override === 'error') {
-      defect.severity = override
+    if (overrides[defect.name]) {
+      defect.severity = overrides[defect.name]
     }
   }
   logger.info(`Processed files: ${stylesheets.length}`)

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -14,9 +14,14 @@ describe('config', function() {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-cfg-'))
     const config = configFrom(undefined, dir)
     fs.rmSync(dir, {recursive: true, force: true})
-    assert.deepStrictEqual(
-      config, {rules: {}, exclude: [], maxWarnings: null},
-    )
+    assert.deepStrictEqual(config, {
+      rules: {},
+      exclude: [],
+      maxWarnings: null,
+      logLevel: null,
+      quiet: null,
+      base: dir,
+    })
   })
   it('reads the rules from a file named explicitly', function() {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-cfg-'))
@@ -34,6 +39,21 @@ describe('config', function() {
     const config = configFrom(undefined, nested)
     fs.rmSync(root, {recursive: true, force: true})
     assert.equal(config.maxWarnings, 5)
+  })
+  it('resolves the base to the directory of the config file', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-cfg-'))
+    const file = path.join(dir, '.xslint.yml')
+    fs.writeFileSync(file, 'exclude:\n  - "x"\n')
+    const config = configFrom(file)
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.equal(config.base, dir)
+  })
+  it('reads the log level from the config file', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-cfg-'))
+    fs.writeFileSync(path.join(dir, '.xslint.yml'), 'log-level: debug\n')
+    const config = configFrom(undefined, dir)
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.equal(config.logLevel, 'debug')
   })
   it('parses the exclude globs into a list', function() {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-cfg-'))

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -266,11 +266,19 @@ describe('xslint', function() {
   })
   it('should skip files matched by a config exclude glob', function() {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
-    const cfg = path.join(dir, '.xslint.yml')
-    fs.writeFileSync(cfg, 'exclude:\n  - "test/resources/**"\n')
+    fs.writeFileSync(path.join(dir, '.xslint.yml'), 'exclude:\n  - "*.xsl"\n')
+    fs.writeFileSync(
+      path.join(dir, 'sheet.xsl'),
+      [
+        '<?xml version="1.0"?>',
+        '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" ' +
+          'version="2.0">',
+        '  <xsl:template match="/"><out/></xsl:template>',
+        '</xsl:stylesheet>',
+      ].join('\n'),
+    )
     const streams = xslintStreams([
-      'test/resources/stylesheets/xsl-with-some-violations.xsl',
-      `--config=${cfg}`,
+      dir, `--config=${path.join(dir, '.xslint.yml')}`,
     ])
     fs.rmSync(dir, {recursive: true, force: true})
     assert.ok(streams.stderr.includes('Processed files: 0'))
@@ -297,5 +305,49 @@ describe('xslint', function() {
     ])
     fs.rmSync(dir, {recursive: true, force: true})
     assert.equal(status, 0)
+  })
+  it('should disable a family of rules by glob in the config', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const cfg = path.join(dir, '.xslint.yml')
+    fs.writeFileSync(cfg, 'rules:\n  "template-match-*": off\n')
+    const streams = xslintStreams([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      `--config=${cfg}`,
+    ])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.ok(!streams.stdout.includes('template-match'))
+  })
+  it('should warn about an unknown key in the config', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const cfg = path.join(dir, '.xslint.yml')
+    fs.writeFileSync(cfg, 'excludes:\n  - "x"\n')
+    const streams = xslintStreams([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      `--config=${cfg}`,
+    ])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.ok(streams.stderr.includes('Unknown key \'excludes\''))
+  })
+  it('should read the log level from the config file', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const cfg = path.join(dir, '.xslint.yml')
+    fs.writeFileSync(cfg, 'log-level: debug\n')
+    const streams = xslintStreams([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      `--config=${cfg}`,
+    ])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.ok(streams.stderr.includes('Log level set to \'debug\''))
+  })
+  it('should read quiet from the config file', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const cfg = path.join(dir, '.xslint.yml')
+    fs.writeFileSync(cfg, 'quiet: true\n')
+    const streams = xslintStreams([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      `--config=${cfg}`,
+    ])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.ok(!streams.stderr.includes('Processed files'))
   })
 })


### PR DESCRIPTION
Rounds out the `.xslint.yml` support shipped in #261, closing the four follow-ups filed against it.

- **#282** — `exclude` globs now resolve against the config file's own directory, not the transient working directory, so they keep matching when xslint is run from a subdirectory. `src/config.js` returns a `base`, and `excluded` in `src/xslint.js` computes the relative path from it (falling back to the cwd when there is no file).
- **#283** — the config can now set `log-level` and `quiet`, not just `max-warnings`. Each resolves as `flag ?? config ?? default`; the `--log-level`/`--quiet` command-line defaults were dropped so the file's value can take effect when the flag is absent.
- **#284** — `rules` keys may be globs. Each key is expanded against the known check names (`template-match-*: off` disables the family); an exact name still matches exactly one check, and a pattern matching nothing is reported as before.
- **#285** — unrecognised top-level keys (a typo like `excludes:`) are reported instead of silently ignored, alongside the existing invalid-severity and unknown-rule warnings.

```yaml
rules:
  "template-match-unused-*": error   # glob
exclude:
  - "test/**"                        # relative to this file
log-level: info
quiet: false
```

Covered by unit specs (base directory, log-level parsing) and end-to-end tests (glob disable, unknown-key warning, config log-level, config quiet, and the reworked exclude test that anchors on the config directory). Coverage holds at 98%. README and CLAUDE.md are updated.

Closes #282, #283, #284, #285.
