### PR TITLE
Dispatch the release cascade to downstream repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,12 @@ jobs:
           gh release edit "${VERSION}" --notes-file notes.md \
             || gh release create "${VERSION}" --title "${VERSION}" \
               --notes-file notes.md
+      - name: Trigger the downstream release cascade
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          for repo in xslint/xslint-lsp xslint/xslint-action; do
+            printf '{"event_type":"xslint-released","client_payload":{"version":"%s"}}' \
+              "${VERSION}" | gh api -X POST "repos/${repo}/dispatches" --input -
+          done


### PR DESCRIPTION
First increment of the one-`@rultor release` cascade (#336-adjacent automation).

When xslint's `release.yml` finishes publishing and cutting the GitHub release, it now fires a `repository_dispatch` (`xslint-released`, carrying the version) to `xslint/xslint-lsp` and `xslint/xslint-action`. Each downstream repo's receiver (separate PRs) bumps its `@maxonfjvipon/xslint` pin and cuts its own patch release.

Uses `secrets.DISPATCH_TOKEN` (org secret) because the built-in `github.token` cannot trigger cross-repo `repository_dispatch`.

Requires: `DISPATCH_TOKEN` present (done), and the downstream receivers + the OrganizationAdmin ruleset bypass (so the automated bump can push to their protected `master`).