### PR TITLE
Promote the changelog to 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+## 0.0.11 - 2026-07-27
+
+- Move the project to the `xslint` GitHub organization; the repository,
+  homepage, and documentation-site URLs now point at `github.com/xslint`.
+
 ## 0.0.10 - 2026-07-26
 
 - Expose a programmatic API: `lint(sources, {suppress, overrides})` returns the


### PR DESCRIPTION
Cuts the `## Unreleased` section as `0.0.11`. The release records the move to the `xslint` GitHub org (the package's repository/homepage/bugs URLs changed). Merging this, then `@rultor release, tag=0.0.11`, is the first end-to-end test of the release cascade.