### PR TITLE
Tolerate entities declared in an internal DTD subset

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,20 +9,46 @@ const {DOMParser} = require('@xmldom/xmldom')
 const yaml = require('yaml')
 
 /**
- * XML parser, built once and reused. Its error handler raises on any
+ * Names of the general entities the given source declares in an internal DTD
+ * subset. `@xmldom/xmldom` never expands them, so a reference to one surfaces
+ * as an "entity not found" error even though the entity is perfectly well
+ * declared — DocBook and TEI stylesheets rely on exactly this. Knowing the
+ * declared names lets the parser tell that recoverable case apart from a
+ * genuinely undefined entity.
+ * @param {string} str - XML source
+ * @return {Set.<string>} - Declared general entity names
+ */
+const declaredEntities = function(str) {
+  const names = new Set()
+  for (const match of str.matchAll(/<!ENTITY\s+([A-Za-z_][\w.-]*)\s/g)) {
+    names.add(match[1])
+  }
+  return names
+}
+
+/**
+ * XML parser for the given source. Its error handler raises on any
  * well-formedness problem the parser reports — not only the fatal ones it
  * throws on, but also the recoverable ones such as an undefined entity — so a
  * not-well-formed document never parses, and keeps the parser's diagnostics
- * off the console.
- * @type {DOMParser}
+ * off the console. The one exception is a reference to an entity the source
+ * itself declares: `@xmldom/xmldom` leaves internal-subset entities unexpanded,
+ * and a declared-but-unexpanded entity is not a malformed document.
+ * @param {string} str - XML source the parser will read
+ * @return {DOMParser} - Configured parser
  */
-const parser = new DOMParser({
-  onError: (level, message) => {
-    if (level !== 'warning') {
-      throw new Error(message.trim())
-    }
-  },
-})
+const parserFor = function(str) {
+  const declared = declaredEntities(str)
+  return new DOMParser({
+    onError: (level, message) => {
+      const text = message.trim()
+      const missing = text.match(/^entity not found:&(.+?);/)
+      if (level !== 'warning' && !(missing && declared.has(missing[1]))) {
+        throw new Error(text)
+      }
+    },
+  })
+}
 
 /**
  * Get all the files recursively from given directory
@@ -67,7 +93,7 @@ const fromFile = function(type, fromString) {
  */
 const xmlFromString = function(str) {
   try {
-    return parser.parseFromString(str, 'text/xml')
+    return parserFor(str).parseFromString(str, 'text/xml')
   } catch (err) {
     throw new Error(`Couldn't parse XML:\n${str}\n\nCause: ${err.message}`)
   }

--- a/test/xsl-validator.test.js
+++ b/test/xsl-validator.test.js
@@ -25,6 +25,19 @@ describe('xsl-validator', function() {
     ])
     assert.equal(defects[0].name, 'malformed-stylesheet')
   })
+  it('should keep a stylesheet that declares an internal entity', function() {
+    const {corpus} = validate([
+      {file: 'declared.xsl', content: '<!DOCTYPE a [<!ENTITY sc "x">]>\n<a>&sc;</a>'},
+    ])
+    assert.equal(corpus[0].file, 'declared.xsl')
+  })
+  it('should report a reference to an entity the subset leaves undeclared',
+    function() {
+      const {defects} = validate([
+        {file: 'gap.xsl', content: '<!DOCTYPE a [<!ENTITY sc "x">]>\n<a>&other;</a>'},
+      ])
+      assert.equal(defects[0].name, 'malformed-stylesheet')
+    })
   it('should not leak parser diagnostics to the console', function() {
     const original = console.error
     const lines = []


### PR DESCRIPTION
Fixes #395.

`@xmldom/xmldom` never expands entities declared in an internal DTD subset, so a reference to one — DocBook's `&lowercase;` / `&uppercase;` — surfaced as an `entity not found` error and `xsl-validator` reported the whole, perfectly well-formed stylesheet as `malformed-stylesheet` and dropped it from the corpus unlinted. DocBook's `common.xsl` was lost this way.

The parser now collects the general-entity names the source declares in its own subset and swallows an `entity not found` error for any of them — a declared-but-unexpanded entity is not a malformed document. A reference to a genuinely undeclared entity is still reported, so the deliberate undefined-entity detection is preserved (both cases are covered by new tests). With this, `common.xsl` parses and lints (190 findings) instead of being dropped.

Out of scope: two DocBook files (`autoidx-kimber.xsl`, `autoidx-kosek.xsl`) declare their entities in an *external* DTD pulled in through a `SYSTEM` parameter entity (`<!ENTITY % common.entities SYSTEM "entities.ent">`). Resolving external entity files is a separate, larger problem and stays for a follow-up.