### PR TITLE
Authenticate Codecov uploads with CODECOV_TOKEN

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,5 +25,6 @@ jobs:
       - uses: codecov/codecov-action@v5
         continue-on-error: true
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           fail_ci_if_error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Authenticate Codecov uploads with `CODECOV_TOKEN`, so coverage reports upload
+  and the badge reflects real coverage (#341).
+
 - Add a `--format github` reporter that prints GitHub Actions workflow
   commands, so findings render as inline annotations on the pull-request diff
   with no SARIF-upload step (#333).


### PR DESCRIPTION
The `coverage` job produces `coverage/lcov.info` (c8) and calls `codecov/codecov-action@v5`, but passed no token — and Codecov now requires an authenticated upload even for public repositories, so the upload failed and the README badge showed `unknown`.

The `CODECOV_TOKEN` secret is now set; the step passes it:

```yaml
with:
  token: ${{ secrets.CODECOV_TOKEN }}
  files: ./coverage/lcov.info
  fail_ci_if_error: false
```

`continue-on-error: true`/`fail_ci_if_error: false` stay: the real coverage gate is the c8 100% threshold (which fails the job on its own), so Codecov remains informational — the badge and pull-request coverage comments. No test-framework or report-format change: c8 already emits the LCOV report Codecov ingests.

Closes #341.
