### PR TITLE
Add a 'proven on real code' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ get inline annotations on your pull requests:
 
 Browse the full [check catalog](https://xslint.github.io/xslint/).
 
+## Proven on real code
+
+Pointed at the 18 core stylesheets of
+[DocBook-XSL](https://github.com/docbook/xslt10-stylesheets) — mature,
+heavily-used XSLT 1.0 — xslint reported issues across 18 different checks:
+41 `xsl:choose` blocks with no `xsl:otherwise`, 30 named templates that are
+never called, 12 unused parameters, and more. Real stylistic and logical
+findings in code that has shipped for two decades.
+
 ## Installation
 
 To install `xslint` globally, install [npm] first, then run:

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -159,6 +159,15 @@ const generate = function() {
 [WARNING] sheet.xsl(3:3) The match attribute starts with //, which scans the whole tree. (starts-with-double-slash)
 [WARNING] sheet.xsl(4:5) A variable has a single-character name. (short-names)</code></pre>
 
+  <h2>Proven on real code</h2>
+  <p>Pointed at the 18 core stylesheets of
+  <a href="https://github.com/docbook/xslt10-stylesheets">DocBook-XSL</a> &mdash;
+  mature, heavily-used XSLT 1.0 &mdash; xslint reported issues across 18
+  different checks: 41 <code>xsl:choose</code> blocks with no
+  <code>xsl:otherwise</code>, 30 named templates that are never called, 12
+  unused parameters, and more. Real stylistic and logical findings in code that
+  has shipped for two decades.</p>
+
   <h2>Checks</h2>
   <p>${checks.length} checks, each with its rationale:</p>
   <table>


### PR DESCRIPTION
Runs xslint over the 18 core stylesheets of [DocBook-XSL](https://github.com/docbook/xslt10-stylesheets) — mature, widely-used XSLT 1.0 — and reports the outcome on the README and the generated landing page.

Stripped of cosmetic whitespace nits and two validator false positives (filed as #395 and #396), the run surfaced over 200 substantive findings across 18 different checks: 41 `xsl:choose` blocks with no `xsl:otherwise`, 30 named templates never invoked, 12 unused parameters, variables set via nested `xsl:value-of`, and more. Concrete credibility for the linter, in code that has shipped for two decades.