### PR TITLE
Name out-of-tree files by absolute path in json/sarif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Name an out-of-tree file by its absolute path in `json`/`sarif` output rather
+  than a `..`-climbing relative path that GitHub code scanning cannot map
+  (#320).
+
 - Parse the corpus checks once at module load instead of on every run, matching
   the other linters and validators (#317).
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ pull requests:
 ```
 
 The `|| true` keeps a findings exit code from failing the step before the
-upload; the alerts still surface in code scanning.
+upload; the alerts still surface in code scanning. Run it from the repository
+root so the reported paths stay repo-relative — a file outside the working
+directory is named by its absolute path instead.
 
 ## Exit code
 

--- a/src/reporters.js
+++ b/src/reporters.js
@@ -15,12 +15,17 @@ const LEVEL = {warning: 'warning', error: 'error'}
 
 /**
  * A defect's file as a path relative to the working directory, in posix form,
- * the shape the machine formats and GitHub code scanning expect.
+ * the shape the machine formats and GitHub code scanning expect. A file outside
+ * the working directory, whose relative path would climb out with '..' (or is
+ * absolute across drives), is named by its absolute path instead, so an
+ * out-of-tree file is unambiguous rather than a confusing relative climb.
  * @param {string} file - Absolute path of the stylesheet
- * @return {string} - Relative posix path
+ * @return {string} - Relative posix path, or absolute when it would escape
  */
 const located = function(file) {
-  return path.relative(process.cwd(), file).split(path.sep).join('/')
+  const relative = path.relative(process.cwd(), file)
+  const escapes = relative.startsWith('..') || path.isAbsolute(relative)
+  return (escapes ? file : relative).split(path.sep).join('/')
 }
 
 /**

--- a/test/reporters.test.js
+++ b/test/reporters.test.js
@@ -59,6 +59,13 @@ describe('reporters', function() {
   it('reports an empty JSON array when there are no defects', function() {
     assert.deepStrictEqual(JSON.parse(capture(reporterOf('json'), [])), [])
   })
+  it('names an out-of-tree file by its absolute path, not a climb', function() {
+    const outside = path.join(path.parse(process.cwd()).root, 'out', 'a.xsl')
+    const reported = JSON.parse(capture(
+      reporterOf('json'), [{...defect('warning'), file: outside}],
+    ))
+    assert.equal(reported[0].file, outside.split(path.sep).join('/'))
+  })
   it('reports the SARIF version', function() {
     assert.equal(
       JSON.parse(capture(reporterOf('sarif'), [defect('warning')])).version,


### PR DESCRIPTION
`located` turned a defect's path into a working-directory-relative one for `json`/`sarif`. For a file outside the working directory, `path.relative` climbed out with `..`, producing `../../../var/.../sheet.xsl` — a URI GitHub code scanning maps against the checkout and cannot resolve.

It now falls back to the absolute posix path when the relative one would escape:

```js
const relative = path.relative(process.cwd(), file)
const escapes = relative.startsWith("..") || path.isAbsolute(relative)
return (escapes ? file : relative).split(path.sep).join("/")
```

In-tree paths (the normal `xslint .` run) are unchanged. The README notes SARIF is best generated from the repository root.

Closes #320.
