### PR TITLE
Run the coverage gate in the merge and release builds

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -17,6 +17,7 @@ release:
     sed -i "s/0\.0\.0/${tag}/" src/version.js
     sed -i "s/0000-00-00/$(date +%Y-%m-%d)/" src/version.js
     npm test
+    npm run coverage
     git commit -am "set version to ${tag}"
     chmod 600 ../npmrc
     echo "xslint dry run:"
@@ -28,3 +29,4 @@ release:
 merge:
   script: |-
     npm test
+    npm run coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Run the coverage gate in Rultor's merge and release builds, so a drop below
+  100% blocks the merge and the release rather than only annotating the pull
+  request (#328).
+
 - Type the `TOKENS` map with a non-drifting index signature instead of a
   hand-maintained key-by-key literal that had fallen out of sync (#327).
 


### PR DESCRIPTION
The 100% coverage gate (`npm run coverage`) ran only in the GitHub Actions `coverage` job. Rultor's own `merge` and `release` builds ran only `npm test` (mocha + eslint), so a change that dropped coverage passed the build that actually gates the merge, and surfaced only as a red push on master afterward.

Both scripts now run the gate:

```yaml
merge:
  script: |-
    npm test
    npm run coverage
```

The rultor image installs devDependencies, so `c8` is present, and the GitHub `coverage` job already proves `npm run coverage` reaches 100% on Linux. No source change.

Closes #328.
