### PR TITLE
Re-home GitHub references to the xslint org

### DIFF
--- a/.github/workflows/up-xslint-action.yml
+++ b/.github/workflows/up-xslint-action.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          latest=$(gh release view --repo maxonfjvipon/xslint-action --json tagName --jq .tagName)
+          latest=$(gh release view --repo xslint/xslint-action --json tagName --jq .tagName)
           echo "latest=${latest}" >> "$GITHUB_OUTPUT"
           current=$(grep -oP 'xslint-action@\K[0-9.]+' README.md | head -1)
           echo "current=${current}" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 Lint your XSL/XSLT stylesheets — catch malformed XML, invalid XPath, and
 stylistic defects before they ship.
 
-[![DevOps By Rultor.com](https://www.rultor.com/b/maxonfjvipon/xslint)](https://www.rultor.com/p/maxonfjvipon/xslint)
+[![DevOps By Rultor.com](https://www.rultor.com/b/xslint/xslint)](https://www.rultor.com/p/xslint/xslint)
 
 [![npm](https://img.shields.io/npm/v/@maxonfjvipon/xslint.svg?style=flat)](https://www.npmjs.com/package/@maxonfjvipon/xslint)
-[![grunt](https://github.com/maxonfjvipon/xslint/actions/workflows/grunt.yml/badge.svg)](https://github.com/maxonfjvipon/xslint/actions/workflows/grunt.yml)
-[![codecov](https://codecov.io/gh/maxonfjvipon/xslint/branch/master/graph/badge.svg)](https://codecov.io/gh/maxonfjvipon/xslint)
-[![PDD status](http://www.0pdd.com/svg?name=maxonfjvipon/xslint)](http://www.0pdd.com/p?name=maxonfjvipon/xslint)
-[![Hits-of-Code](https://hitsofcode.com/github/maxonfjvipon/xslint)](https://hitsofcode.com/view/github/maxonfjvipon/xslint)
-[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/maxonfjvipon/xslint/blob/master/LICENSE.txt)
+[![grunt](https://github.com/xslint/xslint/actions/workflows/grunt.yml/badge.svg)](https://github.com/xslint/xslint/actions/workflows/grunt.yml)
+[![codecov](https://codecov.io/gh/xslint/xslint/branch/master/graph/badge.svg)](https://codecov.io/gh/xslint/xslint)
+[![PDD status](http://www.0pdd.com/svg?name=xslint/xslint)](http://www.0pdd.com/p?name=xslint/xslint)
+[![Hits-of-Code](https://hitsofcode.com/github/xslint/xslint)](https://hitsofcode.com/view/github/xslint/xslint)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/xslint/xslint/blob/master/LICENSE.txt)
 
 `xslint` is a CLI linter for XSL stylesheets. It first checks that every
 stylesheet is well-formed and every XPath expression compiles, then runs its
@@ -45,15 +45,15 @@ xslint points at each problem with its exact position and how to fix it:
 [WARNING] sheet.xsl(4:5) A variable, function, or template has a single-character name. Use a descriptive name that reveals intent. (short-names)
 ```
 
-In CI, use the [GitHub Action](https://github.com/maxonfjvipon/xslint-action) to
+In CI, use the [GitHub Action](https://github.com/xslint/xslint-action) to
 get inline annotations on your pull requests:
 
 ```yaml
 - uses: actions/checkout@v6
-- uses: maxonfjvipon/xslint-action@0.0.5
+- uses: xslint/xslint-action@0.0.5
 ```
 
-Browse the full [check catalog](https://maxonfjvipon.github.io/xslint/).
+Browse the full [check catalog](https://xslint.github.io/xslint/).
 
 ## Installation
 
@@ -69,7 +69,7 @@ xslint --version
 To build `xslint` from source, clone this repository:
 
 ```bash
-git clone git@github.com:maxonfjvipon/xslint.git
+git clone git@github.com:xslint/xslint.git
 cd xslint
 ```
 
@@ -285,7 +285,7 @@ xslint --max-warnings=10   # more than ten warnings fails the run
 ## Checks
 
 The full list of checks with descriptions and examples is available at
-[maxonfjvipon.github.io/xslint][checks].
+[xslint.github.io/xslint][checks].
 
 xslint runs in two stages. **Validators** first establish that the input is
 valid; **linters** then run over the stylesheets that pass, catching
@@ -363,4 +363,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow and
 [npm]: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
 [node]: https://nodejs.org/en
 [guidelines]: https://www.yegor256.com/2014/04/15/github-guidelines.html
-[checks]: https://maxonfjvipon.github.io/xslint/
+[checks]: https://xslint.github.io/xslint/

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "XSL Linter",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxonfjvipon/xslint.git"
+    "url": "git+https://github.com/xslint/xslint.git"
   },
-  "homepage": "https://github.com/maxonfjvipon/xslint#readme",
-  "bugs": "https://github.com/maxonfjvipon/xslint/issues",
+  "homepage": "https://github.com/xslint/xslint#readme",
+  "bugs": "https://github.com/xslint/xslint/issues",
   "main": "src/xslint.js",
   "bin": {
     "xslint": "src/index.mjs"


### PR DESCRIPTION
The repository moved from `maxonfjvipon/xslint` to `xslint/xslint`. This points every repo-URL reference at the new org: the Rultor/codecov/0pdd/Hits-of-Code badges, the GitHub links, `package.json`'s repository/homepage/bugs, the docs-site (GitHub Pages) URL `xslint.github.io/xslint`, and the `up-xslint-action` release lookup.

Deliberately left alone: the npm scope `@maxonfjvipon/xslint` (the package name is not changing), the `author`/`assignees` identity fields, the `deps-sentinel-action` and `rultor-image-js` references (separate tools), and the `xslint:` namespace URI in `src/xpath.js` (a stable identifier; GitHub redirects keep it resolvable).