### PR TITLE
Add --fix-dry-run and report-drop tests for count-compared-to-zero

### DIFF
--- a/test/fixer.test.js
+++ b/test/fixer.test.js
@@ -96,6 +96,20 @@ describe('fixer', function() {
       fixture('count-compared-to-zero.fixed.xsl'),
     )
   })
+  it('cannot rewrite a count comparison with --fix-dry-run', function() {
+    const file = scratch(fixture('count-compared-to-zero.xsl'))
+    runXslint(['--fix-dry-run', file])
+    assert.equal(
+      fs.readFileSync(file, 'utf-8'),
+      fixture('count-compared-to-zero.xsl'),
+    )
+  })
+  it('should drop the fixed count defect from the report', function() {
+    const file = scratch(fixture('count-compared-to-zero.xsl'))
+    assert.ok(
+      !xslintStreams(['--fix', file]).stdout.includes('count-compared-to-zero'),
+    )
+  })
   it('cannot apply a suggestion with plain --fix', function() {
     const file = scratch(fixture('using-disable-output-escaping.xsl'))
     runXslint(['--fix', file])


### PR DESCRIPTION
Follow-up to #441: the count fix landed with a single end-to-end test. This
adds the other two the fixable checks all carry — `--fix-dry-run` leaves the
file untouched, and a fixed `count-compared-to-zero` defect is dropped from the
report — so the fix is exercised from more than one angle.

Relates to #436.