### PR TITLE
Color output only for an interactive terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Color output only for an interactive terminal and honor `NO_COLOR`, so
+  redirected or piped output no longer carries raw ANSI escapes (#302).
 - Report and ignore `.xslint.yml` values of the wrong type — a non-numeric
   `max-warnings` no longer silently disables the warning gate (#301).
 - Add machine-readable output: `--format json` and `--format sarif` (SARIF

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ drop the informational log lines:
 xslint --quiet
 ```
 
+Output is colored only when it goes to an interactive terminal, so a redirected
+or piped run stays plain text; setting the conventional `NO_COLOR` environment
+variable turns coloring off everywhere.
+
 ## Machine-readable output
 
 `--format` selects the output. `text` (the default) is the human format above;

--- a/src/output.js
+++ b/src/output.js
@@ -6,10 +6,23 @@
 const safe = require('colors/safe')
 
 /**
+ * Whether a stream should be colored: only when it is an interactive terminal
+ * and the conventional NO_COLOR variable is not set, so redirected or piped
+ * output stays plain text.
+ * @param {{isTTY: boolean|undefined}} stream - Destination stream
+ * @return {boolean} - True when coloring is appropriate
+ */
+const colorful = function(stream) {
+  return Boolean(stream.isTTY) && !Object.hasOwn(process.env, 'NO_COLOR')
+}
+
+/**
  * Leveled, prefixed writer over a sink. The diagnostics (defects) and the
  * operational logs share this formatting but not their stream: defects go to
- * stdout, logs to stderr.
+ * stdout, logs to stderr. Coloring is applied only when asked for, so a
+ * non-terminal sink receives plain text.
  * @param {function(string, ...*): void} sink - Where a formatted line goes
+ * @param {boolean} colored - Whether to wrap the prefix in ANSI color
  * @return {{
  *  debug: function(string, ...*): void,
  *  info: function(string, ...*): void,
@@ -18,18 +31,25 @@ const safe = require('colors/safe')
  *  error: function(string, ...*): void
  * }} - Writer bound to the sink
  */
-const writer = function(sink) {
+const writer = function(sink, colored = true) {
+  const paint = (color, text) => colored ? safe[color](text) : text
   const write = {
-    debug: (msg, ...args) => sink(`${safe.gray('[DEBUG]')} ${msg}`, ...args),
-    info: (msg, ...args) => sink(`${safe.blue('[INFO]')} ${msg}`, ...args),
-    warn: (msg, ...args) => sink(`${safe.yellow('[WARNING]')} ${msg}`, ...args),
+    debug: (msg, ...args) => sink(`${paint('gray', '[DEBUG]')} ${msg}`, ...args),
+    info: (msg, ...args) => sink(`${paint('blue', '[INFO]')} ${msg}`, ...args),
+    warn: (msg, ...args) =>
+      sink(`${paint('yellow', '[WARNING]')} ${msg}`, ...args),
     warning: (msg, ...args) => write.warn(msg, ...args),
-    error: (msg, ...args) => sink(`${safe.red('[ERROR]')} ${msg}`, ...args),
+    error: (msg, ...args) => sink(`${paint('red', '[ERROR]')} ${msg}`, ...args),
   }
   return write
 }
 
 module.exports = {
-  out: writer((msg, ...args) => console.log(msg, ...args)),
-  err: writer((msg, ...args) => console.error(msg, ...args)),
+  writer,
+  out: writer(
+    (msg, ...args) => console.log(msg, ...args), colorful(process.stdout),
+  ),
+  err: writer(
+    (msg, ...args) => console.error(msg, ...args), colorful(process.stderr),
+  ),
 }

--- a/src/output.js
+++ b/src/output.js
@@ -5,10 +5,13 @@
 
 const safe = require('colors/safe')
 
+safe.enable()
+
 /**
  * Whether a stream should be colored: only when it is an interactive terminal
  * and the conventional NO_COLOR variable is not set, so redirected or piped
- * output stays plain text.
+ * output stays plain text. This is the single gate on coloring — the library's
+ * own terminal heuristics are forced on above so the decision stays here.
  * @param {{isTTY: boolean|undefined}} stream - Destination stream
  * @return {boolean} - True when coloring is appropriate
  */

--- a/test/output.test.js
+++ b/test/output.test.js
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {writer} = require('../src/output')
+const assert = require('assert')
+
+/**
+ * The ANSI escape character, present in colored output and absent in plain.
+ * @type {string}
+ */
+const ESC = String.fromCharCode(27)
+
+describe('output', function() {
+  it('colors a line when coloring is enabled', function() {
+    const lines = []
+    writer((line) => lines.push(line), true).error('boom')
+    assert.ok(lines[0].includes(ESC))
+  })
+  it('leaves a line plain when coloring is disabled', function() {
+    const lines = []
+    writer((line) => lines.push(line), false).error('boom')
+    assert.ok(!lines[0].includes(ESC))
+  })
+})


### PR DESCRIPTION
The default `text` reporter colors every line through `colors/safe`, which emits escape sequences with no terminal check. So `xslint path > report.txt` wrote raw `\x1b[31m…\x1b[39m` bytes into the file, and any pipe carried the same noise.

`writer` now takes an explicit `colored` flag and paints the prefix only when it is set. The two module-level writers derive the flag from their stream — colored only when `isTTY` and `NO_COLOR` is unset — so interactive runs stay colored while redirected or piped output is plain.

```js
const colorful = function(stream) {
  return Boolean(stream.isTTY) && !Object.hasOwn(process.env, 'NO_COLOR')
}
```

A small `output` unit test covers both branches without faking a terminal.

Closes #302.
