### PR TITLE
Refresh the real-code proof after the check audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Refresh the real-code proof after the check audit: 1,974 findings across 22
+  checks on the same 70 DocBook/TEI/DITA files (was 2,019 across 23), and bump
+  the stale install-example version in the README (#423).
+
 ## 0.0.13 - 2026-07-28
 
 - Drop the `unsorted-imports` check. Ordering `xsl:import` elements alphabetically

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ exact line and column, in your terminal or in CI.
 Run it on your stylesheets — no install needed:
 
 ```bash
-npx @maxonfjvipon/xslint@0.0.12 path/to/stylesheets
+npx @maxonfjvipon/xslint@0.0.13 path/to/stylesheets
 ```
 
 Given a stylesheet like this:
@@ -72,7 +72,7 @@ Pointed at core stylesheets from the three most widely-used XSLT projects —
 [DocBook-XSL](https://github.com/docbook/xslt10-stylesheets) (1.0),
 [TEI](https://github.com/TEIC/Stylesheets) (2.0), and
 [DITA-OT](https://github.com/dita-ot/dita-ot) (1.0/2.0), 70 files in all —
-xslint surfaced **2,019 findings across 23 different checks, with no false
+xslint surfaced **1,974 findings across 22 different checks, with no false
 positives from its validators**: 106 `xsl:choose` blocks with no
 `xsl:otherwise`, 67 unused named templates, 40 stylesheet functions never
 called, and more. Real stylistic and logical findings in code that has shipped
@@ -83,7 +83,7 @@ for decades.
 To install `xslint` globally, install [npm] first, then run:
 
 ```bash
-npm install -g @maxonfjvipon/xslint@0.0.12
+npm install -g @maxonfjvipon/xslint@0.0.13
 xslint --version
 ```
 

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -164,7 +164,7 @@ const generate = function() {
   &mdash; <a href="https://github.com/docbook/xslt10-stylesheets">DocBook-XSL</a>
   (1.0), <a href="https://github.com/TEIC/Stylesheets">TEI</a> (2.0), and
   <a href="https://github.com/dita-ot/dita-ot">DITA-OT</a> (1.0/2.0), 70 files
-  in all &mdash; xslint surfaced 2,019 findings across 23 different checks, with
+  in all &mdash; xslint surfaced 1,974 findings across 22 different checks, with
   no false positives from its validators: 106 <code>xsl:choose</code> blocks
   with no <code>xsl:otherwise</code>, 67 unused named templates, 40 stylesheet
   functions never called, and more. Real stylistic and logical findings in code


### PR DESCRIPTION
Re-ran xslint over the same 70 core stylesheets from DocBook-XSL, TEI, and
DITA-OT with the audited check set. The honest number is now **1,974 findings
across 22 different checks**, down from 2,019 across 23: the audit dropped
`unsorted-imports` and narrowed `function-complexity` to functions only, while
the size/count reshuffle roughly balanced out. The three cited specifics — 106
`xsl:choose` blocks without `xsl:otherwise`, 67 unused named templates, 40
uncalled functions — are unchanged.

Updates the README and the docs landing page, and bumps the stale `0.0.12`
install example to `0.0.13`. Follows the audit in #423.