### PR TITLE
Declare repository and a files allowlist for publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Declare `repository` (so `npm publish --provenance` validates) and a
+  `files` allowlist that ships only `src`, keeping `coverage`, tests, and the
+  dev-only `patches` out of the published package (#346).
+
 - Publish releases from a GitHub Actions workflow via npm OIDC trusted
   publishing (no token to rotate, with provenance), promoting the changelog and
   cutting a GitHub Release; `@rultor release` still validates, tests, and pushes

--- a/package.json
+++ b/package.json
@@ -2,10 +2,19 @@
   "name": "@maxonfjvipon/xslint",
   "version": "0.0.0",
   "description": "XSL Linter",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/maxonfjvipon/xslint.git"
+  },
+  "homepage": "https://github.com/maxonfjvipon/xslint#readme",
+  "bugs": "https://github.com/maxonfjvipon/xslint/issues",
   "main": "src/index.mjs",
   "bin": {
     "xslint": "src/index.mjs"
   },
+  "files": [
+    "src"
+  ],
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
The first OIDC release (tag `0.0.7`) failed at `npm publish --provenance` with:

```
npm error 422 ... Error verifying sigstore provenance bundle: package.json:
"repository.url" is "", expected to match "https://github.com/maxonfjvipon/xslint"
```

`--provenance` needs a `repository.url` to match the building repo. `package.json` had none. Nothing published (npm is still 0.0.6), so this is a clean fix.

- Add `repository` (`git+https://github.com/maxonfjvipon/xslint.git`), plus `homepage`/`bugs` for the npm page.
- Add `files: ["src"]`. The failed run's log showed the tarball bundling `coverage/` and everything else not git-ignored; `src` is all the CLI needs at runtime (including `src/resources`). `npm pack --dry-run` now yields `LICENSE.txt, README.md, package.json, src` — 33.7 kB. It also makes the `patch-package` postinstall a clean no-op for consumers, since the dev-only `patches/` no longer ships.

Closes #346.
