### PR TITLE
Set the log level before reading config and suppressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Apply `--log-level`/`--quiet` before reading the configuration, rule
+  patterns, and suppressions, so a raised level now silences their warnings
+  too (#299).
 - Color output only for an interactive terminal and honor `NO_COLOR`, so
   redirected or piped output no longer carries raw ANSI escapes (#302).
 - Report and ignore `.xslint.yml` values of the wrong type — a non-numeric

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -102,16 +102,14 @@ const excluded = function(file, patterns, base) {
 }
 
 /**
- * Set the log level, taking the command line first, then the configuration,
- * then the default.
- * @param {{logLevel: string|undefined, quiet: boolean|undefined}} options - CLI
- *  options
- * @param {{logLevel: string|null, quiet: boolean|null}} config - Configuration
+ * The log level a quiet flag and an explicit level resolve to: quiet forces
+ * warnings-only, otherwise the explicit level, otherwise info.
+ * @param {boolean|null|undefined} quiet - Whether to drop informational logs
+ * @param {string|null|undefined} level - Explicit level, if any
+ * @return {string} - The level to set
  */
-const processOptions = function(options, config) {
-  const quiet = options.quiet ?? config.quiet ?? false
-  const level = options.logLevel ?? config.logLevel ?? levels.INFO
-  logger.setLevel(quiet ? levels.WARNING : level)
+const leveled = function(quiet, level) {
+  return quiet ? levels.WARNING : level ?? levels.INFO
 }
 
 /**
@@ -127,7 +125,11 @@ const processOptions = function(options, config) {
  * }} options - CLI options
  */
 const xslint = function(pths, options) {
+  logger.setLevel(leveled(options.quiet, options.logLevel))
   const config = configFrom(options.config)
+  if (options.quiet == null && options.logLevel == null) {
+    logger.setLevel(leveled(config.quiet, config.logLevel))
+  }
   const disabled = []
   const overrides = {}
   for (const [pattern, severity] of Object.entries(config.rules)) {
@@ -145,7 +147,6 @@ const xslint = function(pths, options) {
   }
   const suppressions = [...validatedSuppressions(options.suppress), ...disabled]
   const maxWarnings = options.maxWarnings ?? config.maxWarnings ?? -1
-  processOptions(options, config)
   logger.info(`Directories and files to process: ${pths.join(', ')}`)
   pths = pths.map((pth) => path.resolve(process.cwd(), pth))
   let stylesheets = []

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -129,6 +129,14 @@ describe('xslint', function() {
     ])
     assert.ok(stdout.includes(`Check with substring '${suppress}' does not exist. Delete this '--suppress' or use another one.`))
   })
+  it('should silence the bad-suppress warning under a raised log level', function() {
+    const streams = xslintStreams([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      '--suppress=qwerty',
+      '--log-level=error',
+    ])
+    assert.ok(!streams.stderr.includes('does not exist'))
+  })
   it('should test non-existing directory', function() {
     const dir = 'non-existing-directory'
     const stdout = runXslint([dir])


### PR DESCRIPTION
`configFrom`, the rule-pattern expansion, and `validatedSuppressions` each call `logger.warn`, but the level was applied only afterwards. So `xslint sheet.xsl --log-level error --suppress=nonexistent` still printed the bad-suppress warning, and an unknown rule name in `.xslint.yml` warned under `--log-level error`.

The command-line level is now set first, so every warning that follows obeys it. Once the config is read, it fills the level in only when the command line said nothing — the command line keeps precedence.

```js
logger.setLevel(leveled(options.quiet, options.logLevel))
const config = configFrom(options.config)
if (options.quiet == null && options.logLevel == null) {
  logger.setLevel(leveled(config.quiet, config.logLevel))
}
```

The old `processOptions` — which only set the level and was named for more — gives way to a small `leveled` helper.

Closes #299.
