### PR TITLE
Add the not-creating-attribute-correctly check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Add the `not-creating-attribute-correctly` check: an `xsl:attribute` with a
+  static name on a literal result element, whose value is simple (a single
+  `xsl:value-of`, text, or empty), can be written inline as a literal attribute
+  (an AVT for a computed value). Warning only — the inline rewrite is structural
+  and waits on the full-fidelity parser (#228). `xsl:element`/`xsl:copy` parents,
+  computed names, and `xsl:choose` values are left alone (#438).
+
 - Add the `translate-for-case` check: in an XSLT 2.0/3.0 stylesheet, a
   `translate(x, 'A..Z', 'a..z')` (or the reverse) that folds case over the ASCII
   alphabet is flagged, with a `--fix-suggestions` that rewrites it to

--- a/src/resources/checks/xpath/not-creating-attribute-correctly.yaml
+++ b/src/resources/checks/xpath/not-creating-attribute-correctly.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+xpath: //xsl:attribute[not(contains(@name, '{'))][parent::*[not(self::xsl:*)]][count(*) = 0 or (count(*) = 1 and xsl:value-of)]
+severity: warning
+message: xsl:attribute with a static name on a literal element can be a literal attribute (an AVT for a computed value). Write it inline.

--- a/src/resources/motives/xpath/not-creating-attribute-correctly.md
+++ b/src/resources/motives/xpath/not-creating-attribute-correctly.md
@@ -1,0 +1,24 @@
+# Not creating attribute correctly
+
+The attribute analog of `not-creating-element-correctly`. When an `xsl:attribute`
+with a static name sits on a literal result element and its value is simple — a
+single `xsl:value-of`, plain text, or empty — it can be written inline as a
+literal attribute, with an attribute value template for a computed value:
+
+```xsl
+<fo:block>
+  <xsl:attribute name="line"><xsl:value-of select="@l"/></xsl:attribute>
+  <xsl:attribute name="kind">head</xsl:attribute>
+```
+
+becomes
+
+```xsl
+<fo:block line="{@l}" kind="head">
+```
+
+The inline form is shorter and keeps the attribute next to the element it
+belongs to. `xsl:attribute` earns its place when the name is computed (an AVT),
+the value needs instructions an AVT cannot hold (an `xsl:choose`), or the parent
+is itself an instruction such as `xsl:element` or `xsl:copy` — those are left
+alone.

--- a/src/resources/motives/xpath/not-creating-attribute-correctly.md
+++ b/src/resources/motives/xpath/not-creating-attribute-correctly.md
@@ -6,15 +6,15 @@ single `xsl:value-of`, plain text, or empty — it can be written inline as a
 literal attribute, with an attribute value template for a computed value:
 
 ```xsl
-<fo:block>
-  <xsl:attribute name="line"><xsl:value-of select="@l"/></xsl:attribute>
-  <xsl:attribute name="kind">head</xsl:attribute>
+<td>
+  <xsl:attribute name="class"><xsl:value-of select="@c"/></xsl:attribute>
+  <xsl:attribute name="role">cell</xsl:attribute>
 ```
 
 becomes
 
 ```xsl
-<fo:block line="{@l}" kind="head">
+<td class="{@c}" role="cell">
 ```
 
 The inline form is shorter and keeps the attribute next to the element it

--- a/test/resources/xpath-packs/creating-attribute-correctly.yaml
+++ b/test/resources/xpath-packs/creating-attribute-correctly.yaml
@@ -11,10 +11,14 @@ input: |-
     <xsl:output encoding="UTF-8" method="xml"/>
     <xsl:template match="/objects/o">
       <xsl:element name="{$dyn}">
-        <xsl:attribute name="role"><xsl:value-of select="@r"/></xsl:attribute>
+        <xsl:attribute name="role">
+          <xsl:value-of select="@r"/>
+        </xsl:attribute>
       </xsl:element>
       <p>
-        <xsl:attribute name="{$attr}"><xsl:value-of select="@x"/></xsl:attribute>
+        <xsl:attribute name="{$attr}">
+          <xsl:value-of select="@x"/>
+        </xsl:attribute>
       </p>
     </xsl:template>
   </xsl:stylesheet>

--- a/test/resources/xpath-packs/creating-attribute-correctly.yaml
+++ b/test/resources/xpath-packs/creating-attribute-correctly.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: not-creating-attribute-correctly
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template match="/objects/o">
+      <xsl:element name="{$dyn}">
+        <xsl:attribute name="role"><xsl:value-of select="@r"/></xsl:attribute>
+      </xsl:element>
+      <p>
+        <xsl:attribute name="{$attr}"><xsl:value-of select="@x"/></xsl:attribute>
+      </p>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-packs/not-creating-attribute-correctly.yaml
+++ b/test/resources/xpath-packs/not-creating-attribute-correctly.yaml
@@ -4,14 +4,16 @@
 pack: not-creating-attribute-correctly
 found:
   amount: 2
-  positions: [ [ 6, 7 ], [ 7, 7 ] ]
+  positions: [ [ 6, 7 ], [ 9, 7 ] ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style1">
     <xsl:output encoding="UTF-8" method="xml"/>
     <xsl:template match="/objects/o">
       <div>
-        <xsl:attribute name="class"><xsl:value-of select="@c"/></xsl:attribute>
+        <xsl:attribute name="class">
+          <xsl:value-of select="@c"/>
+        </xsl:attribute>
         <xsl:attribute name="id">fixed</xsl:attribute>
       </div>
     </xsl:template>

--- a/test/resources/xpath-packs/not-creating-attribute-correctly.yaml
+++ b/test/resources/xpath-packs/not-creating-attribute-correctly.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: not-creating-attribute-correctly
+found:
+  amount: 2
+  positions: [ [ 6, 7 ], [ 7, 7 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template match="/objects/o">
+      <div>
+        <xsl:attribute name="class"><xsl:value-of select="@c"/></xsl:attribute>
+        <xsl:attribute name="id">fixed</xsl:attribute>
+      </div>
+    </xsl:template>
+  </xsl:stylesheet>


### PR DESCRIPTION
Implements #438, the attribute analog of `not-creating-element-correctly`. When
an `xsl:attribute` with a static name sits on a literal result element and its
value is simple — a single `xsl:value-of`, plain text, or empty — it can be
written inline:

```xsl
<fo:block>
  <xsl:attribute name="line"><xsl:value-of select="@l"/></xsl:attribute>
  <xsl:attribute name="kind">head</xsl:attribute>
```
→
```xsl
<fo:block line="{@l}" kind="head">
```

**Warning only, no fix**: the inline rewrite moves the attribute onto the
parent's start tag — a structural, multi-span edit that waits on the
full-fidelity parser (#228), as noted there. `xsl:element`/`xsl:copy` parents,
computed (AVT) names, and values needing an `xsl:choose` are left alone, since
`xsl:attribute` earns its place there.

A plain declarative XPath rule (no linter code), with positive/negative packs
and its motive.