### PR TITLE
Use bare require names and enforce it; collapse warn naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Use bare module names in `require` (drop the `node:` prefix) and enforce it
+  with an ESLint rule; collapse the duplicate `warn`/`warning` naming in the
+  logger and writer (#304).
 - Apply `--log-level`/`--quiet` before reading the configuration, rule
   patterns, and suppressions, so a raised level now silences their warnings
   too (#299).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,9 @@ npx mocha test/xslint.test.js --timeout 10000   # Run a single test file
 npx mocha test/xslint.test.js --grep "sentence"  # Run tests matching a pattern
 ```
 
-Code style is enforced by ESLint (`eslint-config-google` plus `@stylistic`, in `eslint.config.mjs`, run by the `grunt` job on every push and pull request): spaced operators (`@stylistic/space-infix-ops`), no single-letter names (`id-length` minimum 2), and postfix-only increment/decrement (`no-restricted-syntax` bans prefix `++x`/`--x`; `x++` is fine).
+Code style is enforced by ESLint (`eslint-config-google` plus `@stylistic`, in `eslint.config.mjs`, run by the `grunt` job on every push and pull request): spaced operators (`@stylistic/space-infix-ops`), no single-letter names (`id-length` minimum 2), postfix-only increment/decrement (`no-restricted-syntax` bans prefix `++x`/`--x`; `x++` is fine), and bare module names in `require` (`no-restricted-syntax` bans the `node:` prefix — write `require('path')`, not `require('node:path')`).
+
+**Every code-style convention must be machine-enforced.** When a style or consistency issue is fixed, do not just fix the instances — add an automated check that fails when the style is violated again (an ESLint rule, preferably a new `no-restricted-syntax` selector so no dependency is added, or a CI job), in the same change, so the mistake cannot recur.
 
 ## Architecture
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,10 +59,18 @@ export default defineConfig([
       "jsdoc/reject-any-type": "off",
       "@stylistic/space-infix-ops": "error",
       "id-length": ["error", { min: 2 }],
-      "no-restricted-syntax": ["error", {
-        selector: "UpdateExpression[prefix=true]",
-        message: "Use postfix increment/decrement (x++), not prefix (++x)"
-      }]
+      "no-restricted-syntax": ["error",
+        {
+          selector: "UpdateExpression[prefix=true]",
+          message: "Use postfix increment/decrement (x++), not prefix (++x)"
+        },
+        {
+          selector:
+            "CallExpression[callee.name='require'][arguments.0.value=/^node:/]",
+          message:
+            "Do not use the 'node:' prefix in require; use the bare name"
+        }
+      ]
     }
   },
   {

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -5,8 +5,8 @@
 
 'use strict'
 
-const path = require('node:path')
-const fs = require('node:fs')
+const path = require('path')
+const fs = require('fs')
 const {allFilesFrom, yaml} = require('../src/helpers')
 const {marked} = require('marked')
 

--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,7 @@
  */
 
 const fs = require('fs')
-const path = require('node:path')
+const path = require('path')
 const {yaml} = require('./helpers')
 const {logger} = require('./logger')
 

--- a/src/corpus-linter.js
+++ b/src/corpus-linter.js
@@ -5,7 +5,7 @@
 
 const {nodes, strings} = require('./xpath')
 const {allFilesFrom, yaml} = require('./helpers')
-const path = require('node:path')
+const path = require('path')
 const {logger} = require('./logger')
 
 /**

--- a/src/logger.js
+++ b/src/logger.js
@@ -7,13 +7,12 @@ const {err} = require('./output')
 
 /**
  * Log levels.
- * @type {{ERROR: string, INFO: string, DEBUG: string, WARN: string}}
+ * @type {{ERROR: string, INFO: string, DEBUG: string, WARNING: string}}
  */
 const LOG_LEVELS = {
   DEBUG: 'debug',
   INFO: 'info',
   WARNING: 'warning',
-  WARN: 'warn',
   ERROR: 'error',
 }
 
@@ -25,7 +24,6 @@ const LEVELS = {
   [LOG_LEVELS.DEBUG]: 0,
   [LOG_LEVELS.INFO]: 1,
   [LOG_LEVELS.WARNING]: 2,
-  [LOG_LEVELS.WARN]: 2,
   [LOG_LEVELS.ERROR]: 3,
 }
 
@@ -54,7 +52,7 @@ const logger = {
   },
   warn: (msg, ...args) => {
     if (currentLevel <= LEVELS[LOG_LEVELS.WARNING]) {
-      err.warn(msg, ...args)
+      err.warning(msg, ...args)
     }
   },
   error: (msg, ...args) => {

--- a/src/output.js
+++ b/src/output.js
@@ -29,22 +29,19 @@ const colorful = function(stream) {
  * @return {{
  *  debug: function(string, ...*): void,
  *  info: function(string, ...*): void,
- *  warn: function(string, ...*): void,
  *  warning: function(string, ...*): void,
  *  error: function(string, ...*): void
  * }} - Writer bound to the sink
  */
 const writer = function(sink, colored = true) {
   const paint = (color, text) => colored ? safe[color](text) : text
-  const write = {
+  return {
     debug: (msg, ...args) => sink(`${paint('gray', '[DEBUG]')} ${msg}`, ...args),
     info: (msg, ...args) => sink(`${paint('blue', '[INFO]')} ${msg}`, ...args),
-    warn: (msg, ...args) =>
+    warning: (msg, ...args) =>
       sink(`${paint('yellow', '[WARNING]')} ${msg}`, ...args),
-    warning: (msg, ...args) => write.warn(msg, ...args),
     error: (msg, ...args) => sink(`${paint('red', '[ERROR]')} ${msg}`, ...args),
   }
-  return write
 }
 
 module.exports = {

--- a/src/reporters.js
+++ b/src/reporters.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const path = require('node:path')
+const path = require('path')
 const {out} = require('./output')
 const version = require('./version')
 

--- a/src/xpath-format-linter.js
+++ b/src/xpath-format-linter.js
@@ -5,7 +5,7 @@
 
 const {tokenized, TOKENS} = require('./tokens')
 const {yaml} = require('./helpers')
-const path = require('node:path')
+const path = require('path')
 const {logger} = require('./logger')
 
 /**

--- a/src/xpath-linter.js
+++ b/src/xpath-linter.js
@@ -5,7 +5,7 @@
 
 const {nodes} = require('./xpath')
 const {allFilesFrom, yaml} = require('./helpers')
-const path = require('node:path')
+const path = require('path')
 const {logger} = require('./logger')
 
 /**

--- a/src/xpath-validator.js
+++ b/src/xpath-validator.js
@@ -5,7 +5,7 @@
 
 const {nodes, isValid} = require('./xpath')
 const {yaml} = require('./helpers')
-const path = require('node:path')
+const path = require('path')
 const {logger} = require('./logger')
 
 /**

--- a/src/xsl-validator.js
+++ b/src/xsl-validator.js
@@ -4,7 +4,7 @@
  */
 
 const {xml, yaml} = require('./helpers')
-const path = require('node:path')
+const path = require('path')
 const {logger} = require('./logger')
 
 /**


### PR DESCRIPTION
The `path` module was required two ways across `src/` — seven files with the `node:` prefix, two without — and `scripts/generate-docs.js` added two more prefixed requires. This settles on the bare name everywhere and, more to the point, makes the convention stick: a new `no-restricted-syntax` selector fails CI on any prefixed require, so the drift cannot return.

```js
{
  selector:
    "CallExpression[callee.name='require'][arguments.0.value=/^node:/]",
  message: "Do not use the 'node:' prefix in require; use the bare name"
}
```

The same commit collapses the duplicate warning name: `LOG_LEVELS` and the output writer each carried both `warn` and `warning` for one level, and now keep only `warning` (the logger's public `warn` verb is unchanged). `processOptions` was already retired in #299.

`CLAUDE.md` gains the rule and the principle behind it — a fixed code-style convention must be machine-enforced, in the same change, so the mistake cannot recur.

Closes #304.
