### PR TITLE
Add the select-starts-with-double-slash check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Add the `select-starts-with-double-slash` check: a `select` whose XPath begins
+  with `//` scans the whole document from the root every time it runs — a real,
+  repeated scan, unlike the merely redundant leading `//` in a match pattern.
+  Warning only, since the right anchor (`.//` or a specific path) depends on
+  intent. An inner `//`, one inside a string, or one reached through a variable
+  is left alone (#435).
+
 - Add the `string-length-compared-to-zero` check: `string-length(X)` compared
   with `0` to test emptiness (in either operand order, inside larger boolean
   expressions) is flagged, with a `--fix` that rewrites it to `X != ''` or

--- a/src/resources/checks/xpath/select-starts-with-double-slash.yaml
+++ b/src/resources/checks/xpath/select-starts-with-double-slash.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+xpath: //*[starts-with(normalize-space(@select), '//')]
+severity: warning
+message: The select attribute starts with //, which scans the whole document from the root. Anchor it with .// or a specific path.

--- a/src/resources/motives/xpath/select-starts-with-double-slash.md
+++ b/src/resources/motives/xpath/select-starts-with-double-slash.md
@@ -1,0 +1,30 @@
+# Select starts with double slash
+
+A `select` whose XPath begins with `//` is evaluated as
+`/descendant-or-self::node()/…`, so it walks the entire document from the root
+every time it runs — and inside a template applied per node, that is once per
+node. It is also often a latent bug: the author usually meant "descendants of
+the current node" (`.//x`) or a specific path, not "every `x` in the whole
+document".
+
+Unlike a `match` pattern, where a leading `//` is merely redundant, in a
+`select` it is a real, repeated, whole-tree scan.
+
+Incorrect:
+
+```xsl
+<xsl:for-each select="//item">
+  <xsl:value-of select="."/>
+</xsl:for-each>
+```
+
+Correct:
+
+```xsl
+<xsl:for-each select=".//item">
+  <xsl:value-of select="."/>
+</xsl:for-each>
+```
+
+An inner `//` (`items//item`), a `//` inside a string literal, or one reached
+through a variable (`$root//item`) is left alone.

--- a/test/resources/xpath-packs/select-does-not-start-with-double-slash.yaml
+++ b/test/resources/xpath-packs/select-does-not-start-with-double-slash.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: select-starts-with-double-slash
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template match="/objects/o">
+      <xsl:copy-of select="items//item"/>
+      <xsl:copy-of select="$root//node"/>
+      <xsl:copy-of select="'//literal'"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-packs/select-starts-with-double-slash.yaml
+++ b/test/resources/xpath-packs/select-starts-with-double-slash.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: select-starts-with-double-slash
+found:
+  amount: 2
+  positions: [ [ 5, 5 ], [ 6, 5 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template match="/objects/o">
+      <xsl:copy-of select="//title"/>
+      <xsl:copy-of select="//summary"/>
+    </xsl:template>
+  </xsl:stylesheet>


### PR DESCRIPTION
Implements #435. A `select` whose XPath begins with `//` is evaluated as
`/descendant-or-self::node()/…`, so it walks the whole document from the root —
and inside a template applied per node, once per node. Unlike a `match` pattern,
where a leading `//` is merely redundant, in a `select` it is a real, repeated
scan, and often a latent bug where `.//x` was meant.

```xsl
<xsl:for-each select="//item">   →   <xsl:for-each select=".//item">
```

Warning only, with no `fix`: the correct anchor (`.//` vs a specific path)
depends on intent, so there is no deterministic edit. An inner `//`
(`items//item`), a `//` inside a string literal, or one reached through a
variable (`$root//item`) is left alone. A plain declarative XPath rule —
`//*[starts-with(normalize-space(@select), '//')]` — so no linter code, just the
rule, its motive, and positive/negative packs.