### PR TITLE
Add inline xslint-disable comment directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Add inline suppression directives — `xslint-disable-next-line`,
+  `xslint-disable-line`, and `xslint-disable-file` (#262).
 - **Breaking:** drop the `template-match-` prefix from every rule name and
   rationalize a few awkward ones, so `--suppress` strings and config `rules`
   keys change accordingly; add a conformance test that enforces rule naming,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,9 @@ Then: add a rationale (required) at `src/resources/motives/{xpath,corpus,validat
 
 Suppression by users: `xslint --suppress=<rule-substring>` (matches names from all validators and linters).
 
-Configuration by users: a `.xslint.yml` file (discovered by walking up from the working directory, or passed with `--config <path>`) can disable rules (`rules: {<name-or-glob>: off}`), re-grade severity (`warning`/`error`), skip files (`exclude:` globs, resolved relative to the config file's own directory), and set defaults for `max-warnings`, `log-level`, and `quiet`. Unknown top-level keys and rule patterns that match no check are reported. Command-line flags override the file; the file overrides the built-in defaults. Resolution lives in `src/config.js` (which also exposes the config's `base` directory); `src/xslint.js` expands each rule pattern against the check names, folds `off` rules into the suppression list, filters excluded files against `base`, applies severity overrides to the collected defects, and resolves the effective `max-warnings`/`log-level`/`quiet`.
+Configuration by users: a `.xslint.yml` file (discovered by walking up from the working directory, or passed with `--config <path>`) can disable rules (`rules: {<name-or-glob>: off}`), re-grade severity (`warning`/`error`), skip files (`exclude:` globs, resolved relative to the config file's own directory), and set defaults for `max-warnings`, `log-level`, and `quiet`. Unknown top-level keys and rule patterns that match no check are reported. Inline suppression by users: XML-comment directives — `<!-- xslint-disable-next-line [rules] -->` (line after the comment), `<!-- xslint-disable-line [rules] -->` (the comment's line), `<!-- xslint-disable-file [rules] -->` (the whole file); rule names are optional and space-separated, and none means all. `src/directives.js` scans the raw text for them and `src/xslint.js` drops matching defects after collecting them (so it covers every kind, and warns on an unknown rule name).
+
+Command-line flags override the file; the file overrides the built-in defaults. Resolution lives in `src/config.js` (which also exposes the config's `base` directory); `src/xslint.js` expands each rule pattern against the check names, folds `off` rules into the suppression list, filters excluded files against `base`, applies severity overrides to the collected defects, and resolves the effective `max-warnings`/`log-level`/`quiet`.
 
 ## Keeping Docs in Sync
 
@@ -125,6 +127,7 @@ A change that leaves any of these describing the old behavior is not done.
 |------|------|
 | `src/xslint.js` | Orchestrates file discovery, configuration, and suppression, runs validators then linters, formats output |
 | `src/config.js` | Resolves `.xslint.yml` (rule severities/`off`, exclude globs, `max-warnings`), found by walking up from the cwd or via `--config` |
+| `src/directives.js` | Parses inline `xslint-disable-*` comment directives and tests whether one suppresses a defect |
 | `src/xsl-validator.js` | Builds the corpus from raw sources; reports each stylesheet that is not well-formed XML and leaves it out |
 | `src/xpath-validator.js` | Splits each corpus expression into the valid ones (kept for the expression linters) and the malformed ones (reported) |
 | `src/xpath-linter.js` | Loads `checks/xpath/*.yaml`, applies per-file XPath rules |

--- a/README.md
+++ b/README.md
@@ -104,6 +104,23 @@ quiet: false                            # default for --quiet
 Unknown top-level keys and rule names that match no check are reported so typos
 do not pass silently.
 
+## Inline suppression
+
+Silence a rule in one place with an XML-comment directive. Rule names are
+optional and space-separated; with none, every rule at that location is
+suppressed.
+
+```xml
+<!-- xslint-disable-next-line short-names -->
+<xsl:variable name="x" select="1"/>
+
+<!-- xslint-disable-file not-using-schema-types -->
+```
+
+- **`xslint-disable-next-line [rules]`** — the line after the comment.
+- **`xslint-disable-line [rules]`** — the comment's own line.
+- **`xslint-disable-file [rules]`** — the whole file (put it near the top).
+
 ## Output
 
 Defects are written to stdout; progress and diagnostic logs go to stderr, so

--- a/src/directives.js
+++ b/src/directives.js
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Inline suppression directives, written as XML comments, and the scope each
+ * one covers. Rule names are optional and space-separated; with none, the
+ * directive covers every rule at its location.
+ * @type {RegExp}
+ */
+const DIRECTIVE =
+  /<!--\s*xslint-(disable-file|disable-next-line|disable-line)([a-z0-9\s-]*)-->/g
+
+/**
+ * Inline directives found in a stylesheet's raw text, each with the line it
+ * sits on and the rule names it names.
+ * @param {string} content - Raw stylesheet text
+ * @return {Array.<{type: string, line: number, names: Array.<string>}>} -
+ *  Directives in the order they appear
+ */
+const directivesFrom = function(content) {
+  const directives = []
+  for (const match of content.matchAll(DIRECTIVE)) {
+    directives.push({
+      type: match[1],
+      line: content.slice(0, match.index).split('\n').length,
+      names: match[2].trim().split(/\s+/).filter((name) => name.length > 0),
+    })
+  }
+  return directives
+}
+
+/**
+ * Whether any directive suppresses given defect. A directive with no names
+ * covers every rule; otherwise it covers only the ones it names. 'disable-file'
+ * covers the whole file, 'disable-next-line' the line after the comment, and
+ * 'disable-line' the comment's own line.
+ * @param {Array.<{type: string, line: number, names: Array.<string>}>}
+ *  directives - Directives from the defect's file
+ * @param {{name: string, line: number}} defect - Defect to test
+ * @return {boolean} - True when a directive suppresses the defect
+ */
+const suppresses = function(directives, defect) {
+  return directives.some((directive) => {
+    if (directive.names.length > 0 && !directive.names.includes(defect.name)) {
+      return false
+    }
+    if (directive.type === 'disable-file') {
+      return true
+    }
+    if (directive.type === 'disable-next-line') {
+      return defect.line === directive.line + 1
+    }
+    return defect.line === directive.line
+  })
+}
+
+module.exports = {
+  directivesFrom,
+  suppresses,
+}

--- a/src/directives.js
+++ b/src/directives.js
@@ -4,13 +4,29 @@
  */
 
 /**
- * Inline suppression directives, written as XML comments, and the scope each
- * one covers. Rule names are optional and space-separated; with none, the
- * directive covers every rule at its location.
+ * Directive keywords and the scope each one covers: the whole file, the line
+ * after the comment, or the comment's own line.
+ * @type {{FILE: string, NEXT_LINE: string, LINE: string}}
+ */
+const TYPES = {
+  FILE: 'disable-file',
+  NEXT_LINE: 'disable-next-line',
+  LINE: 'disable-line',
+}
+
+/**
+ * Inline suppression directives, written as XML comments. Rule names are
+ * optional and space-separated; with none, the directive covers every rule at
+ * its location. NEXT_LINE precedes LINE in the alternation so the longer
+ * keyword wins.
  * @type {RegExp}
  */
-const DIRECTIVE =
-  /<!--\s*xslint-(disable-file|disable-next-line|disable-line)([a-z0-9\s-]*)-->/g
+const DIRECTIVE = new RegExp(
+  '<!--\\s*xslint-(' +
+  [TYPES.FILE, TYPES.NEXT_LINE, TYPES.LINE].join('|') +
+  ')([a-z0-9\\s-]*)-->',
+  'g',
+)
 
 /**
  * Inline directives found in a stylesheet's raw text, each with the line it
@@ -33,9 +49,7 @@ const directivesFrom = function(content) {
 
 /**
  * Whether any directive suppresses given defect. A directive with no names
- * covers every rule; otherwise it covers only the ones it names. 'disable-file'
- * covers the whole file, 'disable-next-line' the line after the comment, and
- * 'disable-line' the comment's own line.
+ * covers every rule; otherwise it covers only the ones it names.
  * @param {Array.<{type: string, line: number, names: Array.<string>}>}
  *  directives - Directives from the defect's file
  * @param {{name: string, line: number}} defect - Defect to test
@@ -46,10 +60,10 @@ const suppresses = function(directives, defect) {
     if (directive.names.length > 0 && !directive.names.includes(defect.name)) {
       return false
     }
-    if (directive.type === 'disable-file') {
+    if (directive.type === TYPES.FILE) {
       return true
     }
-    if (directive.type === 'disable-next-line') {
+    if (directive.type === TYPES.NEXT_LINE) {
       return defect.line === directive.line + 1
     }
     return defect.line === directive.line

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -16,6 +16,7 @@ const {lintByFormat, names: formatChecks} = require('./xpath-format-linter')
 const {logger, levels} = require('./logger')
 const {out} = require('./output')
 const {configFrom} = require('./config')
+const {directivesFrom, suppresses} = require('./directives')
 const {minimatch} = require('minimatch')
 
 /**
@@ -176,10 +177,27 @@ const xslint = function(pths, options) {
       defect.severity = overrides[defect.name]
     }
   }
+  const directives = new Map(
+    sources.map((source) => [source.file, directivesFrom(source.content)]),
+  )
+  for (const [, list] of directives) {
+    for (const directive of list) {
+      for (const name of directive.names) {
+        if (!CHECKS.includes(name)) {
+          logger.warn(
+            `Rule '${name}' in an xslint-disable directive does not exist`,
+          )
+        }
+      }
+    }
+  }
+  const reported = defects.filter(
+    (defect) => !suppresses(directives.get(defect.file), defect),
+  )
   logger.info(`Processed files: ${stylesheets.length}`)
-  if (defects.length > 0) {
-    logger.info(`Defects found: ${defects.length}`)
-    for (const defect of defects) {
+  if (reported.length > 0) {
+    logger.info(`Defects found: ${reported.length}`)
+    for (const defect of reported) {
       out[defect.severity](
         '%s(%d:%d) %s (%s)',
         defect.file,
@@ -189,8 +207,8 @@ const xslint = function(pths, options) {
         defect.name,
       )
     }
-    const errors = defects.filter((defect) => defect.severity === 'error')
-    const warnings = defects.filter((defect) => defect.severity === 'warning')
+    const errors = reported.filter((defect) => defect.severity === 'error')
+    const warnings = reported.filter((defect) => defect.severity === 'warning')
     if (
       errors.length > 0 ||
       (maxWarnings >= 0 && warnings.length > maxWarnings)

--- a/test/directives.test.js
+++ b/test/directives.test.js
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {directivesFrom, suppresses} = require('../src/directives')
+const assert = require('assert')
+
+describe('directives', function() {
+  it('reads a disable-next-line directive with its line and names', function() {
+    assert.deepStrictEqual(
+      directivesFrom('a\nb\n<!-- xslint-disable-next-line short-names -->\n')[0],
+      {type: 'disable-next-line', line: 3, names: ['short-names']},
+    )
+  })
+  it('reads a nameless disable-file directive as covering everything', function() {
+    assert.deepStrictEqual(
+      directivesFrom('<!-- xslint-disable-file -->\n')[0],
+      {type: 'disable-file', line: 1, names: []},
+    )
+  })
+  it('suppresses a defect on the line after a disable-next-line', function() {
+    assert.ok(
+      suppresses(
+        [{type: 'disable-next-line', line: 3, names: ['short-names']}],
+        {name: 'short-names', line: 4},
+      ),
+    )
+  })
+  it('does not suppress a defect the directive does not name', function() {
+    assert.ok(
+      !suppresses(
+        [{type: 'disable-next-line', line: 3, names: ['short-names']}],
+        {name: 'unused-variable', line: 4},
+      ),
+    )
+  })
+  it('suppresses any defect in the file for a disable-file', function() {
+    assert.ok(
+      suppresses(
+        [{type: 'disable-file', line: 1, names: []}],
+        {name: 'anything', line: 99},
+      ),
+    )
+  })
+  it('does not suppress a defect on another line', function() {
+    assert.ok(
+      !suppresses(
+        [{type: 'disable-line', line: 5, names: []}],
+        {name: 'short-names', line: 6},
+      ),
+    )
+  })
+})

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -350,4 +350,70 @@ describe('xslint', function() {
     fs.rmSync(dir, {recursive: true, force: true})
     assert.ok(!streams.stderr.includes('Processed files'))
   })
+  it('should suppress a defect with an inline disable-next-line', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const file = path.join(dir, 'sheet.xsl')
+    fs.writeFileSync(file, [
+      '<?xml version="1.0"?>',
+      '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" ' +
+        'version="2.0" id="s">',
+      '  <xsl:template match="/">',
+      '    <!-- xslint-disable-next-line short-names -->',
+      '    <xsl:variable name="x" select="1"/>',
+      '  </xsl:template>',
+      '</xsl:stylesheet>',
+    ].join('\n'))
+    const streams = xslintStreams([file])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.ok(!streams.stdout.includes('short-names'))
+  })
+  it('should leave other defects when a disable-next-line is targeted', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const file = path.join(dir, 'sheet.xsl')
+    fs.writeFileSync(file, [
+      '<?xml version="1.0"?>',
+      '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" ' +
+        'version="2.0" id="s">',
+      '  <xsl:template match="/">',
+      '    <!-- xslint-disable-next-line short-names -->',
+      '    <xsl:variable name="x" select="1"/>',
+      '  </xsl:template>',
+      '</xsl:stylesheet>',
+    ].join('\n'))
+    const streams = xslintStreams([file])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.ok(streams.stdout.includes('not-using-schema-types'))
+  })
+  it('should suppress across the file with an inline disable-file', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const file = path.join(dir, 'sheet.xsl')
+    fs.writeFileSync(file, [
+      '<?xml version="1.0"?>',
+      '<!-- xslint-disable-file short-names -->',
+      '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" ' +
+        'version="2.0" id="s">',
+      '  <xsl:template match="/">',
+      '    <xsl:variable name="x" select="1"/>',
+      '  </xsl:template>',
+      '</xsl:stylesheet>',
+    ].join('\n'))
+    const streams = xslintStreams([file])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.ok(!streams.stdout.includes('short-names'))
+  })
+  it('should warn about an unknown rule in a disable directive', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const file = path.join(dir, 'sheet.xsl')
+    fs.writeFileSync(file, [
+      '<?xml version="1.0"?>',
+      '<!-- xslint-disable-file bogus-rule -->',
+      '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" ' +
+        'version="2.0" id="s">',
+      '  <xsl:template match="/"><out/></xsl:template>',
+      '</xsl:stylesheet>',
+    ].join('\n'))
+    const streams = xslintStreams([file])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.ok(streams.stderr.includes('Rule \'bogus-rule\' in an xslint-disable'))
+  })
 })


### PR DESCRIPTION
Suppression was all-or-nothing: `--suppress` and config `off` silence a rule everywhere, so a single justified exception forced a project to turn the rule off for its whole codebase. This adds a local escape hatch, the equivalent of `eslint-disable-next-line`, as XML-comment directives.

```xml
<!-- xslint-disable-next-line short-names -->
<xsl:variable name="x" select="1"/>

<!-- xslint-disable-file not-using-schema-types -->
```

Three forms — `xslint-disable-next-line`, `xslint-disable-line`, and `xslint-disable-file` — each taking an optional, space-separated list of rule names (none means every rule at that location).

A new `src/directives.js` scans the raw stylesheet text for the directives and their lines; `src/xslint.js` drops any collected defect a directive covers, matching on `(file, line, name)`. Because it filters the final defect list, it covers every kind — xpath, corpus, and format — and composes with `--suppress`/config `off`. A directive that names a rule which does not exist is reported, so typos do not pass silently.

Block ranges (`xslint-disable … xslint-enable`) are intentionally left out of this first cut, and reporting unused directives is filed separately as #288.

Covered by a `directives` unit spec (parsing each form and the suppression predicate) and end-to-end tests (next-line suppresses its target, leaves other defects, disable-file spans the file, unknown rule names warn). 315 tests pass, coverage holds at 98%. README and CLAUDE.md document the directives.

Closes #262.
