### PR TITLE
Ban a redundant return variable with a local ESLint rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Add a project-local ESLint rule that bans a redundant return variable
+  (`const x = expr; return x`), so the convention is enforced on new code
+  (#310).
 - Load the CLI entry as an ES module (`src/index.mjs`) so `commander` — which
   is ESM-only — no longer triggers Node's `ExperimentalWarning` on every run;
   the test harness no longer silences warnings, so it sees what users see

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ npx mocha test/xslint.test.js --timeout 10000   # Run a single test file
 npx mocha test/xslint.test.js --grep "sentence"  # Run tests matching a pattern
 ```
 
-Code style is enforced by ESLint (`eslint-config-google` plus `@stylistic`, in `eslint.config.mjs`, run by the `grunt` job on every push and pull request): spaced operators (`@stylistic/space-infix-ops`), no single-letter names (`id-length` minimum 2), postfix-only increment/decrement (`no-restricted-syntax` bans prefix `++x`/`--x`; `x++` is fine), and bare module names in `require` (`no-restricted-syntax` bans the `node:` prefix — write `require('path')`, not `require('node:path')`).
+Code style is enforced by ESLint (`eslint-config-google` plus `@stylistic`, in `eslint.config.mjs`, run by the `grunt` job on every push and pull request): spaced operators (`@stylistic/space-infix-ops`), no single-letter names (`id-length` minimum 2), postfix-only increment/decrement (`no-restricted-syntax` bans prefix `++x`/`--x`; `x++` is fine), bare module names in `require` (`no-restricted-syntax` bans the `node:` prefix — write `require('path')`, not `require('node:path')`), and no redundant return variable (a project-local `local/no-redundant-return-variable` rule bans `const x = expr; return x` — return the expression directly).
 
 **Every code-style convention must be machine-enforced.** When a style or consistency issue is fixed, do not just fix the instances — add an automated check that fails when the style is violated again (an ESLint rule, preferably a new `no-restricted-syntax` selector so no dependency is added, or a CI job), in the same change, so the mistake cannot recur.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,53 @@ const compat = new FlatCompat({
   allConfig: js.configs.all
 });
 
+// A project-local rule: a variable whose only purpose is to be returned by the
+// very next statement is redundant and should be inlined. No plugin dependency
+// is needed — a single no-restricted-syntax selector cannot compare a
+// declaration's name with the identifier the following return uses.
+const local = {
+  rules: {
+    "no-redundant-return-variable": {
+      meta: {
+        type: "suggestion",
+        docs: {
+          description:
+            "disallow a variable that only exists to be returned next"
+        },
+        messages: {
+          redundant:
+            "Return the expression directly instead of binding it to a " +
+            "variable first"
+        }
+      },
+      create(context) {
+        return {
+          ReturnStatement(node) {
+            const block = node.parent;
+            if (
+              !node.argument ||
+              node.argument.type !== "Identifier" ||
+              block.type !== "BlockStatement"
+            ) {
+              return;
+            }
+            const prev = block.body[block.body.indexOf(node) - 1];
+            if (
+              prev &&
+              prev.type === "VariableDeclaration" &&
+              prev.declarations.length === 1 &&
+              prev.declarations[0].id.type === "Identifier" &&
+              prev.declarations[0].id.name === node.argument.name
+            ) {
+              context.report({ node: prev, messageId: "redundant" });
+            }
+          }
+        };
+      }
+    }
+  }
+};
+
 export default defineConfig([
   { ignores: ["eslint.config.mjs", "docs/**"] },
   js.configs.recommended,
@@ -37,8 +84,9 @@ export default defineConfig([
         tagNamePreference: { returns: "return" }
       }
     },
-    plugins: { "@stylistic": stylistic },
+    plugins: { "@stylistic": stylistic, local },
     rules: {
+      "local/no-redundant-return-variable": "error",
       "valid-jsdoc": "off",
       "require-jsdoc": "off",
       semi: ["error", "never"],


### PR DESCRIPTION
A variable that exists only to be handed back by the very next statement — `const x = expr; return x` — should be inlined to `return expr`. #304 removed one such variable by hand; this makes the convention stick.

A single `no-restricted-syntax` selector cannot express it, because esquery cannot compare the declaration's name with the identifier the following `return` uses. So the check is a small project-local ESLint rule, wired into `eslint.config.mjs` with no new dependency:

```js
ReturnStatement(node) {
  const prev = block.body[block.body.indexOf(node) - 1];
  if (prev?.type === "VariableDeclaration" &&
      prev.declarations.length === 1 &&
      prev.declarations[0].id.name === node.argument.name) {
    context.report({ node: prev, messageId: "redundant" });
  }
}
```

No current file violates it — an AST scan across `src`, `test`, and `scripts` found zero instances — so this is prevention, not cleanup. `CLAUDE.md` gains the rule alongside the other enforced conventions.

Closes #310.
