### PR TITLE
Reach 100% coverage and raise the gate to 100

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -2,13 +2,16 @@
   "include": [
     "src/**"
   ],
+  "exclude": [
+    "src/index.mjs"
+  ],
   "reporter": [
     "text-summary",
     "lcov"
   ],
   "check-coverage": true,
-  "statements": 90,
-  "lines": 90,
-  "functions": 90,
-  "branches": 90
+  "statements": 100,
+  "lines": 100,
+  "functions": 100,
+  "branches": 100
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Reach 100% statement, branch, function, and line coverage and raise the
+  gate from 90% to 100% (the CLI bootstrap `src/index.mjs` is excluded, as it
+  already is from mutation testing) (#305).
 - Add a project-local ESLint rule that bans a redundant return variable
   (`const x = expr; return x`), so the convention is enforced on new code
   (#310).

--- a/src/logger.js
+++ b/src/logger.js
@@ -55,11 +55,7 @@ const logger = {
       err.warning(msg, ...args)
     }
   },
-  error: (msg, ...args) => {
-    if (currentLevel <= LEVELS[LOG_LEVELS.ERROR]) {
-      err.error(msg, ...args)
-    }
-  },
+  error: (msg, ...args) => err.error(msg, ...args),
   setLevel: (level) => {
     level = level.toLowerCase()
     if (!Object.hasOwn(LEVELS, level)) {

--- a/src/output.js
+++ b/src/output.js
@@ -46,6 +46,7 @@ const writer = function(sink, colored = true) {
 
 module.exports = {
   writer,
+  colorful,
   out: writer(
     (msg, ...args) => console.log(msg, ...args), colorful(process.stdout),
   ),

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {xml, yaml} = require('../src/helpers')
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+
+describe('helpers', function() {
+  it('refuses to parse a file that does not exist', function() {
+    assert.throws(() => xml.parsedFromFile(path.join(os.tmpdir(), 'no.xml')))
+  })
+  it('refuses to parse a directory', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-help-'))
+    let threw = false
+    try {
+      xml.parsedFromFile(dir)
+    } catch {
+      threw = true
+    }
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.ok(threw)
+  })
+  it('reports YAML that does not parse', function() {
+    assert.throws(() => yaml.parsedFromString('"unterminated'))
+  })
+  it('keeps a document the parser only warns about', function() {
+    assert.ok(xml.parsedFromString('<a b=c></a>').documentElement)
+  })
+})

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {logger, levels} = require('../src/logger')
+const assert = require('assert')
+
+/**
+ * Set the level, run a logging action, and capture what reaches the console,
+ * restoring the default level afterwards so no state leaks to other files.
+ * @param {string} level - Level to set first
+ * @param {function(): void} act - Logging to run
+ * @return {string} - The captured output
+ */
+const captured = function(level, act) {
+  const original = console.error
+  const lines = []
+  console.error = (...args) => lines.push(args.join(' '))
+  try {
+    logger.setLevel(level)
+    act()
+  } finally {
+    console.error = original
+    logger.setLevel(levels.INFO)
+  }
+  return lines.join('\n')
+}
+
+describe('logger', function() {
+  it('emits a debug line when the level allows it', function() {
+    assert.ok(captured(levels.DEBUG, () => logger.debug('dbg')).includes('dbg'))
+  })
+  it('drops an info line above its level', function() {
+    assert.ok(!captured(levels.ERROR, () => logger.info('inf')).includes('inf'))
+  })
+  it('drops a warning above its level', function() {
+    assert.ok(!captured(levels.ERROR, () => logger.warn('wrn')).includes('wrn'))
+  })
+  it('always emits an error line', function() {
+    assert.ok(captured(levels.ERROR, () => logger.error('err')).includes('err'))
+  })
+  it('warns about an unknown level', function() {
+    assert.ok(
+      captured(levels.DEBUG, () => logger.setLevel('nonsense'))
+        .includes('incorrect'),
+    )
+  })
+})

--- a/test/output.test.js
+++ b/test/output.test.js
@@ -3,8 +3,30 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {writer} = require('../src/output')
+const {writer, colorful} = require('../src/output')
 const assert = require('assert')
+
+/**
+ * Read colorful for a tty stream with NO_COLOR forced to a given state,
+ * restoring the environment afterwards.
+ * @param {string|undefined} value - NO_COLOR to set, or undefined to unset it
+ * @return {boolean} - Whether coloring is enabled
+ */
+const withNoColor = function(value) {
+  const saved = process.env.NO_COLOR
+  if (value === undefined) {
+    delete process.env.NO_COLOR
+  } else {
+    process.env.NO_COLOR = value
+  }
+  const result = colorful({isTTY: true})
+  if (saved === undefined) {
+    delete process.env.NO_COLOR
+  } else {
+    process.env.NO_COLOR = saved
+  }
+  return result
+}
 
 /**
  * The ANSI escape character, present in colored output and absent in plain.
@@ -22,5 +44,14 @@ describe('output', function() {
     const lines = []
     writer((line) => lines.push(line), false).error('boom')
     assert.ok(!lines[0].includes(ESC))
+  })
+  it('does not color a stream that is not a terminal', function() {
+    assert.equal(colorful({isTTY: false}), false)
+  })
+  it('colors a terminal when NO_COLOR is unset', function() {
+    assert.ok(withNoColor(undefined))
+  })
+  it('does not color a terminal when NO_COLOR is set', function() {
+    assert.ok(!withNoColor('1'))
   })
 })

--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -67,11 +67,15 @@ describe('tokens', function() {
       '123.45.6',
       '123e45E6',
       '123e45.6',
+      '1e',
+      '1e+',
     ]
     const ACTUAL = [
       '123.45',
       '123e45',
       '123e45',
+      '1',
+      '1',
     ]
     FULL.forEach((string, index) => {
       assert.equal(

--- a/test/xpath.test.js
+++ b/test/xpath.test.js
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {isValid} = require('../src/xpath')
+const assert = require('assert')
+
+describe('xpath', function() {
+  it('accepts a syntactically valid expression', function() {
+    assert.ok(isValid('count(//o) = 2'))
+  })
+  it('rejects a syntactically invalid expression', function() {
+    assert.ok(!isValid('1 +'))
+  })
+  it('resolves a standard namespace prefix', function() {
+    assert.ok(isValid('xsl:thing'))
+  })
+  it('resolves a non-standard namespace prefix rather than failing', function() {
+    assert.ok(isValid('zq:thing'))
+  })
+})

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -288,6 +288,19 @@ describe('xslint', function() {
     fs.rmSync(dir, {recursive: true, force: true})
     assert.ok(streams.stderr.includes('Unknown key \'excludes\''))
   })
+  it('should warn about an unknown rule in the config', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const cfg = path.join(dir, '.xslint.yml')
+    fs.writeFileSync(cfg, 'rules:\n  no-such-rule: error\n')
+    const streams = xslintStreams([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      `--config=${cfg}`,
+    ])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.ok(streams.stderr.includes(
+      'Rule \'no-such-rule\' in configuration does not exist',
+    ))
+  })
   it('should read the log level from the config file', function() {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
     const cfg = path.join(dir, '.xslint.yml')


### PR DESCRIPTION
Coverage was in the high 90s with the gate at 90%. This closes the remaining gaps and raises the `.c8rc.json` thresholds to 100 for statements, branches, functions, and lines.

The untested paths were exercised with focused tests:

- `helpers` — the `fromFile` guards (a missing file, a directory) and a YAML string that does not parse.
- `logger` — the debug, error, and unknown-level paths; its `error` method dropped a dead level guard (error is the highest level, so the check was always true).
- `tokens` — the two malformed-exponent number edges (`1e`, `1e+`).
- `xslint` — the unknown-rule-in-config warning.
- `output` — `colorful` for a non-terminal, and a terminal with and without `NO_COLOR`.
- `xpath` — both `namespaceResolver` branches (a standard `xsl:` prefix and a non-standard one); fontoxpath resolves `xs`/`fn`/`math` natively, so only `xsl:` reaches the standard-prefix branch.

The CLI bootstrap `src/index.mjs` is excluded from coverage, as it already is from mutation testing — its only untested line is the top-level `catch`, which commander does not reach without `exitOverride`.

Closes #305.
