### PR TITLE
Fix four false positives found linting objectionary/eo

### DIFF
--- a/src/resources/checks/xpath/empty-content-in-instructions.yaml
+++ b/src/resources/checks/xpath/empty-content-in-instructions.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //*[name()='xsl:for-each' or name()='xsl:if' or name()='xsl:otherwise' or name()='xsl:when'][count(node()) = count(text()) and normalize-space() = ""]
+xpath: //*[name()='xsl:for-each' or name()='xsl:if'][count(node()) = count(text()) and normalize-space() = ""]
 severity: warning
-message: An instruction element such as xsl:for-each, xsl:if, or xsl:when has no content. Add content or remove the empty element.
+message: An instruction element such as xsl:for-each or xsl:if has no content. Add content or remove the empty element.

--- a/src/resources/checks/xpath/not-using-output.yaml
+++ b/src/resources/checks/xpath/not-using-output.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: /xsl:stylesheet[count(xsl:output) = 0]
+xpath: /xsl:stylesheet[count(xsl:template) > 0 and count(xsl:output) = 0]
 severity: error
 message: The xsl:output instruction is missing. Declare it to specify the serialization format explicitly.

--- a/src/resources/checks/xpath/null-output-from-stylesheet.yaml
+++ b/src/resources/checks/xpath/null-output-from-stylesheet.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: /xsl:stylesheet//xsl:template[starts-with(@match, '/')][(count(*) = count(xsl:variable)) and (normalize-space(string-join(text(), '')) = '')]
+xpath: /xsl:stylesheet//xsl:template[starts-with(@match, '/')][count(xsl:variable) > 0 and (count(*) = count(xsl:variable)) and (normalize-space(string-join(text(), '')) = '')]
 severity: warning
 message: The root template contains only variable declarations and produces no output. Add instructions that write to the result tree.

--- a/src/resources/checks/xpath/stylesheet-has-no-templates.yaml
+++ b/src/resources/checks/xpath/stylesheet-has-no-templates.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: /xsl:stylesheet[count(xsl:template)=0]
+xpath: /xsl:stylesheet[count(xsl:template)=0 and count(xsl:function)=0 and count(xsl:variable)=0]
 severity: error
-message: The stylesheet has no xsl:template elements and produces no output. Add at least one template.
+message: The stylesheet has no templates, functions, or variables and offers nothing. Add at least one template.

--- a/src/resources/motives/xpath/empty-content-in-instructions.md
+++ b/src/resources/motives/xpath/empty-content-in-instructions.md
@@ -1,8 +1,9 @@
 # Empty content in instructions
 
-Instruction elements such as `xsl:for-each`, `xsl:if`, `xsl:when`, and
-`xsl:otherwise` with no content produce no output and are almost certainly
-a mistake.
+Instruction elements such as `xsl:for-each` and `xsl:if` with no content
+produce no output and are almost certainly a mistake. An empty `xsl:when` or
+`xsl:otherwise` is a deliberate "this case produces nothing" and is left
+alone — the latter is exactly what `use-choose-without-otherwise` asks for.
 
 Incorrect:
 

--- a/src/resources/motives/xpath/not-using-output.md
+++ b/src/resources/motives/xpath/not-using-output.md
@@ -1,8 +1,10 @@
 # Not using output
 
-Every stylesheet must declare `xsl:output` to specify the serialization format
-explicitly. Omitting it leaves the output method implementation-defined and
-leads to inconsistent results across processors.
+Every stylesheet that has templates must declare `xsl:output` to specify the
+serialization format explicitly. Omitting it leaves the output method
+implementation-defined and leads to inconsistent results across processors. A
+module with no templates — one imported into a pipeline that sets the output
+itself — is exempt, since it never serializes on its own.
 
 Incorrect:
 

--- a/src/resources/motives/xpath/null-output-from-stylesheet.md
+++ b/src/resources/motives/xpath/null-output-from-stylesheet.md
@@ -2,7 +2,9 @@
 
 A root-matching template whose only children are `xsl:variable` declarations
 produces no output. The variables are computed but nothing is ever written
-to the result tree, which is almost certainly a logic error.
+to the result tree, which is almost certainly a logic error. An empty template
+that matches specific nodes to strip them — the "override to delete" idiom — is
+not flagged; the template must actually declare a variable to qualify.
 
 Incorrect:
 

--- a/src/resources/motives/xpath/stylesheet-has-no-templates.md
+++ b/src/resources/motives/xpath/stylesheet-has-no-templates.md
@@ -1,14 +1,16 @@
 # Stylesheet has no templates
 
-A stylesheet without any `xsl:template` elements can produce no output. Add
-at least one template to process the input document.
+A stylesheet with no templates, functions, or variables offers nothing: it can
+produce no output and exports nothing to import. Add at least one template. A
+function or variable library — one whose definitions are pulled in by the
+stylesheets that `xsl:import` it — is exempt, since its templates live in the
+importer.
 
 Incorrect:
 
 ```xsl
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:output method="html"/>
-  <xsl:variable name="title" select="'Hello'"/>
 </xsl:stylesheet>
 ```
 

