### PR TITLE
Give the up workflows a PAT so they can open PRs

### DIFF
--- a/.github/workflows/up-xslint-action.yml
+++ b/.github/workflows/up-xslint-action.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: peter-evans/create-pull-request@v8
         if: steps.version.outputs.latest != steps.version.outputs.current
         with:
+          token: ${{ secrets.DISPATCH_TOKEN }}
           sign-commits: true
           branch: xslint-action-version-up
           commit-message: 'new xslint-action version in README'

--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -25,6 +25,7 @@ jobs:
           sed -E -i "s/xslint@[0-9.]+/xslint@${latest}/g" README.md
       - uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ secrets.DISPATCH_TOKEN }}
           sign-commits: true
           branch: version-up
           commit-message: 'new version in README'


### PR DESCRIPTION
After the transfer, the `up` and `up-xslint-action` workflows go red with `Resource not accessible by integration` — the new org defaults `GITHUB_TOKEN` to read-only (`default_workflow_permissions: read`), so `peter-evans/create-pull-request` can't create the branch/PR.

Fix: pass `secrets.DISPATCH_TOKEN` (already an org secret for the release cascade) to the two `create-pull-request` steps. A PAT is exempt from both the read-only default and the org's "Actions cannot create pull requests" policy, so this works without loosening any org-wide Actions setting.