### PR TITLE
Require backticks around the rultor release tag

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,8 +11,11 @@ First, in `CHANGELOG.md`, rename the `## Unreleased` heading to
 Then comment on any issue or pull request:
 
 ```text
-@rultor release, tag=0.0.12
+@rultor release, tag=`0.0.12`
 ```
+
+The backticks around the version are required — without them Rultor reads an
+empty tag and refuses the release.
 
 Rultor validates and tests, tags the commit, and the tag triggers
 [`.github/workflows/release.yml`](.github/workflows/release.yml), which:


### PR DESCRIPTION
The first cascade test failed because `@rultor release, tag=0.0.11` (no backticks) makes Rultor read an empty tag. Correct the RELEASING.md example to `tag=\`0.0.12\`` and note the backticks are required.