### PR TITLE
Load the CLI entry as an ES module to drop the commander warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Load the CLI entry as an ES module (`src/index.mjs`) so `commander` — which
+  is ESM-only — no longer triggers Node's `ExperimentalWarning` on every run;
+  the test harness no longer silences warnings, so it sees what users see
+  (#300).
 - Report a stylesheet as malformed for any well-formedness problem the XML
   parser reports, not only the fatal ones — an undefined entity or a stray
   `<` no longer slips through — and route the parser's own diagnostics through

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Code style is enforced by ESLint (`eslint-config-google` plus `@stylistic`, in `
 
 Flow:
 ```text
-src/index.js (CLI, commander.js)
+src/index.mjs (CLI, commander.js — ESM entry so commander loads natively)
   → src/xslint.js (file discovery, suppression, run order, output: defects to
       stdout, logs to stderr)
     VALIDATORS (is it valid?) — each partitions its input, reporting the bad

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,8 @@ module.exports = function(grunt) {
   grunt.initConfig({
     eslint: {
       target: [
-        'Gruntfile.js', 'src/**/*.js', 'test/**/*.js', 'scripts/**/*.js',
+        'Gruntfile.js', 'src/**/*.js', 'src/**/*.mjs',
+        'test/**/*.js', 'scripts/**/*.js',
       ],
     },
     mochacli: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,7 +26,7 @@ export default defineConfig([
   ...compat.extends("google"),
   jsdoc.configs["flat/recommended-error"],
   {
-    files: ["**/*.js"],
+    files: ["**/*.js", "**/*.mjs"],
     languageOptions: {
       globals: { ...globals.node, ...globals.mocha },
       ecmaVersion: 2022,
@@ -74,11 +74,15 @@ export default defineConfig([
     }
   },
   {
-    files: ["src/**/*.js"],
+    files: ["src/**/*.js", "src/**/*.mjs"],
     rules: {
       "jsdoc/require-jsdoc": ["error", {
         require: { FunctionDeclaration: true, FunctionExpression: true }
       }]
     }
+  },
+  {
+    files: ["**/*.mjs"],
+    languageOptions: { sourceType: "module" }
   }
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "yaml": "^2.7.0"
       },
       "bin": {
-        "xslint": "src/index.js"
+        "xslint": "src/index.mjs"
       },
       "devDependencies": {
         "@stryker-mutator/core": "^9.6.1",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "@maxonfjvipon/xslint",
   "version": "0.0.0",
   "description": "XSL Linter",
-  "main": "src/index.js",
+  "main": "src/index.mjs",
   "bin": {
-    "xslint": "src/index.js"
+    "xslint": "src/index.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {program, Option} = require('commander')
-const version = require('./version')
-const xslint = require('./xslint')
+import {program, Option} from 'commander'
+import version from './version.js'
+import xslint from './xslint.js'
 
 program
   .name('xslint')

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -9,7 +9,6 @@
   "coverageAnalysis": "perTest",
   "mutate": [
     "src/**/*.js",
-    "!src/index.js",
     "!src/xslint.js",
     "!src/logger.js",
     "!src/output.js"

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -26,20 +26,19 @@ const execCmd = function(command, args, print) {
 }
 
 /**
- * Run xslint in a child process, node warnings silenced so only the tool's own
- * output remains.
+ * Run xslint in a child process, exactly as a user would, so the test sees the
+ * same output — no node warnings are silenced.
  * @param {Array.<string>} args - Array of args
  * @return {import('child_process').SpawnSyncReturns<string>} - Result
  */
 const spawnXslint = function(args) {
   return spawnSync(
     'node',
-    [path.resolve('./src/index.js'), ...args],
+    [path.resolve('./src/index.mjs'), ...args],
     {
       timeout: 120000,
       windowsHide: true,
       encoding: 'utf-8',
-      env: {...process.env, NODE_NO_WARNINGS: '1'},
     },
   )
 }


### PR DESCRIPTION
`commander` (15.x) ships as an ES module with no CommonJS entry, so `require('commander')` from the CommonJS CLI made Node print an `ExperimentalWarning` on every run. The test harness hid it with `NODE_NO_WARNINGS=1`, so the suite stayed quiet while a user saw the warning the tests never did.

The entry becomes an ES module, `src/index.mjs`, importing commander natively — no require-of-ESM, no warning:

```js
import {program, Option} from 'commander'
import version from './version.js'
import xslint from './xslint.js'
```

`NODE_NO_WARNINGS` is dropped from the test helper, so a spawned run is exactly a user's run. `bin`, `main`, the Stryker mutate list, and the Grunt/ESLint globs now point at the `.mjs` entry, and a new ESLint block lints it as a module so it stays covered — verified that a planted error in `index.mjs` now fails `grunt eslint`.

Closes #300.
