### PR TITLE
Evaluate xpath-linter suppression once, not per file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Evaluate suppression once per run in the per-file XPath linter instead of
+  re-checking it for every file, matching the other linters (#331).
+
 - Run the coverage gate in Rultor's merge and release builds, so a drop below
   100% blocks the merge and the release rather than only annotating the pull
   request (#328).

--- a/src/xpath-linter.js
+++ b/src/xpath-linter.js
@@ -54,11 +54,11 @@ const evaluateXpath = function(xsl, xpath) {
 const lintByXpath = function(corpus, suppressions = []) {
   logger.debug(`Xpath linting started`)
   const defects = []
+  const active = PACKS.filter(
+    (pack) => !suppressions.some((sup) => pack.name.includes(sup)),
+  )
   for (const {file, xsl} of corpus) {
-    for (const pack of PACKS) {
-      if (suppressions.some((sup) => pack.name.includes(sup))) {
-        continue
-      }
+    for (const pack of active) {
       for (const node of evaluateXpath(xsl, pack.xpath)) {
         defects.push({
           name: pack.name,


### PR DESCRIPTION
`lintByXpath` re-evaluated pack suppression for every file, inside the per-file loop — the only check-owning module to do so; the validators, `xpath-format-linter`, and `corpus-linter` all evaluate it once.

The suppressed set is the same for every file, so it is now computed once, and the loop runs over the active packs:

```js
const active = PACKS.filter(
  (pack) => !suppressions.some((sup) => pack.name.includes(sup)),
)
for (const {file, xsl} of corpus) {
  for (const pack of active) { ... }
}
```

Behavior is unchanged — the pack tests and the `--suppress` end-to-end tests still pass at 100% coverage. Same per-file-waste class as #256 and #317.

Closes #331.
