### PR TITLE
Add --format json and sarif output behind a uniform reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Add machine-readable output: `--format json` and `--format sarif` (SARIF
+  2.1.0, for GitHub code scanning) alongside the default `text` (#260).
 - Add inline suppression directives — `xslint-disable-next-line`,
   `xslint-disable-line`, and `xslint-disable-file` (#262), and report a
   directive that suppresses nothing as unused (#288).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ A change that leaves any of these describing the old behavior is not done.
 | `src/xslint.js` | Orchestrates file discovery, configuration, and suppression, runs validators then linters, formats output |
 | `src/config.js` | Resolves `.xslint.yml` (rule severities/`off`, exclude globs, `max-warnings`), found by walking up from the cwd or via `--config` |
 | `src/directives.js` | Parses inline `xslint-disable-*` comment directives and tests whether one suppresses a defect |
+| `src/reporters.js` | Formats the collected defects for output — `text` (default), `json`, or `sarif` — behind a uniform `reporterOf(format)` that `src/xslint.js` calls without knowing the format |
 | `src/xsl-validator.js` | Builds the corpus from raw sources; reports each stylesheet that is not well-formed XML and leaves it out |
 | `src/xpath-validator.js` | Splits each corpus expression into the valid ones (kept for the expression linters) and the malformed ones (reported) |
 | `src/xpath-linter.js` | Loads `checks/xpath/*.yaml`, applies per-file XPath rules |

--- a/README.md
+++ b/README.md
@@ -134,6 +134,30 @@ drop the informational log lines:
 xslint --quiet
 ```
 
+## Machine-readable output
+
+`--format` selects the output. `text` (the default) is the human format above;
+`json` and `sarif` print a single document to stdout — logs stay on stderr, so
+the document is clean to pipe or redirect:
+
+```bash
+xslint --format json path/to/dir     # a flat array of defects
+xslint --format sarif path/to/dir    # a SARIF 2.1.0 log
+```
+
+SARIF feeds GitHub code scanning, so xslint findings appear as annotations on
+pull requests:
+
+```yaml
+- run: xslint --format sarif . > xslint.sarif || true
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: xslint.sarif
+```
+
+The `|| true` keeps a findings exit code from failing the step before the
+upload; the alerts still surface in code scanning.
+
 ## Exit code
 
 `xslint` exits non-zero when any `error`-severity defect is found. Warnings do

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {program} = require('commander')
+const {program, Option} = require('commander')
 const version = require('./version')
 const xslint = require('./xslint')
 
@@ -19,6 +19,11 @@ program
   .helpOption('-?, --help', 'Print this help information')
   .option('--log-level <level>', 'Set log level')
   .option('--quiet', 'Suppress informational logs, printing only defects')
+  .addOption(
+    new Option('--format <format>', 'Output format for defects')
+      .choices(['text', 'json', 'sarif'])
+      .default('text'),
+  )
   .option('--config <path>', 'Path to a configuration file')
   .option(
     '--max-warnings <n>',

--- a/src/reporters.js
+++ b/src/reporters.js
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const path = require('node:path')
+const {out} = require('./output')
+const version = require('./version')
+
+/**
+ * Defect severity mapped to a SARIF level.
+ * @type {{warning: string, error: string}}
+ */
+const LEVEL = {warning: 'warning', error: 'error'}
+
+/**
+ * A defect's file as a path relative to the working directory, in posix form,
+ * the shape the machine formats and GitHub code scanning expect.
+ * @param {string} file - Absolute path of the stylesheet
+ * @return {string} - Relative posix path
+ */
+const located = function(file) {
+  return path.relative(process.cwd(), file).split(path.sep).join('/')
+}
+
+/**
+ * Print defects as the human-readable lines that xslint has always emitted.
+ * @param {Array.<object>} defects - Defects to print
+ */
+const text = function(defects) {
+  for (const defect of defects) {
+    out[defect.severity](
+      '%s(%d:%d) %s (%s)',
+      defect.file,
+      defect.line,
+      defect.pos,
+      defect.message,
+      defect.name,
+    )
+  }
+}
+
+/**
+ * Print defects as a flat JSON array, one object per defect.
+ * @param {Array.<object>} defects - Defects to print
+ */
+const json = function(defects) {
+  console.log(JSON.stringify(
+    defects.map((defect) => ({
+      rule: defect.name,
+      severity: defect.severity,
+      message: defect.message,
+      file: located(defect.file),
+      line: defect.line,
+      column: defect.pos,
+    })),
+    null,
+    2,
+  ))
+}
+
+/**
+ * Print defects as a SARIF 2.1.0 log. The rules are derived from the defects
+ * present, so the log is self-contained; GitHub code scanning ingests it.
+ * @param {Array.<object>} defects - Defects to print
+ */
+const sarif = function(defects) {
+  const rules = []
+  const indexed = {}
+  for (const defect of defects) {
+    if (!Object.hasOwn(indexed, defect.name)) {
+      indexed[defect.name] = rules.length
+      rules.push({
+        id: defect.name,
+        shortDescription: {text: defect.message},
+        defaultConfiguration: {level: LEVEL[defect.severity]},
+      })
+    }
+  }
+  console.log(JSON.stringify({
+    version: '2.1.0',
+    $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+    runs: [{
+      tool: {driver: {name: 'xslint', version: version.what, rules: rules}},
+      results: defects.map((defect) => ({
+        ruleId: defect.name,
+        ruleIndex: indexed[defect.name],
+        level: LEVEL[defect.severity],
+        message: {text: defect.message},
+        locations: [{
+          physicalLocation: {
+            artifactLocation: {uri: located(defect.file)},
+            region: {startLine: defect.line, startColumn: defect.pos},
+          },
+        }],
+      })),
+    }],
+  }, null, 2))
+}
+
+/**
+ * Reporters by format name, each a function that writes given defects.
+ * @type {{[format: string]: function(Array.<object>): void}}
+ */
+const REPORTERS = {text: text, json: json, sarif: sarif}
+
+/**
+ * The reporter for a format, so a caller writes defects without knowing how.
+ * @param {string} format - Format name (text, json, or sarif)
+ * @return {function(Array.<object>): void} - Reporter that writes the defects
+ */
+const reporterOf = function(format) {
+  return REPORTERS[format]
+}
+
+module.exports = {
+  reporterOf,
+}

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -14,7 +14,7 @@ const {lintByXpath, names: xpathChecks} = require('./xpath-linter')
 const {lintByCorpus, names: corpusChecks} = require('./corpus-linter')
 const {lintByFormat, names: formatChecks} = require('./xpath-format-linter')
 const {logger, levels} = require('./logger')
-const {out} = require('./output')
+const {reporterOf} = require('./reporters')
 const {configFrom} = require('./config')
 const {directivesFrom, suppresses, unused} = require('./directives')
 const {minimatch} = require('minimatch')
@@ -122,7 +122,8 @@ const processOptions = function(options, config) {
  *  quiet: boolean,
  *  suppress: Array.<string>,
  *  maxWarnings: number|undefined,
- *  config: string|undefined
+ *  config: string|undefined,
+ *  format: string
  * }} options - CLI options
  */
 const xslint = function(pths, options) {
@@ -201,26 +202,17 @@ const xslint = function(pths, options) {
   logger.info(`Processed files: ${stylesheets.length}`)
   if (reported.length > 0) {
     logger.info(`Defects found: ${reported.length}`)
-    for (const defect of reported) {
-      out[defect.severity](
-        '%s(%d:%d) %s (%s)',
-        defect.file,
-        defect.line,
-        defect.pos,
-        defect.message,
-        defect.name,
-      )
-    }
-    const errors = reported.filter((defect) => defect.severity === 'error')
-    const warnings = reported.filter((defect) => defect.severity === 'warning')
-    if (
-      errors.length > 0 ||
-      (maxWarnings >= 0 && warnings.length > maxWarnings)
-    ) {
-      process.exit(1)
-    }
   } else {
     logger.info(`No defects found`)
+  }
+  reporterOf(options.format)(reported)
+  const errors = reported.filter((defect) => defect.severity === 'error')
+  const warnings = reported.filter((defect) => defect.severity === 'warning')
+  if (
+    errors.length > 0 ||
+    (maxWarnings >= 0 && warnings.length > maxWarnings)
+  ) {
+    process.exit(1)
   }
 }
 

--- a/test/reporters.test.js
+++ b/test/reporters.test.js
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {reporterOf} = require('../src/reporters')
+const assert = require('assert')
+const path = require('path')
+
+/**
+ * Run a reporter over given defects and capture what it writes to stdout.
+ * @param {function(Array.<object>): void} report - Reporter under test
+ * @param {Array.<object>} defects - Defects to report
+ * @return {string} - The captured output
+ */
+const capture = function(report, defects) {
+  const lines = []
+  const original = console.log
+  console.log = (line) => lines.push(line)
+  try {
+    report(defects)
+  } finally {
+    console.log = original
+  }
+  return lines.join('\n')
+}
+
+/**
+ * A defect of given severity, its file under the working directory so the
+ * relative path is deterministic.
+ * @param {string} severity - Defect severity
+ * @return {object} - Defect
+ */
+const defect = function(severity) {
+  return {
+    name: 'short-names',
+    severity: severity,
+    message: 'Use a descriptive name',
+    file: path.join(process.cwd(), 'sheets', 'a.xsl'),
+    line: 16,
+    pos: 3,
+  }
+}
+
+describe('reporters', function() {
+  it('reports a defect as a JSON object with position and message', function() {
+    assert.deepStrictEqual(
+      JSON.parse(capture(reporterOf('json'), [defect('warning')]))[0],
+      {
+        rule: 'short-names',
+        severity: 'warning',
+        message: 'Use a descriptive name',
+        file: 'sheets/a.xsl',
+        line: 16,
+        column: 3,
+      },
+    )
+  })
+  it('reports an empty JSON array when there are no defects', function() {
+    assert.deepStrictEqual(JSON.parse(capture(reporterOf('json'), [])), [])
+  })
+  it('reports the SARIF version', function() {
+    assert.equal(
+      JSON.parse(capture(reporterOf('sarif'), [defect('warning')])).version,
+      '2.1.0',
+    )
+  })
+  it('places a SARIF result at the defect location', function() {
+    const log = JSON.parse(capture(reporterOf('sarif'), [defect('warning')]))
+    assert.deepStrictEqual(
+      log.runs[0].results[0].locations[0].physicalLocation.region,
+      {startLine: 16, startColumn: 3},
+    )
+  })
+  it('derives a SARIF rule from the defect', function() {
+    const log = JSON.parse(capture(reporterOf('sarif'), [defect('warning')]))
+    assert.equal(log.runs[0].tool.driver.rules[0].id, 'short-names')
+  })
+  it('maps an error defect to the SARIF error level', function() {
+    const log = JSON.parse(capture(reporterOf('sarif'), [defect('error')]))
+    assert.equal(log.runs[0].results[0].level, 'error')
+  })
+})

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -330,4 +330,27 @@ describe('xslint', function() {
     const streams = xslintStreams(['test/resources/directives/used.xsl'])
     assert.ok(!streams.stderr.includes('Unused xslint-disable directive'))
   })
+  it('should print defects as a JSON array with --format json', function() {
+    const streams = xslintStreams([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      '--format=json',
+    ])
+    assert.ok(
+      JSON.parse(streams.stdout).some((defect) => defect.rule === 'short-names'),
+    )
+  })
+  it('should print a SARIF 2.1.0 log with --format sarif', function() {
+    const streams = xslintStreams([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      '--format=sarif',
+    ])
+    assert.equal(JSON.parse(streams.stdout).version, '2.1.0')
+  })
+  it('should reject an unknown --format value', function() {
+    const status = xslintStatus([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      '--format=bogus',
+    ])
+    assert.notEqual(status, 0)
+  })
 })


### PR DESCRIPTION
xslint only spoke human text, which closed off the tooling ecosystem — GitHub code scanning, CI annotations, editors. This adds `--format <text|json|sarif>` (default `text`, so nothing changes unless asked).

- **json** — a flat array of `{rule, severity, message, file, line, column}`.
- **sarif** — a SARIF 2.1.0 log; `runs[0].results[]` carry `ruleId`, `level`, `message`, and a `physicalLocation`, and `tool.driver.rules[]` is derived from the rules present, so the log is self-contained. GitHub code scanning ingests it (README shows the `upload-sarif` snippet).

Both machine formats print one document to stdout — clean to pipe, because #263 already put logs on stderr — and use cwd-relative posix paths, what code scanning expects. The exit code stays severity-aware regardless of format.

Per the request, output goes through a single interface: `src/reporters.js` exposes `reporterOf(format)`, and `src/xslint.js` just calls `reporterOf(options.format)(reported)` without knowing which format it is. The three reporters (`text`, `json`, `sarif`) share the `(defects) => void` shape; `text` is the former inline loop moved behind the same interface. An unknown `--format` fails fast via commander's `choices`.

Tested both ways: a `reporters` unit spec drives each reporter and asserts the JSON object shape, the empty-array case, and the SARIF version, result location, derived rule, and error-level mapping; end-to-end tests run the CLI with each `--format` and parse stdout. No new dependency (SARIF is a plain object). 328 tests pass, coverage holds at 98%.

Closes #260.
