### PR TITLE
Add otherwise-not-last check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Add the `otherwise-not-last` check: an `xsl:otherwise` followed by another
+  branch is invalid — it is the default and must come last in its
+  `xsl:choose`. Report-only, since reordering the branches is structural
+  (#373).
+
 - Add the `when-or-otherwise-outside-choose` check: an `xsl:when` or
   `xsl:otherwise` whose parent is not `xsl:choose` is invalid XSLT that XML
   well-formedness never catches. Report-only — wrapping the branch in an

--- a/src/resources/checks/xpath/otherwise-not-last.yaml
+++ b/src/resources/checks/xpath/otherwise-not-last.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+xpath: "//xsl:otherwise[following-sibling::*]"
+severity: error
+message: "'xsl:otherwise' must be the last child of its 'xsl:choose'. Move it after every 'xsl:when'."

--- a/src/resources/motives/xpath/otherwise-not-last.md
+++ b/src/resources/motives/xpath/otherwise-not-last.md
@@ -1,0 +1,27 @@
+# Otherwise not last
+
+`xsl:otherwise` is the default branch of an `xsl:choose`, chosen only when no
+`xsl:when` matches, so it belongs last. Anything after it — another `xsl:when`,
+a second `xsl:otherwise` — is invalid: a processor rejects the misplaced
+`xsl:otherwise`, and a reader is misled into thinking a later branch can run.
+
+The check is report-only: reordering the branches so `xsl:otherwise` comes last
+is a structural move that waits on the full-fidelity parser (#228).
+
+Incorrect:
+
+```xsl
+<xsl:choose>
+  <xsl:otherwise>none</xsl:otherwise>
+  <xsl:when test="@a">a</xsl:when>
+</xsl:choose>
+```
+
+Correct:
+
+```xsl
+<xsl:choose>
+  <xsl:when test="@a">a</xsl:when>
+  <xsl:otherwise>none</xsl:otherwise>
+</xsl:choose>
+```

--- a/test/resources/xpath-packs/otherwise-not-last.yaml
+++ b/test/resources/xpath-packs/otherwise-not-last.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: otherwise-not-last
+found:
+  amount: 1
+  positions: [ [ 6, 7 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template match="/objects">
+      <xsl:choose>
+        <xsl:otherwise>
+          <p>y</p>
+        </xsl:otherwise>
+        <xsl:when test="a">
+          <p>x</p>
+        </xsl:when>
+        <xsl:when test="b">
+          <p>z</p>
+        </xsl:when>
+      </xsl:choose>
+    </xsl:template>
+  </xsl:stylesheet>


### PR DESCRIPTION
Closes #373. An `xsl:otherwise` with a following sibling is invalid — it is the `xsl:choose` default and must come last. Declarative XPath rule, severity error: `//xsl:otherwise[following-sibling::*]`. Report-only, since reordering the branches is structural (#228). One YAML + pack + motive; 450 tests, coverage 100%.