### PR TITLE
Auto-bump the xslint-action version in the README

### DIFF
--- a/.github/workflows/up-xslint-action.yml
+++ b/.github/workflows/up-xslint-action.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: up-xslint-action
+'on':
+  schedule:
+    - cron: '0 6 * * *'
+concurrency:
+  group: up-xslint-action-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  up:
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Resolve the latest and current xslint-action versions
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          latest=$(gh release view --repo maxonfjvipon/xslint-action --json tagName --jq .tagName)
+          echo "latest=${latest}" >> "$GITHUB_OUTPUT"
+          current=$(grep -oP 'xslint-action@\K[0-9.]+' README.md | head -1)
+          echo "current=${current}" >> "$GITHUB_OUTPUT"
+      - name: Update the README to the latest xslint-action version
+        if: steps.version.outputs.latest != steps.version.outputs.current
+        run: |
+          sed -E -i "s|xslint-action@[0-9.]+|xslint-action@${{ steps.version.outputs.latest }}|g" README.md
+      - uses: peter-evans/create-pull-request@v8
+        if: steps.version.outputs.latest != steps.version.outputs.current
+        with:
+          sign-commits: true
+          branch: xslint-action-version-up
+          commit-message: 'new xslint-action version in README'
+          delete-branch: true
+          title: 'New xslint-action version in README'
+          assignees: maxonfjvipon
+          base: master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Add a scheduled workflow that keeps the `xslint-action` version in the README
+  current, opening a PR when the action publishes a new release (#357).
+
 - Enforce a 100-character line length for Markdown (code blocks and tables
   exempt); `CLAUDE.md`, a dense one-line-per-paragraph reference, is exempt
   (#355).


### PR DESCRIPTION
The README's CI example pins `maxonfjvipon/xslint-action@X.Y.Z`, which goes stale when the action publishes a new release.

`up-xslint-action.yml` runs daily, reads the latest `xslint-action` release with `gh release view`, and — if the README's pin is behind — updates it and opens a PR (via `peter-evans/create-pull-request`, as `up.yml` already does). Unlike `up.yml`, it queries the *other* repository, because the action's tags don't trigger an event here.

```yaml
sed -E -i "s|xslint-action@[0-9.]+|xslint-action@${{ steps.version.outputs.latest }}|g" README.md
```

Its `sed` targets `xslint-action@`, which is disjoint from `up.yml`'s `xslint@` (that pattern never matches `xslint-action@`), so the two auto-bump workflows do not interfere. Verified the `gh` query returns `0.0.5` and the sed bumps a stale reference.

Closes #357.
