### PR TITLE
Flag boolean constants only in a boolean context

### DIFF
--- a/src/resources/checks/xpath/incorrect-use-of-boolean-constants.yaml
+++ b/src/resources/checks/xpath/incorrect-use-of-boolean-constants.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //*[@*[(contains(., 'true') and not(contains(., 'true()'))) or (contains(., 'false') and not(contains(., 'false()')))]]
+xpath: "//xsl:*[local-name() = ('if', 'when')][normalize-space(@test) = (\"'true'\", \"'false'\")]"
 severity: warning
-message: "Boolean constants 'true' and 'false' are non-empty strings, not booleans. Use true() and false() instead."
+message: "The test is the string 'true' or 'false', a non-empty string that is always true, not a boolean. Use true() or false() instead."

--- a/src/resources/motives/xpath/incorrect-use-of-boolean-constants.md
+++ b/src/resources/motives/xpath/incorrect-use-of-boolean-constants.md
@@ -1,12 +1,14 @@
 # Incorrect use of boolean constants
 
-The strings `'true'` and `'false'` are non-empty strings that always evaluate
-to boolean `true`. Use the XPath functions `true()` and `false()` instead.
+When an `xsl:if` or `xsl:when` test is the bare string `'true'` or `'false'`,
+it is a non-empty string, so the branch is *always* taken — `test="'false'"`
+runs when you meant it never should. Say what you mean with the boolean
+functions `true()` and `false()`.
 
-Incorrect:
+Incorrect (the branch always runs):
 
 ```xsl
-<xsl:if test="@active = 'true'">
+<xsl:if test="'false'">
   <xsl:value-of select="."/>
 </xsl:if>
 ```
@@ -14,7 +16,11 @@ Incorrect:
 Correct:
 
 ```xsl
-<xsl:if test="@active = true()">
+<xsl:if test="false()">
   <xsl:value-of select="."/>
 </xsl:if>
 ```
+
+Comparing a value to the string `'true'` is a different thing and correct —
+XML attributes are strings, so `@active = 'true'` is how you test one. That,
+and literal output like `<td hidden="true"/>`, are left alone.

--- a/test/resources/xpath-packs/correct-use-of-boolean-constants.yaml
+++ b/test/resources/xpath-packs/correct-use-of-boolean-constants.yaml
@@ -9,16 +9,14 @@ input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
     <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:param name="coverage" select="'false'"/>
     <xsl:template match="R/R/q">
-      <xsl:if test="@ooo = true()">
-        <p>OOO</p>
-      </xsl:if>
-      <xsl:if test="@ooo = false()">
-        <p>not OOO</p>
+      <xsl:if test="@ooo = 'true'">
+        <p hidden="true">OOO</p>
       </xsl:if>
     </xsl:template>
-    <xsl:template match="/objects/o/o[1]/o[2]">
-      <xsl:variable name="qw" as="xs:string" select="ooo" />
+    <xsl:template match="/objects/o/o[1]/o[1]">
+      <xsl:variable name="qw" as="xs:string" select="ooo"/>
       <xsl:copy-of select="$qw"/>
     </xsl:template>
   </xsl:stylesheet>

--- a/test/resources/xpath-packs/incorrect-use-of-boolean-constants.yaml
+++ b/test/resources/xpath-packs/incorrect-use-of-boolean-constants.yaml
@@ -10,15 +10,15 @@ input: |-
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
     <xsl:output encoding="UTF-8" method="xml"/>
     <xsl:template match="R/R/q">
-      <xsl:if test="@ooo = 'true'">
+      <xsl:if test="'true'">
         <p>OOO</p>
       </xsl:if>
-      <xsl:if test="@ooo = 'false'">
+      <xsl:if test="'false'">
         <p>not OOO</p>
       </xsl:if>
     </xsl:template>
     <xsl:template match="/objects/o/o[1]/o[1]">
-      <xsl:variable name="qw" as="xs:string" select="ooo" />
+      <xsl:variable name="qw" as="xs:string" select="ooo"/>
       <xsl:copy-of select="$qw"/>
     </xsl:template>
   </xsl:stylesheet>


### PR DESCRIPTION
Fixes #409.

`incorrect-use-of-boolean-constants` matched `'true'`/`'false'` as a substring of *any* attribute — `//*[@*[contains(., 'true') …]]` — so it fired on string comparisons (`@active = 'true'`, the correct way to test an XML boolean attribute), literal output (`<td hidden="true"/>`), and string parameter defaults (`select="'false'"`). Over [objectionary/eo](https://github.com/objectionary/eo) it reported **82 defects, 79 of them correct comparisons** and none a real bug. Its motive compounded this by teaching `@active = true()`, a different and usually wrong expression.

Now the check fires only on an `xsl:if`/`xsl:when` whose `@test` is exactly `'true'` or `'false'` — a bare boolean constant used as a condition, where `test="'false'"` is a non-empty string and so always true. Strings used as data (comparisons, output, defaults) are left alone. The motive is rewritten to show the real fix, and the packs now encode the genuine bug plus the comparisons/output that must *not* be flagged.