### PR TITLE
Move test stylesheet fixtures to resources; complain about concatenation in CI

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+name: fixtures
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  fixtures:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Complain about concatenated stylesheet fixtures
+        run: |
+          matches=$(grep -rn "]\.join(" test/ --include='*.test.js' || true)
+          if [ -n "${matches}" ]; then
+            echo "${matches}"
+            echo "::warning::Build test stylesheet fixtures from .xsl resources or the pack input: block, not string concatenation"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,8 @@ XPath uses namespace prefix `xsl:` → `http://www.w3.org/1999/XSL/Transform` an
 
 **xcop formatting** — `test/xcop.test.js` extracts the inline XSL from every pack directory holding *well-formed* fixtures (`xpath-packs`, `corpus-packs`, `xpath-validator-packs`, `xpath-format-packs`), re-serializes it, and runs [xcop](https://github.com/yegor256/xcop) over it to verify the fixtures are well-formatted XML (skipped when `xcop` is not installed). The XML validator's malformed fixtures are deliberately not xcop-checked. A new pack directory of well-formed fixtures must be added to its `PACKS` list, or it goes unchecked.
 
+**Stylesheet fixtures in tests** — build them from committed `.xsl` resources (under `test/resources/`, linted by path) or the pack `input:` block scalar, never from JavaScript string concatenation like `[...].join('\n')`. The `fixtures` CI job complains (a warning annotation) when a test does. Two exceptions stay inline as template literals: malformed stylesheets (xcop cannot accept them as committed files) and trivial one-to-five-line snippets. Note that a committed `.xsl` is counted by the `should test default directory` test, so adding one bumps its `Processed files: N`.
+
 ## Adding a New Rule
 
 Rule names are kebab-case with no `template-match-` (or other noise) prefix. Every rule needs a motive and at least one test pack. `test/conformance.test.js` enforces all three across `xpath` and `corpus` (naming and motives are enforced for `validation` and `format` too), so a rule that misnames itself, drops its motive, or ships without a pack fails the build.

--- a/test/resources/directives/disable-file.xsl
+++ b/test/resources/directives/disable-file.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="disable-file">
+  <xsl:template match="/">
+    <!-- xslint-disable-file short-names -->
+    <xsl:variable name="x" as="xs:integer" select="1"/>
+    <xsl:value-of select="$x"/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/directives/targeted.xsl
+++ b/test/resources/directives/targeted.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="targeted">
+  <xsl:template match="/">
+    <!-- xslint-disable-next-line short-names -->
+    <xsl:variable name="x" select="1"/>
+    <xsl:value-of select="$x"/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -100,7 +100,7 @@ describe('xslint', function() {
   it('should test default directory', function() {
     const stdout = runXslint([])
     assert.ok(stdout.includes('Directories and files to process: .'))
-    assert.ok(stdout.includes('Processed files: 8'))
+    assert.ok(stdout.includes('Processed files: 10'))
   })
   it('should test empty suppress', function() {
     const stdout = runXslint([
@@ -150,25 +150,21 @@ describe('xslint', function() {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
     fs.writeFileSync(
       path.join(dir, 'good.xsl'),
-      [
-        '<?xml version="1.0"?>',
-        '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">',
-        '  <xsl:template match="/">',
-        '    <xsl:value-of select="1 +"/>',
-        '  </xsl:template>',
-        '</xsl:stylesheet>',
-      ].join('\n'),
+      `<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:template match="/">
+    <xsl:value-of select="1 +"/>
+  </xsl:template>
+</xsl:stylesheet>`,
     )
     fs.writeFileSync(
       path.join(dir, 'bad.xsl'),
-      [
-        '<?xml version="1.0"?>',
-        '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">',
-        '  <xsl:template match="/">',
-        '    <result>',
-        '  </xsl:template>',
-        '</xsl:stylesheet>',
-      ].join('\n'),
+      `<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:template match="/">
+    <result>
+  </xsl:template>
+</xsl:stylesheet>`,
     )
     const stdout = runXslint([dir])
     fs.rmSync(dir, {recursive: true, force: true});
@@ -204,14 +200,12 @@ describe('xslint', function() {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
     fs.writeFileSync(
       path.join(dir, 'broken.xsl'),
-      [
-        '<?xml version="1.0"?>',
-        '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">',
-        '  <xsl:template match="/">',
-        '    <result>',
-        '  </xsl:template>',
-        '</xsl:stylesheet>',
-      ].join('\n'),
+      `<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:template match="/">
+    <result>
+  </xsl:template>
+</xsl:stylesheet>`,
     )
     const status = xslintStatus([dir, '--max-warnings=100'])
     fs.rmSync(dir, {recursive: true, force: true})
@@ -269,13 +263,10 @@ describe('xslint', function() {
     fs.writeFileSync(path.join(dir, '.xslint.yml'), 'exclude:\n  - "*.xsl"\n')
     fs.writeFileSync(
       path.join(dir, 'sheet.xsl'),
-      [
-        '<?xml version="1.0"?>',
-        '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" ' +
-          'version="2.0">',
-        '  <xsl:template match="/"><out/></xsl:template>',
-        '</xsl:stylesheet>',
-      ].join('\n'),
+      `<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:template match="/"><out/></xsl:template>
+</xsl:stylesheet>`,
     )
     const streams = xslintStreams([
       dir, `--config=${path.join(dir, '.xslint.yml')}`,
@@ -351,67 +342,25 @@ describe('xslint', function() {
     assert.ok(!streams.stderr.includes('Processed files'))
   })
   it('should suppress a defect with an inline disable-next-line', function() {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
-    const file = path.join(dir, 'sheet.xsl')
-    fs.writeFileSync(file, [
-      '<?xml version="1.0"?>',
-      '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" ' +
-        'version="2.0" id="s">',
-      '  <xsl:template match="/">',
-      '    <!-- xslint-disable-next-line short-names -->',
-      '    <xsl:variable name="x" select="1"/>',
-      '  </xsl:template>',
-      '</xsl:stylesheet>',
-    ].join('\n'))
-    const streams = xslintStreams([file])
-    fs.rmSync(dir, {recursive: true, force: true})
+    const streams = xslintStreams(['test/resources/directives/used.xsl'])
     assert.ok(!streams.stdout.includes('short-names'))
   })
   it('should leave other defects when a disable-next-line is targeted', function() {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
-    const file = path.join(dir, 'sheet.xsl')
-    fs.writeFileSync(file, [
-      '<?xml version="1.0"?>',
-      '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" ' +
-        'version="2.0" id="s">',
-      '  <xsl:template match="/">',
-      '    <!-- xslint-disable-next-line short-names -->',
-      '    <xsl:variable name="x" select="1"/>',
-      '  </xsl:template>',
-      '</xsl:stylesheet>',
-    ].join('\n'))
-    const streams = xslintStreams([file])
-    fs.rmSync(dir, {recursive: true, force: true})
+    const streams = xslintStreams(['test/resources/directives/targeted.xsl'])
     assert.ok(streams.stdout.includes('not-using-schema-types'))
   })
   it('should suppress across the file with an inline disable-file', function() {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
-    const file = path.join(dir, 'sheet.xsl')
-    fs.writeFileSync(file, [
-      '<?xml version="1.0"?>',
-      '<!-- xslint-disable-file short-names -->',
-      '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" ' +
-        'version="2.0" id="s">',
-      '  <xsl:template match="/">',
-      '    <xsl:variable name="x" select="1"/>',
-      '  </xsl:template>',
-      '</xsl:stylesheet>',
-    ].join('\n'))
-    const streams = xslintStreams([file])
-    fs.rmSync(dir, {recursive: true, force: true})
+    const streams = xslintStreams(['test/resources/directives/disable-file.xsl'])
     assert.ok(!streams.stdout.includes('short-names'))
   })
   it('should warn about an unknown rule in a disable directive', function() {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
     const file = path.join(dir, 'sheet.xsl')
-    fs.writeFileSync(file, [
-      '<?xml version="1.0"?>',
-      '<!-- xslint-disable-file bogus-rule -->',
-      '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" ' +
-        'version="2.0" id="s">',
-      '  <xsl:template match="/"><out/></xsl:template>',
-      '</xsl:stylesheet>',
-    ].join('\n'))
+    fs.writeFileSync(file, `<?xml version="1.0"?>
+<!-- xslint-disable-file bogus-rule -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+  <xsl:template match="/"><out/></xsl:template>
+</xsl:stylesheet>`)
     const streams = xslintStreams([file])
     fs.rmSync(dir, {recursive: true, force: true})
     assert.ok(streams.stderr.includes('Rule \'bogus-rule\' in an xslint-disable'))


### PR DESCRIPTION
Several tests built their stylesheet fixtures by concatenating lines in JavaScript — `[...].join('\n')` — which reads poorly next to the project's committed `.xsl` fixtures and pack `input:` blocks. This moves them to proper resources and adds a CI nudge so new ones do not creep in.

The well-formed multi-line inline-suppression fixtures become committed resources under `test/resources/directives/` and are linted by path: the next-line test reuses `used.xsl`, and two new fixtures, `targeted.xsl` and `disable-file.xsl`, cover the remaining cases. Both carry the SPDX header and are xcop-clean.

Two kinds of fixture stay inline, now as template literals rather than `join` concatenation: malformed stylesheets (the `should lint the parseable stylesheets…` and error-exit tests), which xcop cannot accept as committed files, and trivial one-to-five-line snippets (the exclude and unknown-rule tests). No test now uses `[...].join('\n')`.

A new `fixtures` CI job greps the test files for the concatenation pattern and, if it finds one, emits a warning annotation — a complaint, not a failure, so the convention is visible without being brittle. CLAUDE.md documents the rule and its two exceptions.

The `should test default directory` count moves to 10 for the two new committed fixtures. 319 tests pass, coverage holds at 98%.

Closes #290.
