### PR TITLE
Promote the changelog to 0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+## 0.0.13 - 2026-07-28
+
 - Drop the `unsorted-imports` check. Ordering `xsl:import` elements alphabetically
   can change import precedence — a later import overrides an earlier one on a
   template conflict — so advising that reorder risked changing behavior (#423).


### PR DESCRIPTION
Renames the `Unreleased` heading to `0.0.13 - 2026-07-28` so the release
workflow reads the right notes for the GitHub release. Cuts the version that
carries the check audit from #423: the dropped `unsorted-imports`, the
reworked size-and-count band, and the four honest motives.

Merge this, then `@rultor release, tag=` the version.