### PR TITLE
Send the CLI error stack to stderr, not stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Send a fatal CLI error's stack trace to stderr instead of stdout, so stdout
+  stays clean for defects and machine-readable output (#318).
+
 - Reach 100% statement, branch, function, and line coverage and raise the
   gate from 90% to 100% (the CLI bootstrap `src/index.mjs` is excluded, as it
   already is from mutation testing) (#305).

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -44,6 +44,6 @@ try {
   program.parse(process.argv)
 } catch (error) {
   console.error(error.message)
-  console.debug(error.stack)
+  console.error(error.stack)
   process.exit(1)
 }

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -301,6 +301,15 @@ describe('xslint', function() {
       'Rule \'no-such-rule\' in configuration does not exist',
     ))
   })
+  it('should keep stdout clean when it fails to read the config', function() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
+    const streams = xslintStreams([
+      'test/resources/stylesheets/xsl-with-no-violations.xsl',
+      `--config=${dir}`,
+    ])
+    fs.rmSync(dir, {recursive: true, force: true})
+    assert.equal(streams.stdout, '')
+  })
   it('should read the log level from the config file', function() {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-'))
     const cfg = path.join(dir, '.xslint.yml')


### PR DESCRIPTION
`console.debug` is an alias for `console.log` and writes to stdout, so the top-level catch in `src/index.mjs` sent a fatal error message to stderr but its stack trace to stdout — the stream that carries defects and, under `--format json`/`sarif`, a single machine-readable document.

```js
catch (error) {
  console.error(error.message)
  console.error(error.stack)   // was console.debug -> stdout
  process.exit(1)
}
```

A regression test reaches the catch through `--config <directory>` (an unreadable config makes `configFrom` throw) and asserts stdout stays empty.

Closes #318.
