### PR TITLE
Enforce operator spacing, id-length, and postfix-only increment (stylistic gate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ npx mocha test/xslint.test.js --timeout 10000   # Run a single test file
 npx mocha test/xslint.test.js --grep "sentence"  # Run tests matching a pattern
 ```
 
+Code style is enforced by ESLint (`eslint-config-google` plus `@stylistic`, in `eslint.config.mjs`, run by the `grunt` job on every push and pull request): spaced operators (`@stylistic/space-infix-ops`), no single-letter names (`id-length` minimum 2), and postfix-only increment/decrement (`no-restricted-syntax` bans prefix `++x`/`--x`; `x++` is fine).
+
 ## Architecture
 
 **xslint** is a CLI linter for XSL stylesheets. It runs in two stages: **validators** first establish that the input is valid (each stylesheet is well-formed XML, and every XPath expression compiles), then **linters** run over what passed — the well-formed stylesheets, and the XPath expressions that parse — catching stylistic, semantic, and logical problems. Each validator *partitions* its input: it hands the valid part to the next stage and reports the rest, so one broken file (or one malformed expression) never hides the feedback on the rest.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
 import globals from "globals";
 import jsdoc from "eslint-plugin-jsdoc";
+import stylistic from "@stylistic/eslint-plugin";
 import { FlatCompat } from "@eslint/eslintrc";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -36,6 +37,7 @@ export default defineConfig([
         tagNamePreference: { returns: "return" }
       }
     },
+    plugins: { "@stylistic": stylistic },
     rules: {
       "valid-jsdoc": "off",
       "require-jsdoc": "off",
@@ -54,7 +56,13 @@ export default defineConfig([
         "error",
         { definedTypes: ["Document", "Node", "Element"] }
       ],
-      "jsdoc/reject-any-type": "off"
+      "jsdoc/reject-any-type": "off",
+      "@stylistic/space-infix-ops": "error",
+      "id-length": ["error", { min: 2 }],
+      "no-restricted-syntax": ["error", {
+        selector: "UpdateExpression[prefix=true]",
+        message: "Use postfix increment/decrement (x++), not prefix (++x)"
+      }]
     }
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "devDependencies": {
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/mocha-runner": "^9.6.1",
+        "@stylistic/eslint-plugin": "^5.10.0",
         "c8": "^12.0.0",
         "eslint": "^10.5.0",
         "eslint-config-google": "^0.14.0",
@@ -1552,6 +1553,71 @@
       "integrity": "sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+      "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/types": "^8.56.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/mocha-runner": "^9.6.1",
+    "@stylistic/eslint-plugin": "^5.10.0",
     "c8": "^12.0.0",
     "eslint": "^10.5.0",
     "eslint-config-google": "^0.14.0",

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -117,7 +117,7 @@ const expressions = (kind, lint) => {
 
 const generate = function() {
   const checks = KINDS.flatMap((kind) => allFilesFrom(path.join(CHECKS, kind))
-    .filter((f) => f.endsWith('.yaml'))
+    .filter((file) => file.endsWith('.yaml'))
     .sort()
     .map((yamlFile) => {
       const name = path.basename(yamlFile, '.yaml')

--- a/src/index.js
+++ b/src/index.js
@@ -37,8 +37,8 @@ program
 
 try {
   program.parse(process.argv)
-} catch (e) {
-  console.error(e.message)
-  console.debug(e.stack)
+} catch (error) {
+  console.error(error.message)
+  console.debug(error.stack)
   process.exit(1)
 }

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -225,23 +225,23 @@ const opensComment = function(xpath, at) {
  */
 const opensAxis = function(xpath, at) {
   let axis = ''
-  if (at<xpath.length && xpath[at].match(/[a-zA-Z]/)) {
+  if (at < xpath.length && xpath[at].match(/[a-zA-Z]/)) {
     do {
       axis += xpath[at]
       at++
       if (xpath[at] === ':') {
-        if (xpath[at+1] === ':') {
-          axis += xpath.slice(at, at+2)
+        if (xpath[at + 1] === ':') {
+          axis += xpath.slice(at, at + 2)
           at++
         } else {
           axis = ''
         }
         break
       }
-    } while (at<xpath.length && xpath[at].match(/[a-zA-Z\-:]/))
+    } while (at < xpath.length && xpath[at].match(/[a-zA-Z\-:]/))
   }
   if (!AXES[axis]) {
-    axis=''
+    axis = ''
   }
   return axis
 }
@@ -253,7 +253,7 @@ const opensAxis = function(xpath, at) {
  * @return {boolean} - True when digit or "." with digit starts here
  */
 const opensNumber = function(xpath, at) {
-  return DIGIT.includes(xpath[at]) || (xpath[at] === '.' && DIGIT.includes(xpath[at+1]))
+  return DIGIT.includes(xpath[at]) || (xpath[at] === '.' && DIGIT.includes(xpath[at + 1]))
 }
 
 /**
@@ -263,12 +263,12 @@ const opensNumber = function(xpath, at) {
  * @return {string} - User function
  */
 const opensUserFunction = function(xpath, at) {
-  let func=''
+  let func = ''
   let colon = 0
-  if (at<xpath.length && xpath[at].match(/[a-zA-Z]/)) {
+  if (at < xpath.length && xpath[at].match(/[a-zA-Z]/)) {
     func += xpath[at]
     at++
-    while (at<xpath.length && xpath[at].match(/[a-zA-Z0-9_:]/)) {
+    while (at < xpath.length && xpath[at].match(/[a-zA-Z0-9_:]/)) {
       if (xpath[at].match(/[a-zA-Z0-9_]/)) {
         func = func + xpath[at]
         at++
@@ -283,7 +283,7 @@ const opensUserFunction = function(xpath, at) {
         }
       }
     }
-    if (xpath[at-1] === ':' || xpath[at] !== '(' || colon !== 1) func = ''
+    if (xpath[at - 1] === ':' || xpath[at] !== '(' || colon !== 1) func = ''
   }
   return func
 }
@@ -358,21 +358,21 @@ const afterComment = function(xpath, start) {
  * @return {number} - Offset just past the closing digit
  */
 const afterNumber = function(xpath, start) {
-  let at = start +1
+  let at = start + 1
   let point = 0
-  let e = 0
+  let exponent = 0
   while (at < xpath.length) {
-    if (xpath[at] === '.' && point === 0 && e === 0 ) {
+    if (xpath[at] === '.' && point === 0 && exponent === 0 ) {
       point += 1
       at += 1
     } else if (DIGIT.includes(xpath[at])) {
       at += 1
-    } else if ((xpath[at] === 'e' || xpath[at] === 'E') && e === 0) {
-      e+=1
-      if (DIGIT.includes(xpath[at+1])) {
+    } else if ((xpath[at] === 'e' || xpath[at] === 'E') && exponent === 0) {
+      exponent += 1
+      if (DIGIT.includes(xpath[at + 1])) {
         at += 2
-      } else if (xpath[at+1] ==='+' || xpath[at+1] === '-') {
-        if (DIGIT.includes(xpath[at+2])) {
+      } else if (xpath[at + 1] === '+' || xpath[at + 1] === '-') {
+        if (DIGIT.includes(xpath[at + 2])) {
           at += 3
         } else {
           break
@@ -402,8 +402,8 @@ const afterOther = function(xpath, start) {
     !QUOTES.includes(xpath[at]) &&
     !WHITESPACE.includes(xpath[at]) &&
     !SINGLE[xpath[at]] &&
-    !DOUBLE[xpath.slice(at, at+2)] &&
-    !TRIPLE[xpath.slice(at, at+3)] &&
+    !DOUBLE[xpath.slice(at, at + 2)] &&
+    !TRIPLE[xpath.slice(at, at + 3)] &&
     !opensMore(xpath, at) &&
     !opensComment(xpath, at) &&
     !opensUserFunction(xpath, at) &&
@@ -463,12 +463,12 @@ const tokenized = function(xpath) {
     } else if (more) {
       type = MORE[more]
       at += more.length
-    } else if (TRIPLE[xpath.slice(at, at+3)]) {
-      type = TRIPLE[xpath.slice(at, at+3)]
-      at+=3
-    } else if (DOUBLE[xpath.slice(at, at+2)]) {
-      type = DOUBLE[xpath.slice(at, at+2)]
-      at+=2
+    } else if (TRIPLE[xpath.slice(at, at + 3)]) {
+      type = TRIPLE[xpath.slice(at, at + 3)]
+      at += 3
+    } else if (DOUBLE[xpath.slice(at, at + 2)]) {
+      type = DOUBLE[xpath.slice(at, at + 2)]
+      at += 2
     } else if (SINGLE[xpath[at]]) {
       type = SINGLE[xpath[at]]
       at++

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -190,7 +190,8 @@ const xslint = function(pths, options) {
         }
       }
     }
-    for (const stale of unused(list, defects.filter((d) => d.file === file))) {
+    const found = defects.filter((defect) => defect.file === file)
+    for (const stale of unused(list, found)) {
       logger.warn(`Unused xslint-disable directive at ${file}:${stale.line}`)
     }
   }

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -122,7 +122,7 @@ describe('xslint', function() {
     expected.forEach((str) => assert.ok(stdout.includes(str)))
   })
   it('should test incorrect suppress', function() {
-    const suppress='qwerty'
+    const suppress = 'qwerty'
     const stdout = runXslint([
       'test/resources/stylesheets/xsl-with-some-violations.xsl',
       `--suppress=${suppress}`,


### PR DESCRIPTION
The house style was advisory: ESLint 10 dropped the formatting rules from core, and `eslint-config-google` (loaded through `FlatCompat`) can no longer reactivate them, so `space-infix-ops`, `id-length`, and friends resolved to `undefined`. `tokens.js` passed lint despite `at<xpath.length`, a single-letter `e`, and unspaced `+=`. The `grunt` ESLint job ran on every push and pull request but enforced nothing stylistic.

This adds `@stylistic/eslint-plugin` and turns on a curated set in `eslint.config.mjs`, so the existing job now has teeth:

- `@stylistic/space-infix-ops` — operators must be spaced.
- `id-length` (minimum 2) — no single-letter names.
- `no-restricted-syntax` on `UpdateExpression[prefix=true]` — postfix `x++` is allowed, prefix `++x`/`--x` is not.

Then it fixes every violation the gate surfaces. Most were in `tokens.js` (spacing, auto-fixed; the exponent flag `e` renamed to `exponent`); the rest were one-liners the gate usefully caught elsewhere — `catch (e)` in `src/index.js`, a `d` lambda in `src/xslint.js` (introduced in #288), and an `f` in `scripts/generate-docs.js`. The postfix `++` in `tokens.js` are left as-is, since only prefix is banned. No behaviour changed — the changes are spacing and renames, and the full suite (including the tokenizer property tests) stays green; coverage holds at 98%.

CLAUDE.md documents the enforced rules.

Closes #257.
