### PR TITLE
Make the double-slash check messages honest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Make the `starts-with-double-slash` and `use-double-slash` messages honest.
+  They blamed a "document scan" that a match pattern never performs; they now
+  say a leading `//` is redundant and an inner `//` matches at any depth,
+  matching the motives corrected earlier (#423).
+
 - Drop the `not-using-schema-types` check. It fired on a 2.0/3.0 stylesheet that
   used no `xs:` type anywhere — an arbitrary "use at least one type" rule that a
   single token type silenced and that flagged perfectly valid untyped

--- a/src/resources/checks/xpath/starts-with-double-slash.yaml
+++ b/src/resources/checks/xpath/starts-with-double-slash.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //xsl:template[starts-with(@match, '//')]
 severity: warning
-message: The match attribute of xsl:template starts with //, which scans the entire document tree. Use a more specific pattern.
+message: The match attribute of xsl:template starts with //, which is redundant since an unanchored pattern already matches at any depth. Remove the leading //.

--- a/src/resources/checks/xpath/use-double-slash.yaml
+++ b/src/resources/checks/xpath/use-double-slash.yaml
@@ -3,4 +3,4 @@
 ---
 xpath: //xsl:template[not(starts-with(@match, '//')) and contains(@match, '//')]
 severity: warning
-message: The match attribute of xsl:template contains //, which triggers a full document scan. Use a more specific path.
+message: The match attribute of xsl:template contains //, which matches at any depth and is broader than intended. Use a specific path.

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -31,7 +31,7 @@ describe('xslint', function() {
       'Processed files: 1',
       '(16:3) A variable is assigned via a nested xsl:value-of instead of the select attribute. Use select syntax instead. (setting-value-of-variable-incorrectly)',
       '(16:3) A variable, function, or template has a single-character name. Use a descriptive name that reveals intent. (short-names)',
-      '(31:3) The match attribute of xsl:template starts with //, which scans the entire document tree. Use a more specific pattern. (starts-with-double-slash)',
+      '(31:3) The match attribute of xsl:template starts with //, which is redundant since an unanchored pattern already matches at any depth. Remove the leading //. (starts-with-double-slash)',
       '(45:3) A named template is never invoked via xsl:call-template. Remove it or call it. (unused-named-template)',
     ]
     expected.forEach((str) => assert.ok(stdout.includes(str)))
@@ -107,7 +107,7 @@ describe('xslint', function() {
       'Processed files: 1',
       '(16:3) A variable is assigned via a nested xsl:value-of instead of the select attribute. Use select syntax instead. (setting-value-of-variable-incorrectly)',
       '(16:3) A variable, function, or template has a single-character name. Use a descriptive name that reveals intent. (short-names)',
-      '(31:3) The match attribute of xsl:template starts with //, which scans the entire document tree. Use a more specific pattern. (starts-with-double-slash)',
+      '(31:3) The match attribute of xsl:template starts with //, which is redundant since an unanchored pattern already matches at any depth. Remove the leading //. (starts-with-double-slash)',
       '(45:3) A named template is never invoked via xsl:call-template. Remove it or call it. (unused-named-template)',
     ]
     assert.ok(stdout.includes('Empty suppress is incorrect. Delete this "--suppress" or use another one.'))


### PR DESCRIPTION
Follow-up to the motive fixes in #426. Those corrected the *motives* for
`starts-with-double-slash` and `use-double-slash` but left the one-line
*messages* still claiming a "document scan" — which a match pattern never
performs, so the message contradicted its own motive.

The messages now say what is actually true: a leading `//` is redundant because
an unanchored pattern already matches at any depth, and an inner `//` matches
at any depth and is broader than intended. Updates the two end-to-end
expectations that pin the `starts-with-double-slash` message. Part of #423.