### PR TITLE
Add a --fix mode that rewrites redundant whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Add a `--fix` mode (`--fix-dry-run` to preview) that rewrites the
+  mechanically-fixable defects in place. It covers `redundant-whitespace`
+  today: a check-agnostic engine (`src/fixer.js`) applies the `fix` a defect
+  carries only when the flagged span still matches, leaving the rest of the
+  file byte-for-byte intact (#334).
+
 - Add a scheduled workflow that keeps the `xslint-action` version in the README
   current, opening a PR when the action publishes a new release (#357).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,8 @@ Configuration by users: a `.xslint.yml` file (discovered by walking up from the 
 
 Command-line flags override the file; the file overrides the built-in defaults. Resolution lives in `src/config.js` (which also exposes the config's `base` directory); `src/xslint.js` expands each rule pattern against the check names, folds `off` rules into the suppression list, filters excluded files against `base`, applies severity overrides to the collected defects, and resolves the effective `max-warnings`/`log-level`/`quiet`.
 
+Fixing by users: `xslint --fix` rewrites the mechanically-fixable defects in place (`--fix-dry-run` reports the same result without writing any file). A defect is fixable when it carries a `fix: {line, col, value, replacement}` — the format linter attaches one to each `redundant-whitespace` defect, and no other check does yet. `src/fixer.js` maps each fix's position to a source offset and applies it *only* when the span still holds the exact `value` (a shifted offset — an entity ahead of the run, an already-edited file — is skipped, never corrupting the source), applying a file's fixes from the end backwards so earlier offsets stay valid, and returns the rewritten content per changed file plus the defects it applied. `src/xslint.js` writes the changed files (unless `--fix-dry-run`) and drops the applied defects from the report, so the exit code reflects only what remains. The fix engine is check-agnostic — the `fix` shape is the whole contract — so future fixers (axis abbreviation, unused-namespace removal) attach a `fix` and need no engine change.
+
 ## Keeping Docs in Sync
 
 Any change to behavior — new logic, a new check or validator, a rename, a moved file, a changed flag or output — must update the documentation in the same change. Before finishing, check all three and fix whichever went stale:
@@ -145,6 +147,7 @@ A change that leaves any of these describing the old behavior is not done.
 | `src/corpus-linter.js` | Loads `checks/corpus/*.yaml`, applies cross-file rules over the corpus |
 | `src/xpath-format-linter.js` | Tokenizes the validator's valid expressions and flags formatting noise (`redundant-whitespace`) |
 | `src/tokens.js` | XPath lexer: positioned token stream (`TOKENS`: string, comment, whitespace, other) preserving whitespace |
+| `src/fixer.js` | Applies the `fix` a defect carries to its source text (verify-before-apply, end-to-start) for `--fix`/`--fix-dry-run` |
 | `src/xpath.js` | Shared fontoxpath environment: prefixes, custom functions, node/string evaluators, expression validator (`isValid`) |
 | `src/helpers.js` | XML parsing (`@xmldom/xmldom`), YAML parsing, file recursion |
 | `src/logger.js` | 4-level logger (debug/info/warning/error) |

--- a/README.md
+++ b/README.md
@@ -216,6 +216,29 @@ upload; the alerts still surface in code scanning. Run it from the repository
 root so the reported paths stay repo-relative — a file outside the working
 directory is named by its absolute path instead.
 
+## Fixing
+
+Some defects have a single unambiguous correction, and `--fix` applies it in
+place:
+
+```bash
+xslint --fix path/to/dir
+```
+
+Today this covers `redundant-whitespace`: a doubled space is collapsed to one,
+and a space leading or trailing an XPath expression is removed. Only the exact
+span that was flagged is rewritten — the rest of the file is left
+byte-for-byte intact — and a fix is skipped rather than applied when the source
+no longer matches what it expects. Checks whose correction needs a human
+decision stay report-only.
+
+Pass `--fix-dry-run` to see what would remain after fixing, without writing any
+file:
+
+```bash
+xslint --fix-dry-run path/to/dir
+```
+
 ## Exit code
 
 `xslint` exits non-zero when any `error`-severity defect is found. Warnings do

--- a/src/fixer.js
+++ b/src/fixer.js
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {logger} = require('./logger')
+
+/**
+ * Absolute offset in a text of a one-based line and column.
+ * @param {string} text - Source text
+ * @param {number} line - One-based line number
+ * @param {number} col - One-based column number
+ * @return {number} - Zero-based offset into the text
+ */
+const offsetAt = function(text, line, col) {
+  const lines = text.split('\n')
+  let offset = col - 1
+  for (let ln = 0; ln < line - 1; ln++) {
+    offset += lines[ln].length + 1
+  }
+  return offset
+}
+
+/**
+ * Apply the fixes carried by defects to their sources, returning the rewritten
+ * content of each changed file and the defects whose fix was applied. Each fix
+ * names a source span and its replacement; a fix is applied only when that span
+ * still holds the exact text the fix expects, so a shifted offset — an entity
+ * ahead of the run, an already-edited file — is skipped rather than corrupting
+ * the source. Fixes for one file are applied from the end backwards so earlier
+ * offsets stay valid.
+ * @param {Array.<{file: string, content: string}>} sources - Original sources
+ * @param {Array.<{file: string, fix: {line: number, col: number, value: string,
+ *  replacement: string}}>} defects - Defects, only those carrying a `fix` fixed
+ * @return {{contents: Map.<string, string>, applied: Array.<object>}} - The
+ *  rewritten content by file and the defects that were applied
+ */
+const fixed = function(sources, defects) {
+  const fixable = defects.filter((defect) => defect.fix)
+  const contents = new Map()
+  const applied = []
+  for (const {file, content} of sources) {
+    const edits = fixable
+      .filter((defect) => defect.file === file)
+      .map((defect) => ({
+        defect: defect,
+        start: offsetAt(content, defect.fix.line, defect.fix.col),
+      }))
+      .filter(({defect, start}) => {
+        const matches =
+          content.substr(start, defect.fix.value.length) === defect.fix.value
+        if (!matches) {
+          logger.warn(
+            `Skipped fixing ${defect.name} at ${file}:${defect.fix.line}, ` +
+            `the source no longer matches`,
+          )
+        }
+        return matches
+      })
+      .sort((left, right) => right.start - left.start)
+    if (edits.length > 0) {
+      let text = content
+      for (const {defect, start} of edits) {
+        text =
+          text.slice(0, start) +
+          defect.fix.replacement +
+          text.slice(start + defect.fix.value.length)
+        applied.push(defect)
+      }
+      contents.set(file, text)
+    }
+  }
+  return {contents: contents, applied: applied}
+}
+
+module.exports = {
+  fixed,
+}

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -25,6 +25,11 @@ program
       .default('text'),
   )
   .option('--config <path>', 'Path to a configuration file')
+  .option('--fix', 'Rewrite the fixable defects in place')
+  .option(
+    '--fix-dry-run',
+    'Report what --fix would change without writing files',
+  )
   .option(
     '--max-warnings <n>',
     'Number of warnings to allow before the exit code becomes non-zero ' +

--- a/src/xpath-format-linter.js
+++ b/src/xpath-format-linter.js
@@ -29,27 +29,34 @@ const META = yaml.parsedFromFile(
 const names = [CHECK]
 
 /**
- * Offsets of the redundant whitespace runs in an expression. A run is redundant
- * when it is longer than one space, or leads or trails the expression; a run
- * that wraps a line is left alone, and runs inside string literals or comments
- * are never seen because the lexer keeps those whole.
+ * Redundant whitespace runs in an expression. A run is redundant when it is
+ * longer than one space, or leads or trails the expression; a run that wraps a
+ * line is left alone, and runs inside string literals or comments are never
+ * seen because the lexer keeps those whole. Each run carries the offset where
+ * it starts, its raw value, and the text that should replace it — empty when it
+ * leads or trails, a single space when it is a doubled run in the middle.
  * @param {string} expression - Xpath expression
- * @return {Array.<number>} - Offsets where redundant runs start
+ * @return {Array.<{offset: number, value: string, replacement: string}>} - Runs
  */
 const redundancies = function(expression) {
-  const offsets = []
+  const runs = []
   for (const token of tokenized(expression)) {
+    const edge =
+      token.start === 0 ||
+      token.start + token.value.length === expression.length
     if (
       token.type === TOKENS.WHITESPACE &&
       !/[\r\n]/.test(token.value) &&
-      (token.start === 0 ||
-        token.start + token.value.length === expression.length ||
-        token.value.length > 1)
+      (edge || token.value.length > 1)
     ) {
-      offsets.push(token.start)
+      runs.push({
+        offset: token.start,
+        value: token.value,
+        replacement: edge ? '' : ' ',
+      })
     }
   }
-  return offsets
+  return runs
 }
 
 /**
@@ -67,14 +74,23 @@ const lintByFormat = function(expressions, suppressions = []) {
   const defects = []
   if (!suppressions.some((sup) => CHECK.includes(sup))) {
     for (const {file, expression} of expressions) {
-      for (const offset of redundancies(expression.nodeValue)) {
+      for (const {offset, value, replacement} of redundancies(
+        expression.nodeValue,
+      )) {
+        const pos = expression.columnNumber + 1 + offset
         defects.push({
           name: CHECK,
           severity: META.severity,
           message: META.message,
           file: file,
           line: expression.lineNumber,
-          pos: expression.columnNumber + 1 + offset,
+          pos: pos,
+          fix: {
+            line: expression.lineNumber,
+            col: pos,
+            value: value,
+            replacement: replacement,
+          },
         })
       }
     }

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -13,6 +13,7 @@ const {
 const {lintByXpath, names: xpathChecks} = require('./xpath-linter')
 const {lintByCorpus, names: corpusChecks} = require('./corpus-linter')
 const {lintByFormat, names: formatChecks} = require('./xpath-format-linter')
+const {fixed} = require('./fixer')
 const {logger, levels} = require('./logger')
 const {reporterOf} = require('./reporters')
 const {configFrom} = require('./config')
@@ -121,7 +122,9 @@ const leveled = function(quiet, level) {
  *  suppress: Array.<string>,
  *  maxWarnings: number|undefined,
  *  config: string|undefined,
- *  format: string
+ *  format: string,
+ *  fix: boolean|undefined,
+ *  fixDryRun: boolean|undefined
  * }} options - CLI options
  */
 const xslint = function(pths, options) {
@@ -197,9 +200,21 @@ const xslint = function(pths, options) {
       logger.warn(`Unused xslint-disable directive at ${file}:${stale.line}`)
     }
   }
-  const reported = defects.filter(
+  let reported = defects.filter(
     (defect) => !suppresses(directives.get(defect.file), defect),
   )
+  if (options.fix || options.fixDryRun) {
+    const {contents, applied} = fixed(sources, reported)
+    for (const [file, content] of contents) {
+      if (!options.fixDryRun) {
+        fs.writeFileSync(file, content)
+      }
+    }
+    if (applied.length > 0) {
+      logger.info(`Fixed ${applied.length} defects in ${contents.size} files`)
+    }
+    reported = reported.filter((defect) => !applied.includes(defect))
+  }
   logger.info(`Processed files: ${stylesheets.length}`)
   if (reported.length > 0) {
     logger.info(`Defects found: ${reported.length}`)

--- a/test/fixer.test.js
+++ b/test/fixer.test.js
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {runXslint, xslintStreams} = require('./helpers')
+const {fixed} = require('../src/fixer')
+const assert = require('assert')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+/**
+ * A stylesheet carrying redundant whitespace, copied into a temporary file so
+ * a fixing run never mutates the committed fixture.
+ * @type {string}
+ */
+const dirty = fs.readFileSync(
+  path.resolve(__dirname, 'resources', 'fix', 'redundant-whitespace.xsl'),
+  'utf-8',
+)
+
+/**
+ * The same stylesheet with every redundant whitespace run collapsed or trimmed.
+ * @type {string}
+ */
+const clean = fs.readFileSync(
+  path.resolve(__dirname, 'resources', 'fix', 'redundant-whitespace.fixed.xsl'),
+  'utf-8',
+)
+
+/**
+ * Copy the dirty fixture into a fresh temporary file and return its path.
+ * @return {string} - Path of the temporary stylesheet
+ */
+const scratch = function() {
+  const file = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-fix-')),
+    'sheet.xsl',
+  )
+  fs.writeFileSync(file, dirty)
+  return file
+}
+
+describe('fixer', function() {
+  it('should collapse redundant whitespace in place with --fix', function() {
+    const file = scratch()
+    runXslint(['--fix', file])
+    assert.equal(fs.readFileSync(file, 'utf-8'), clean)
+  })
+  it('cannot touch the file with --fix-dry-run', function() {
+    const file = scratch()
+    runXslint(['--fix-dry-run', file])
+    assert.equal(fs.readFileSync(file, 'utf-8'), dirty)
+  })
+  it('should drop the fixed defect from the report', function() {
+    const file = scratch()
+    assert.ok(!xslintStreams(['--fix', file]).stdout.includes('redundant-whitespace'))
+  })
+  it('should collapse a run whose span it can verify', function() {
+    assert.equal(
+      fixed(
+        [{file: 'a.xsl', content: 'X  Y'}],
+        [{file: 'a.xsl', fix: {line: 1, col: 2, value: '  ', replacement: ' '}}],
+      ).contents.get('a.xsl'),
+      'X Y',
+    )
+  })
+  it('cannot fix a run whose span no longer matches', function() {
+    assert.ok(
+      !fixed(
+        [{file: 'a.xsl', content: 'X  Y'}],
+        [{
+          file: 'a.xsl',
+          name: 'redundant-whitespace',
+          fix: {line: 1, col: 2, value: 'ZZ', replacement: ' '},
+        }],
+      ).contents.has('a.xsl'),
+    )
+  })
+  it('cannot fix a defect that belongs to another file', function() {
+    assert.deepEqual(
+      fixed(
+        [{file: 'a.xsl', content: 'X  Y'}],
+        [{file: 'b.xsl', fix: {line: 1, col: 2, value: '  ', replacement: ' '}}],
+      ).applied,
+      [],
+    )
+  })
+})

--- a/test/resources/fix/redundant-whitespace.fixed.xsl
+++ b/test/resources/fix/redundant-whitespace.fixed.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <xsl:template match="/">
+    <xsl:value-of select="foo( a)"/>
+    <xsl:if test=". = 'hi'">
+      <xsl:value-of select="."/>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/redundant-whitespace.xsl
+++ b/test/resources/fix/redundant-whitespace.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <xsl:template match="/">
+    <xsl:value-of select="foo(  a)"/>
+    <xsl:if test=". = 'hi' ">
+      <xsl:value-of select=" ."/>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Autofix is the strongest retention lever a linter has, and xslint could only report. This adds `--fix`, starting with the one check whose correction is unambiguous — `redundant-whitespace`.

The engine is deliberately check-agnostic. A defect may carry a fix, and that shape is the whole contract:

```js
fix: {
  line: expression.lineNumber,
  col: pos,
  value: value,          // the exact text to replace
  replacement: replacement,  // '' to trim, ' ' to collapse
}
```

`src/fixer.js` maps each fix to a source offset and applies it only when the span still holds that exact `value`, so a shifted offset — an entity ahead of the run, an already-edited file — is skipped rather than corrupting the source. A file's fixes are applied from the end backwards so earlier offsets stay valid. `src/xslint.js` writes the changed files (unless `--fix-dry-run`) and drops the applied defects, so the exit code reflects only what remains.

Because fixability lives entirely in the `fix` shape, the next fixers — axis abbreviation, unused-namespace removal — attach a fix and need no engine change. This is phase 1 of the plan on #334.
