### PR TITLE
Promote the changelog to 0.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+## 0.0.14 - 2026-07-28
+
 - Make the `starts-with-double-slash` and `use-double-slash` messages honest.
   They blamed a "document scan" that a match pattern never performs; they now
   say a leading `//` is redundant and an inner `//` matches at any depth,


### PR DESCRIPTION
Renames the `Unreleased` heading to `0.0.14 - 2026-07-28` so the release
workflow reads the right notes. This version finishes the #423 audit: the
`not-using-schema-types` cut, the honest double-slash messages, and the
refreshed real-code proof.

Merge, then `@rultor release, tag=` the version.