### PR TITLE
Promote the changelog for 0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+## 0.0.10 - 2026-07-26
+
 - Expose a programmatic API: `lint(sources, {suppress, overrides})` returns the
   defects for in-memory `{file, content}` sources without reading files,
   printing, or exiting, and `fixed` applies the fixes. The package `main` now


### PR DESCRIPTION
Promotes the `Unreleased` section to `## 0.0.10` ahead of the release, so the tag-triggered `release.yml` can read the notes for the GitHub release.

This is the pre-tag changelog PR; after it merges, `@rultor release, tag=0.0.10` cuts the release, which publishes the programmatic `lint`/`fixed` API and the whole `--fix` batch to npm — the version the LSP server will depend on.