### PR TITLE
Count every src file toward the coverage gate

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -5,6 +5,7 @@
   "exclude": [
     "src/index.mjs"
   ],
+  "all": true,
   "reporter": [
     "text-summary",
     "lcov"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Count every `src` file toward the 100% coverage gate (`c8` `all`), so a module
+  shipped without a test now fails CI instead of being silently omitted (#322).
+
 - Extend the `node:`-prefix ban from `require` to ESM `import` as well, and use
   bare specifiers in `eslint.config.mjs` (#319).
 


### PR DESCRIPTION
`c8` measured only files that a test actually loaded, because `.c8rc.json` did not set `all`. A source file no test `require`s was omitted from the report rather than counted as `0%`, so the 100% gate was met vacuously and a new untested module would not fail CI.

`"all": true` makes `c8` instrument every file matched by `include` (`src/**`, minus the excluded `src/index.mjs`). Verified: the full suite still reports 100% and exits `0`, while a planted untested file now drops coverage below the threshold and fails the run.

Closes #322.
