### PR TITLE
Add a --format github reporter for CI annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Add a `--format github` reporter that prints GitHub Actions workflow
+  commands, so findings render as inline annotations on the pull-request diff
+  with no SARIF-upload step (#333).
+
 - Evaluate suppression once per run in the per-file XPath linter instead of
   re-checking it for every file, matching the other linters (#331).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ A change that leaves any of these describing the old behavior is not done.
 | `src/xslint.js` | Orchestrates file discovery, configuration, and suppression, runs validators then linters, formats output |
 | `src/config.js` | Resolves `.xslint.yml` (rule severities/`off`, exclude globs, `max-warnings`), found by walking up from the cwd or via `--config` |
 | `src/directives.js` | Parses inline `xslint-disable-*` comment directives and tests whether one suppresses a defect |
-| `src/reporters.js` | Formats the collected defects for output — `text` (default), `json`, or `sarif` — behind a uniform `reporterOf(format)` that `src/xslint.js` calls without knowing the format |
+| `src/reporters.js` | Formats the collected defects for output — `text` (default), `json`, `sarif`, or `github` (GitHub Actions workflow-command annotations) — behind a uniform `reporterOf(format)` that `src/xslint.js` calls without knowing the format |
 | `src/xsl-validator.js` | Builds the corpus from raw sources; reports each stylesheet that is not well-formed XML and leaves it out |
 | `src/xpath-validator.js` | Splits each corpus expression into the valid ones (kept for the expression linters) and the malformed ones (reported) |
 | `src/xpath-linter.js` | Loads `checks/xpath/*.yaml`, applies per-file XPath rules |

--- a/README.md
+++ b/README.md
@@ -144,12 +144,18 @@ variable turns coloring off everywhere.
 
 `--format` selects the output. `text` (the default) is the human format above;
 `json` and `sarif` print a single document to stdout — logs stay on stderr, so
-the document is clean to pipe or redirect:
+the document is clean to pipe or redirect; `github` prints GitHub Actions
+workflow commands:
 
 ```bash
 xslint --format json path/to/dir     # a flat array of defects
 xslint --format sarif path/to/dir    # a SARIF 2.1.0 log
+xslint --format github path/to/dir   # ::warning/::error annotations for CI
 ```
+
+Inside a GitHub Action, `--format github` makes each defect an inline
+annotation on the pull-request diff with no upload step — the lowest-friction
+way to see findings on a review.
 
 SARIF feeds GitHub code scanning, so xslint findings appear as annotations on
 pull requests:

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -21,7 +21,7 @@ program
   .option('--quiet', 'Suppress informational logs, printing only defects')
   .addOption(
     new Option('--format <format>', 'Output format for defects')
-      .choices(['text', 'json', 'sarif'])
+      .choices(['text', 'json', 'sarif', 'github'])
       .default('text'),
   )
   .option('--config <path>', 'Path to a configuration file')

--- a/src/reporters.js
+++ b/src/reporters.js
@@ -104,14 +104,54 @@ const sarif = function(defects) {
 }
 
 /**
+ * Escape a value for the message data of a workflow command.
+ * @param {string} data - Raw text
+ * @return {string} - Escaped text
+ */
+const escapedData = function(data) {
+  return String(data)
+    .replace(/%/g, '%25')
+    .replace(/\r/g, '%0D')
+    .replace(/\n/g, '%0A')
+}
+
+/**
+ * Escape a value for a property of a workflow command, where the property
+ * delimiters also need escaping.
+ * @param {string} data - Raw text
+ * @return {string} - Escaped text
+ */
+const escapedProperty = function(data) {
+  return escapedData(data).replace(/:/g, '%3A').replace(/,/g, '%2C')
+}
+
+/**
+ * Print defects as GitHub Actions workflow commands, so a run inside a GitHub
+ * Action renders each as an inline annotation on the pull-request diff with no
+ * separate upload step.
+ * @param {Array.<object>} defects - Defects to print
+ */
+const github = function(defects) {
+  for (const defect of defects) {
+    console.log(
+      `::${LEVEL[defect.severity]} ` +
+      `file=${escapedProperty(located(defect.file))},` +
+      `line=${defect.line},col=${defect.pos},` +
+      `title=${escapedProperty(defect.name)}` +
+      `::${escapedData(defect.message)}`,
+    )
+  }
+}
+
+/**
  * Reporters by format name, each a function that writes given defects.
  * @type {{[format: string]: function(Array.<object>): void}}
  */
-const REPORTERS = {text: text, json: json, sarif: sarif}
+const REPORTERS = {text: text, json: json, sarif: sarif, github: github}
 
 /**
  * The reporter for a format, so a caller writes defects without knowing how.
- * @param {string} format - Format name (text, json, or sarif)
+ * @param {string} format - Format name (text, json, sarif, or github)
  * @return {function(Array.<object>): void} - Reporter that writes the defects
  */
 const reporterOf = function(format) {

--- a/test/reporters.test.js
+++ b/test/reporters.test.js
@@ -87,4 +87,21 @@ describe('reporters', function() {
     const log = JSON.parse(capture(reporterOf('sarif'), [defect('error')]))
     assert.equal(log.runs[0].results[0].level, 'error')
   })
+  it('emits a GitHub warning command at the defect location', function() {
+    assert.ok(
+      capture(reporterOf('github'), [defect('warning')])
+        .includes('::warning file=sheets/a.xsl,line=16,col=3'),
+    )
+  })
+  it('maps an error defect to a GitHub error command', function() {
+    assert.ok(
+      capture(reporterOf('github'), [defect('error')]).startsWith('::error '),
+    )
+  })
+  it('carries the rule name as the GitHub annotation title', function() {
+    assert.ok(
+      capture(reporterOf('github'), [defect('warning')])
+        .includes('title=short-names'),
+    )
+  })
 })

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -374,6 +374,13 @@ describe('xslint', function() {
     ])
     assert.equal(JSON.parse(streams.stdout).version, '2.1.0')
   })
+  it('should print GitHub workflow commands with --format github', function() {
+    const streams = xslintStreams([
+      'test/resources/stylesheets/xsl-with-some-violations.xsl',
+      '--format=github',
+    ])
+    assert.ok(/::(warning|error) file=/.test(streams.stdout))
+  })
   it('should reject an unknown --format value', function() {
     const status = xslintStatus([
       'test/resources/stylesheets/xsl-with-some-violations.xsl',


### PR DESCRIPTION
Adds a `github` output format that prints GitHub Actions workflow commands, so a run inside a GitHub Action turns each defect into an inline annotation on the pull-request diff — no SARIF-upload step, which is the lowest-friction way to surface findings on a review.

```
::warning file=path/to/sheet.xsl,line=16,col=3,title=short-names::A variable... has a single-character name.
```

`github` joins `text`/`json`/`sarif` in the `reporterOf` map and the `--format` choices; severity maps to `::warning`/`::error`, the path reuses the existing `located` helper, and the rule name becomes the annotation title. Values are escaped per the workflow-command rules. Covered by reporter unit tests and an end-to-end `--format github` test; suite stays at 100% coverage.

This unblocks maxonfjvipon/xslint-action#22 (the action can pass `--format github` for inline annotations).

Closes #333.