--- a/test/resources/xpath-packs/empty-content-in-instructions.yaml
+++ b/test/resources/xpath-packs/empty-content-in-instructions.yaml
@@ -3,8 +3,8 @@
 ---
 pack: empty-content-in-instructions
 found:
-  amount: 4
-  positions: [ [ 5, 5 ], [ 7, 5 ], [ 9, 7 ], [ 10, 7 ] ]
+  amount: 2
+  positions: [ [ 5, 5 ], [ 7, 5 ] ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
@@ -13,14 +13,9 @@ input: |-
       <xsl:for-each select="o/o">
       </xsl:for-each>
       <xsl:if test="@ooo = true()"/>
-      <xsl:choose>
-        <xsl:when test="o/o"/>
-        <xsl:otherwise>
-        </xsl:otherwise>
-      </xsl:choose>
     </xsl:template>
     <xsl:template match="/objects/o/o[1]/o[1]">
-      <xsl:variable name="qw" as="xs:string" select="ooo" />
+      <xsl:variable name="qw" as="xs:string" select="ooo"/>
       <xsl:copy-of select="$qw"/>
     </xsl:template>
   </xsl:stylesheet>

--- a/test/resources/xpath-packs/not-empty-content-in-instructions.yaml
+++ b/test/resources/xpath-packs/not-empty-content-in-instructions.yaml
@@ -15,9 +15,7 @@ input: |-
           <xsl:when test="@ooo = false()">
             <HR STYLE="color:red"/>
           </xsl:when>
-          <xsl:otherwise>
-            <BR/>
-          </xsl:otherwise>
+          <xsl:otherwise/>
         </xsl:choose>
       </xsl:for-each>
       <xsl:if test="@ooo = false()">

--- a/test/resources/xpath-packs/not-null-output-from-stylesheet.yaml
+++ b/test/resources/xpath-packs/not-null-output-from-stylesheet.yaml
@@ -17,4 +17,5 @@ input: |-
     <xsl:template match="/objects/o/o[1]/o[2]">
       <xsl:copy-of select="$oo"/>
     </xsl:template>
+    <xsl:template match="/object/noise"/>
   </xsl:stylesheet>

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -29,8 +29,6 @@ describe('xslint', function() {
     const stdout = runXslint(['test/resources/stylesheets/xsl-with-some-violations.xsl'])
     const expected = [
       'Processed files: 1',
-      '(26:9) An instruction element such as xsl:for-each, xsl:if, or xsl:when has no content. Add content or remove the empty element. (empty-content-in-instructions)',
-      '(27:9) An instruction element such as xsl:for-each, xsl:if, or xsl:when has no content. Add content or remove the empty element. (empty-content-in-instructions)',
       '(6:1) No built-in Schema types are used in XSLT 2.0 or 3.0 mode. Declare variable types with xs:string, xs:integer, or similar. (not-using-schema-types)',
       '(16:3) A variable is assigned via a nested xsl:value-of instead of the select attribute. Use select syntax instead. (setting-value-of-variable-incorrectly)',
       '(16:3) A variable, function, or template has a single-character name. Use a descriptive name that reveals intent. (short-names)',
@@ -108,8 +106,6 @@ describe('xslint', function() {
     ])
     const expected = [
       'Processed files: 1',
-      '(26:9) An instruction element such as xsl:for-each, xsl:if, or xsl:when has no content. Add content or remove the empty element. (empty-content-in-instructions)',
-      '(27:9) An instruction element such as xsl:for-each, xsl:if, or xsl:when has no content. Add content or remove the empty element. (empty-content-in-instructions)',
       '(6:1) No built-in Schema types are used in XSLT 2.0 or 3.0 mode. Declare variable types with xs:string, xs:integer, or similar. (not-using-schema-types)',
       '(16:3) A variable is assigned via a nested xsl:value-of instead of the select attribute. Use select syntax instead. (setting-value-of-variable-incorrectly)',
       '(16:3) A variable, function, or template has a single-character name. Use a descriptive name that reveals intent. (short-names)',


### PR DESCRIPTION
Running xslint over [objectionary/eo](https://github.com/objectionary/eo) surfaced four checks that misfire on legitimate patterns. Fixes #411, #412, #413, #414.

| check | false positive | fix |
|-------|----------------|-----|
| `empty-content-in-instructions` | an intentional empty `<xsl:otherwise/>` (which `use-choose-without-otherwise` asks for — the two checks fought) | flag only empty `xsl:if` / `xsl:for-each` |
| `stylesheet-has-no-templates` | function/variable **library modules** (`_funcs.xsl` imported by 17 files, `_specials.xsl` by 4) | exempt a stylesheet that has functions or variables |
| `null-output-from-stylesheet` | empty **"delete these nodes"** templates (`remove-noise.xsl`) | require `count(xsl:variable) > 0`, matching the message |
| `not-using-output` | imported modules that never serialize | flag only a stylesheet that has templates |

Verified on eo: the three module/idiom checks drop to **0** and `not-using-output` drops 4 → 2, the two survivors being genuine (templated stylesheets that really lack `xsl:output`). Each fix keeps its genuine case firing (positive packs unchanged) and adds the false-positive case to the negative packs. 376 tests, 100% coverage.