### PR TITLE
Release from GitHub Actions via npm OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+name: release
+'on':
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+permissions:
+  contents: write
+  id-token: write
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - run: npm install
+      - name: Stamp the released version
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          today="$(date +%F)"
+          sed -i "s/0\.0\.0/${VERSION}/" package.json
+          sed -i "s/0\.0\.0/${VERSION}/" src/version.js
+          sed -i "s/0000-00-00/${today}/" src/version.js
+      - run: npm test
+      - run: npm run coverage
+      - name: Publish to npm via OIDC
+        run: |
+          npm install -g npm@latest
+          npm publish --provenance --access public
+      - name: Promote the changelog and collect the release notes
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          today="$(date +%F)"
+          node scripts/changelog-release.js "${VERSION}" "${today}" > notes.md
+      - name: Create the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ github.ref_name }}
+        run: gh release create "${VERSION}" --title "${VERSION}" --notes-file notes.md
+      - name: Commit the promoted changelog to master
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add CHANGELOG.md
+          git commit -m "changelog: release ${VERSION}"
+          git push origin HEAD:master

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -3,29 +3,16 @@
 ---
 docker:
   image: maxonfjvipon/rultor-image-js:latest
-assets:
-  npmrc: maxonfjvipon/secrets#.npmrc
 install: |
   npm install --no-color
   npm install --no-color mocha
   pdd -f /dev/null -v
 release:
   pre: false
-  script: |
+  script: |-
     [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
-    sed -i "s/0\.0\.0/${tag}/" package.json
-    sed -i "s/0\.0\.0/${tag}/" src/version.js
-    sed -i "s/0000-00-00/$(date +%Y-%m-%d)/" src/version.js
     npm test
     npm run coverage
-    git commit -am "set version to ${tag}"
-    chmod 600 ../npmrc
-    echo "xslint dry run:"
-    npm publish --dry-run --userconfig=../npmrc || exit 1
-    echo "Check if xslint exists:"
-    npm view @maxonfjvipon/xslint@${tag} && exit 1
-    echo "Publishing xslint:"
-    npm publish --userconfig=../npmrc --access=public
 merge:
   script: |-
     npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Publish releases from a GitHub Actions workflow via npm OIDC trusted
+  publishing (no token to rotate, with provenance), promoting the changelog and
+  cutting a GitHub Release; `@rultor release` still validates, tests, and pushes
+  the tag that triggers it (#343).
+
 - Authenticate Codecov uploads with `CODECOV_TOKEN`, so coverage reports upload
   and the badge reflects real coverage (#341).
 

--- a/scripts/changelog-release.js
+++ b/scripts/changelog-release.js
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+'use strict'
+
+const fs = require('fs')
+
+const version = process.argv[2]
+const date = process.argv[3]
+if (!version || !date) {
+  throw new Error('usage: changelog-release.js <version> <date>')
+}
+
+const file = 'CHANGELOG.md'
+const lines = fs.readFileSync(file, 'utf-8').split('\n')
+const start = lines.findIndex((line) => line.trim() === '## Unreleased')
+if (start < 0) {
+  throw new Error('no "## Unreleased" section in CHANGELOG.md')
+}
+const next = lines.findIndex(
+  (line, index) => index > start && line.startsWith('## '),
+)
+const stop = next < 0 ? lines.length : next
+const notes = lines.slice(start + 1, stop).join('\n').trim()
+if (notes === '') {
+  throw new Error('the "## Unreleased" section is empty, nothing to release')
+}
+
+fs.writeFileSync(file, [
+  ...lines.slice(0, start + 1),
+  '',
+  `## ${version} - ${date}`,
+  ...lines.slice(start + 1),
+].join('\n'))
+
+process.stdout.write(`${notes}\n`)


### PR DESCRIPTION
Publishing moves off Rultor's token-based `release` and onto a GitHub Actions workflow that authenticates with npm via **OIDC trusted publishing** — no token in the repo, nothing to rotate, and build provenance attached.

`release.yml` triggers on a semver tag and:

- gates on `npm test` and `npm run coverage`;
- stamps the version/date (the `0.0.0` placeholder stays on master);
- `npm publish --provenance --access public` (OIDC, npm >= 11.5.1);
- promotes the `## Unreleased` changelog section to `## <version> - <date>` via `scripts/changelog-release.js`, opening a fresh `## Unreleased`;
- creates a GitHub Release whose notes are that section;
- commits the promoted changelog back to master.

Per your idea, Rultor stays the trigger: its `release` script is slimmed to validate the tag and run the gates, and `@rultor release` still pushes the tag that fires this workflow. The `npmrc` asset and the token publish are gone.

Publish is ordered before the changelog commit, so if the master push is blocked by branch protection the release still went out (recoverable).

**One-time setup before the first tag:** on npmjs.com add a Trusted Publisher for `@maxonfjvipon/xslint` pointing at `maxonfjvipon/xslint` / `release.yml`. Set the optional environment only if you want a manual-approval gate (tell me the name and I will add `environment:` to the job — it must match).

Closes #343.
