### PR TITLE
Enforce a 100-character line length for Markdown

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,7 @@
 {
-  "line-length": false
+  "line-length": {
+    "line_length": 100,
+    "code_blocks": false,
+    "tables": false
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Enforce a 100-character line length for Markdown (code blocks and tables
+  exempt); `CLAUDE.md`, a dense one-line-per-paragraph reference, is exempt
+  (#355).
+
 ## 0.0.9 - 2026-07-24
 
 - Fix the release workflow: read the changelog for the GitHub Release notes and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
  # CLAUDE.md
 
+<!-- markdownlint-disable MD013 -->
+<!-- This file is dense reference prose written one paragraph per line; the
+     100-char line length is not enforced here. -->
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Git Workflow

--- a/src/resources/motives/xpath/with-param-use-in-invalid-parent-node.md
+++ b/src/resources/motives/xpath/with-param-use-in-invalid-parent-node.md
@@ -1,8 +1,9 @@
 # Using `xsl:with-param` in invalid parent node
 
 `xsl:with-param` is allowed within `xsl:call-template`, `xsl:apply-templates`,
-`xsl:apply-imports`, `xsl:next-match` and `xsl:next-iteration`. `xsl:with-param` is needed to pass values
-to the called template or to the applied templates. Otherwise it doesn't make sense.
+`xsl:apply-imports`, `xsl:next-match` and `xsl:next-iteration`. `xsl:with-param` is
+needed to pass values to the called template or to the applied templates. Otherwise
+it doesn't make sense.
 
 Incorrect:
 


### PR DESCRIPTION
Markdownlint had `line-length` disabled entirely. This turns it on at 100 characters, so Markdown prose stays readable and the limit is enforced on new docs.

- `line_length: 100`, with `code_blocks` and `tables` exempt (their lines can't wrap).
- `CLAUDE.md` is exempt via an inline `markdownlint-disable MD013` — it is dense reference prose written one paragraph per line, with several 200–1200-character lines that would be impractical to wrap.
- One motive line (105 chars) is rewrapped.

README badges are already exempt (MD013 does not fire on unbreakable long URLs), and the other auto-fixable rules are handled by the workflow's `fix: true`. Verified against the CI markdownlint version (0.17.2): zero unfixable issues remain.

Closes #355.
