### PR TITLE
Parse corpus checks once at module load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Parse the corpus checks once at module load instead of on every run, matching
+  the other linters and validators (#317).
+
 - Send a fatal CLI error's stack trace to stderr instead of stdout, so stdout
   stays clean for defects and machine-readable output (#318).
 

--- a/src/corpus-linter.js
+++ b/src/corpus-linter.js
@@ -9,8 +9,10 @@ const path = require('path')
 const {logger} = require('./logger')
 
 /**
- * Corpus checks, each identified by the name suppressions match against.
- * @type {Array.<{name: string, path: string}>}
+ * Corpus checks, each parsed once at load: the name suppressions match against,
+ * plus the declaration/usage selectors and defect metadata.
+ * @type {Array.<{name: string, declaration: string, usage: string,
+ *  severity: string, message: string}>}
  */
 const CHECKS = allFilesFrom(
   path.join(__dirname, 'resources', 'checks', 'corpus'),
@@ -18,7 +20,7 @@ const CHECKS = allFilesFrom(
   name: check.substring(
     check.lastIndexOf(path.sep) + 1, check.lastIndexOf('.yaml'),
   ),
-  path: check,
+  ...yaml.parsedFromFile(check),
 }))
 
 /**
@@ -43,17 +45,16 @@ const lintByCorpus = function(corpus, suppressions = []) {
     if (suppressions.some((sup) => check.name.includes(sup))) {
       continue
     }
-    const yml = yaml.parsedFromFile(check.path)
     const used = new Set(
-      corpus.flatMap(({xsl}) => strings(xsl, yml.usage)),
+      corpus.flatMap(({xsl}) => strings(xsl, check.usage)),
     )
     for (const {file, xsl} of corpus) {
-      for (const node of nodes(xsl, yml.declaration)) {
+      for (const node of nodes(xsl, check.declaration)) {
         if (!used.has(node.getAttribute('name'))) {
           defects.push({
             name: check.name,
-            severity: yml.severity,
-            message: yml.message,
+            severity: check.severity,
+            message: check.message,
             file: file,
             line: node.lineNumber,
             pos: node.columnNumber,


### PR DESCRIPTION
`lintByCorpus` re-read and re-parsed each check""s YAML from disk on every run, while every other check-owning module (`xsl-validator`, `xpath-validator`, `xpath-linter`, `xpath-format-linter`) parses once at module load.

The parse now folds into the `CHECKS` map at load, so each check carries its declaration/usage selectors and defect metadata, and the loop reads from that:

```js
const CHECKS = allFilesFrom(...).map((check) => ({
  name: check.substring(...),
  ...yaml.parsedFromFile(check),
}))
```

Behavior is unchanged — the corpus-pack tests still pass — only the redundant per-run I/O disappears.

Closes #317.
