### PR TITLE
Add empty-choose check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Add the `empty-choose` check: an `xsl:choose` with no `xsl:when` is
+  degenerate — XSLT requires at least one, and a `choose` holding only an
+  `xsl:otherwise` is a wrapper that always runs. Report-only, since the fix
+  (add a `when`, or drop the `choose`) is a judgement call (#374).
+
 - Add the `otherwise-not-last` check: an `xsl:otherwise` followed by another
   branch is invalid — it is the default and must come last in its
   `xsl:choose`. Report-only, since reordering the branches is structural

--- a/src/resources/checks/xpath/empty-choose.yaml
+++ b/src/resources/checks/xpath/empty-choose.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+xpath: "//xsl:choose[not(xsl:when)]"
+severity: error
+message: "'xsl:choose' has no 'xsl:when' branch. Add one, or drop the 'xsl:choose' and keep its content directly."

--- a/src/resources/motives/xpath/empty-choose.md
+++ b/src/resources/motives/xpath/empty-choose.md
@@ -1,0 +1,25 @@
+# Empty choose
+
+An `xsl:choose` exists to pick among `xsl:when` branches, so one with no
+`xsl:when` is degenerate. XSLT requires at least one `xsl:when`, so a processor
+rejects it; and even read loosely, an `xsl:choose` holding only an
+`xsl:otherwise` is a wrapper that always runs its single branch — the
+`xsl:choose` adds nothing.
+
+The check is report-only: the fix — deleting the `xsl:choose` and keeping its
+`xsl:otherwise` content directly, or adding the missing `xsl:when` — is a
+structural change and a judgement call.
+
+Incorrect:
+
+```xsl
+<xsl:choose>
+  <xsl:otherwise>fallback</xsl:otherwise>
+</xsl:choose>
+```
+
+Correct:
+
+```xsl
+fallback
+```

--- a/test/resources/xpath-packs/empty-choose.yaml
+++ b/test/resources/xpath-packs/empty-choose.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: empty-choose
+found:
+  amount: 2
+  positions: [ [ 5, 5 ], [ 5, 5, use-single-option-for-choose ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template match="/objects">
+      <xsl:choose>
+        <xsl:otherwise>
+          <p>y</p>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-packs/use-single-option-for-choose.yaml
+++ b/test/resources/xpath-packs/use-single-option-for-choose.yaml
@@ -3,8 +3,8 @@
 ---
 pack: use-single-option-for-choose
 found:
-  amount: 1
-  positions: [ [ 5, 5 ] ]
+  amount: 2
+  positions: [ [ 5, 5, empty-choose ], [ 5, 5 ] ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">


### PR DESCRIPTION
Closes #374. An `xsl:choose` with no `xsl:when` is degenerate — XSLT requires at least one, and a `choose` holding only an `xsl:otherwise` always runs its single branch. Declarative XPath rule, severity **error**: `//xsl:choose[not(xsl:when)]`. Report-only (add a `when`, or drop the `choose` — a judgement call).

Note: a no-`when` choose already trips `use-single-option-for-choose` (`count(*)=1`) on the same node, so the two co-fire; both packs record it via the harness's length-3 positions. That overlap points at a small follow-up — `use-single-option-for-choose` mis-fires on a lone `xsl:otherwise` (its "use xsl:if" advice makes no sense with no condition), so it could be tightened to `count(xsl:when)=1`, which would make the two checks disjoint. Out of scope here.

One YAML + pack + motive; docs regenerated (60 checks); 452 tests; coverage 100%.
