### PR TITLE
Treat every reported XML problem as malformed and quiet the parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Report a stylesheet as malformed for any well-formedness problem the XML
+  parser reports, not only the fatal ones — an undefined entity or a stray
+  `<` no longer slips through — and route the parser's own diagnostics through
+  the logger instead of leaking them to the console (#298).
 - Assert behavior rather than whole-corpus totals in the end-to-end tests, so
   adding a fixture or a rule no longer breaks an unrelated test (#303).
 - Use bare module names in `require` (drop the `node:` prefix) and enforce it

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,12 +9,6 @@ const {DOMParser} = require('@xmldom/xmldom')
 const yaml = require('yaml')
 
 /**
- * XML Parser
- * @type {DOMParser}
- */
-const parser = new DOMParser()
-
-/**
  * Get all the files recursively from given directory
  * @param {string} dir - Directory path
  * @return {Array.<string>} - Array of file in given directory
@@ -51,16 +45,29 @@ const fromFile = function(type, fromString) {
 }
 
 /**
- * Parse XML from string.
+ * Parse XML from string. Any well-formedness problem the parser reports — not
+ * only the fatal ones it throws on, but also the recoverable ones such as an
+ * undefined entity — is treated as a failure, and the parser's own diagnostics
+ * are collected here rather than left to spill onto the console.
  * @param {string} str - XML as string
  * @return {Document} - Parsed XML as Document
  */
 const xmlFromString = function(str) {
+  const problems = []
   let parsed
   try {
-    parsed = parser.parseFromString(str, 'text/xml')
+    parsed = new DOMParser({
+      onError: (level, message) => {
+        if (level !== 'warning') {
+          problems.push(message.trim())
+        }
+      },
+    }).parseFromString(str, 'text/xml')
   } catch (err) {
     throw new Error(`Couldn't parse XML:\n${str}\n\nCause: ${err.message}`)
+  }
+  if (problems.length > 0) {
+    throw new Error(`Couldn't parse XML:\n${str}\n\nCause: ${problems[0]}`)
   }
   return parsed
 }

--- a/test/resources/xpath-packs/not-using-disable-output-escaping.yaml
+++ b/test/resources/xpath-packs/not-using-disable-output-escaping.yaml
@@ -11,7 +11,7 @@ input: |-
     <xsl:output encoding="UTF-8" method="xml"/>
     <xsl:template match="/objects/o/o[1]/o[1]">
       <title>
-        <xsl:text disable-output-escaping="yes"><</xsl:text>
+        <xsl:text disable-output-escaping="yes">&lt;</xsl:text>
       </title>
     </xsl:template>
     <xsl:template match="/objects/o/o[1]/o[1]">

--- a/test/resources/xpath-packs/using-disable-output-escaping.yaml
+++ b/test/resources/xpath-packs/using-disable-output-escaping.yaml
@@ -11,7 +11,7 @@ input: |-
     <xsl:output encoding="UTF-8" method="xml"/>
     <xsl:template match="/objects/o/o[1]/o[1]">
       <title>
-        <xsl:text disable-output-escaping="no"><</xsl:text>
+        <xsl:text disable-output-escaping="no">&lt;</xsl:text>
       </title>
     </xsl:template>
     <xsl:template match="/objects/o/o[1]/o[1]">

--- a/test/xsl-validator.test.js
+++ b/test/xsl-validator.test.js
@@ -19,6 +19,23 @@ describe('xsl-validator', function() {
     ])
     assert.equal(defects[0].name, 'malformed-stylesheet')
   })
+  it('should report an undefined entity as a defect', function() {
+    const {defects} = validate([
+      {file: 'entity.xsl', content: '<a>&nope; text</a>'},
+    ])
+    assert.equal(defects[0].name, 'malformed-stylesheet')
+  })
+  it('should not leak parser diagnostics to the console', function() {
+    const original = console.error
+    const lines = []
+    console.error = (...args) => lines.push(args.join(' '))
+    try {
+      validate([{file: 'broken.xsl', content: '<a><b></a>'}])
+    } finally {
+      console.error = original
+    }
+    assert.equal(lines.length, 0)
+  })
   it('should leave a malformed stylesheet out of the corpus', function() {
     const {corpus} = validate([
       {file: 'broken.xsl', content: '<a><b></a>'},


### PR DESCRIPTION
`@xmldom/xmldom` splits parse problems in two: it throws on a fatal error (a tag mismatch, an unclosed tag) but only reports a recoverable one (an undefined entity, a stray `<`) to its error handler and returns a document anyway. The parser was built with no handler, so it relied on the throw alone — a not-well-formed stylesheet slipped into the corpus unreported and was linted as valid, while xmldom's default handler spilled `[xmldom error]` lines onto the console, past the logger and past `--quiet`.

`xmlFromString` now parses with an `onError` handler that collects any non-warning problem and fails when one is present, so both classes reach `xsl-validator` as a `malformed-stylesheet` defect and the parser's diagnostics stay off the console.

```js
const parsed = new DOMParser({
  onError: (level, message) => {
    if (level !== 'warning') {
      problems.push(message.trim())
    }
  },
}).parseFromString(str, 'text/xml')
if (problems.length > 0) {
  throw new Error(`Couldn't parse XML:\n${str}\n\nCause: ${problems[0]}`)
}
```

Two `disable-output-escaping` fixture packs carried a raw `<` as `xsl:text` content — not well-formed XML that xmldom's recovery had masked. They are escaped to `&lt;`, the same character, now well-formed. New validator tests cover an undefined entity and the absence of console noise.

Closes #298.
