### PR TITLE
Test that --fix removes four of five duplicate imports

### DIFF
--- a/test/fixer.test.js
+++ b/test/fixer.test.js
@@ -113,6 +113,14 @@ describe('fixer', function() {
       fixture('redundant-import.fixed.xsl'),
     )
   })
+  it('should delete four of five duplicate imports with --fix', function() {
+    const file = scratch(fixture('redundant-import-many.xsl'))
+    runXslint(['--fix', file])
+    assert.equal(
+      fs.readFileSync(file, 'utf-8'),
+      fixture('redundant-import-many.fixed.xsl'),
+    )
+  })
   it('cannot delete a redundant import with --fix-dry-run', function() {
     const file = scratch(fixture('redundant-import.xsl'))
     runXslint(['--fix-dry-run', file])

--- a/test/resources/fix/redundant-import-many.fixed.xsl
+++ b/test/resources/fix/redundant-import-many.fixed.xsl
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="common.xsl"/>
+  <xsl:template match="/">
+    <xsl:value-of select="."/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/redundant-import-many.xsl
+++ b/test/resources/fix/redundant-import-many.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="common.xsl"/>
+  <xsl:import href="common.xsl"/>
+  <xsl:import href="common.xsl"/>
+  <xsl:import href="common.xsl"/>
+  <xsl:import href="common.xsl"/>
+  <xsl:template match="/">
+    <xsl:value-of select="."/>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
A hardening test for the `redundant-import` `--fix` (shipped in #471): a stylesheet that imports the same module **five** times should keep exactly one after `--fix`, with the other four removed.

It confirms the multi-duplicate case works — the four deletions are disjoint whole-line removals applied end-to-start against the original offsets, so they never overlap or corrupt the source, and the result is clean (no blank lines, no mis-indentation):

```
5 × <xsl:import href="common.xsl"/>   →   1 × <xsl:import href="common.xsl"/>
```

A committed `.xsl`/`.fixed.xsl` pair plus one `test/fixer.test.js` case. No production change — coverage stays at 100%.
