### PR TITLE
Refresh the real-code proof numbers after the false-positive fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ Pointed at core stylesheets from the three most widely-used XSLT projects —
 [DocBook-XSL](https://github.com/docbook/xslt10-stylesheets) (1.0),
 [TEI](https://github.com/TEIC/Stylesheets) (2.0), and
 [DITA-OT](https://github.com/dita-ot/dita-ot) (1.0/2.0), 70 files in all —
-xslint surfaced **2,191 findings across 25 different checks, with no false
+xslint surfaced **2,019 findings across 23 different checks, with no false
 positives from its validators**: 106 `xsl:choose` blocks with no
-`xsl:otherwise`, 71 stylesheet functions never called, 67 unused named
-templates, 54 uses of the string `'true'` as a boolean, and more. Real
-stylistic and logical findings in code that has shipped for decades.
+`xsl:otherwise`, 67 unused named templates, 40 stylesheet functions never
+called, and more. Real stylistic and logical findings in code that has shipped
+for decades.
 
 ## Installation
 

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -164,10 +164,10 @@ const generate = function() {
   &mdash; <a href="https://github.com/docbook/xslt10-stylesheets">DocBook-XSL</a>
   (1.0), <a href="https://github.com/TEIC/Stylesheets">TEI</a> (2.0), and
   <a href="https://github.com/dita-ot/dita-ot">DITA-OT</a> (1.0/2.0), 70 files
-  in all &mdash; xslint surfaced 2,191 findings across 25 different checks, with
+  in all &mdash; xslint surfaced 2,019 findings across 23 different checks, with
   no false positives from its validators: 106 <code>xsl:choose</code> blocks
-  with no <code>xsl:otherwise</code>, 71 stylesheet functions never called, 67
-  unused named templates, and more. Real stylistic and logical findings in code
+  with no <code>xsl:otherwise</code>, 67 unused named templates, 40 stylesheet
+  functions never called, and more. Real stylistic and logical findings in code
   that has shipped for decades.</p>
 
   <h2>Checks</h2>


### PR DESCRIPTION
The published proof (2,191 findings) predated #407, #409, and #411-#414, so it still counted the false positives those fixes removed. Re-running xslint over the same DocBook/TEI/DITA subsets now gives **2,019 findings across 23 checks, still zero validator false positives** — ~172 fewer, all of them FPs the fixes eliminated:

| check | before → now |
|-------|:---:|
| empty-content-in-instructions | 76 → 1 |
| incorrect-use-of-boolean-constants | 54 → 0 |
| unused-function | 71 → 40 |
| null-output-from-stylesheet | 8 → 0 |

Crucially, the old copy cited `54 uses of the string 'true' as a boolean` — which were exactly the `incorrect-use-of-boolean-constants` false positives, now 0. Keeping it would misrepresent the tool. Lower number, higher signal.