### PR TITLE
Expand the real-code proof to three projects, zero false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,15 @@ Browse the full [check catalog](https://xslint.github.io/xslint/).
 
 ## Proven on real code
 
-Pointed at the 18 core stylesheets of
-[DocBook-XSL](https://github.com/docbook/xslt10-stylesheets) — mature,
-heavily-used XSLT 1.0 — xslint reported issues across 18 different checks:
-41 `xsl:choose` blocks with no `xsl:otherwise`, 30 named templates that are
-never called, 12 unused parameters, and more. Real stylistic and logical
-findings in code that has shipped for two decades.
+Pointed at core stylesheets from the three most widely-used XSLT projects —
+[DocBook-XSL](https://github.com/docbook/xslt10-stylesheets) (1.0),
+[TEI](https://github.com/TEIC/Stylesheets) (2.0), and
+[DITA-OT](https://github.com/dita-ot/dita-ot) (1.0/2.0), 70 files in all —
+xslint surfaced **2,191 findings across 25 different checks, with no false
+positives from its validators**: 106 `xsl:choose` blocks with no
+`xsl:otherwise`, 71 stylesheet functions never called, 67 unused named
+templates, 54 uses of the string `'true'` as a boolean, and more. Real
+stylistic and logical findings in code that has shipped for decades.
 
 ## Installation
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+
+# DITA-OT is the DITA Open Toolkit; its "-OT" tokenises to "OT", which typos
+# would otherwise flag.
+[default.extend-words]
+OT = "OT"

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -160,13 +160,15 @@ const generate = function() {
 [WARNING] sheet.xsl(4:5) A variable has a single-character name. (short-names)</code></pre>
 
   <h2>Proven on real code</h2>
-  <p>Pointed at the 18 core stylesheets of
-  <a href="https://github.com/docbook/xslt10-stylesheets">DocBook-XSL</a> &mdash;
-  mature, heavily-used XSLT 1.0 &mdash; xslint reported issues across 18
-  different checks: 41 <code>xsl:choose</code> blocks with no
-  <code>xsl:otherwise</code>, 30 named templates that are never called, 12
-  unused parameters, and more. Real stylistic and logical findings in code that
-  has shipped for two decades.</p>
+  <p>Pointed at core stylesheets from the three most widely-used XSLT projects
+  &mdash; <a href="https://github.com/docbook/xslt10-stylesheets">DocBook-XSL</a>
+  (1.0), <a href="https://github.com/TEIC/Stylesheets">TEI</a> (2.0), and
+  <a href="https://github.com/dita-ot/dita-ot">DITA-OT</a> (1.0/2.0), 70 files
+  in all &mdash; xslint surfaced 2,191 findings across 25 different checks, with
+  no false positives from its validators: 106 <code>xsl:choose</code> blocks
+  with no <code>xsl:otherwise</code>, 71 stylesheet functions never called, 67
+  unused named templates, and more. Real stylistic and logical findings in code
+  that has shipped for decades.</p>
 
   <h2>Checks</h2>
   <p>${checks.length} checks, each with its rationale:</p>


### PR DESCRIPTION
Now that #395, #396, #402 and #403 have removed every validator false-positive class the corpus exposed, this expands the "Proven on real code" section (README + landing page) from DocBook-only to all three flagship XSLT projects.

Re-run on clean master over core subsets of [DocBook-XSL](https://github.com/docbook/xslt10-stylesheets) (1.0), [TEI](https://github.com/TEIC/Stylesheets) (2.0) and [DITA-OT](https://github.com/dita-ot/dita-ot) (1.0/2.0) — 70 files:

| corpus | files | findings | validator FPs |
|--------|:-----:|:--------:|:-------------:|
| DocBook `common/` | 18 | 727 | 0 |
| TEI `common/` | 17 | 862 | 0 |
| DITA `html5/xsl` | 35 | 602 | 0 |
| **Total** | **70** | **2,191** | **0** |

**2,191 findings across 25 distinct checks, zero false positives** — down from 7 before the fixes (3 malformed on DTD entities, 4 invalid-xpath on 1.0 coercion / the namespace axis / unexpanded entities). The section now leads with the three-project, both-dialect result.