### PR TITLE
Provide a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+- id: xslint
+  name: xslint
+  description: Lint XSL/XSLT stylesheets with xslint
+  entry: xslint
+  language: node
+  files: \.(xsl|xslt)$

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ get inline annotations on your pull requests:
 - uses: xslint/xslint-action@0.0.6
 ```
 
+Or run it on commit with [pre-commit](https://pre-commit.com) — add to your
+`.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/xslint/xslint
+    rev: 0.0.11
+    hooks:
+      - id: xslint
+```
+
 Browse the full [check catalog](https://xslint.github.io/xslint/).
 
 ## Installation


### PR DESCRIPTION
Adds `.pre-commit-hooks.yaml` so xslint works with the [pre-commit](https://pre-commit.com) framework — a major adoption channel for linters. Projects add `repo: https://github.com/xslint/xslint` + `id: xslint` to their `.pre-commit-config.yaml`, and xslint runs on `.xsl`/`.xslt` files at commit (`language: node`, so pre-commit installs the package and runs the `xslint` bin). Documented in the README.