### PR TITLE
Add sort-not-first check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Add the `sort-not-first` check: an `xsl:sort` that follows other content in
+  its `xsl:for-each` or `xsl:apply-templates` is invalid and silently ignored
+  by some processors. Report-only, since moving it to the front is structural
+  (#372).
+
 - Add the `empty-choose` check: an `xsl:choose` with no `xsl:when` is
   degenerate — XSLT requires at least one, and a `choose` holding only an
   `xsl:otherwise` is a wrapper that always runs. Report-only, since the fix

--- a/src/resources/checks/xpath/sort-not-first.yaml
+++ b/src/resources/checks/xpath/sort-not-first.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+xpath: "//xsl:sort[preceding-sibling::*[not(self::xsl:sort)]]"
+severity: error
+message: "'xsl:sort' must come before any other content in its 'xsl:for-each' or 'xsl:apply-templates'. Move it to the front."

--- a/src/resources/motives/xpath/sort-not-first.md
+++ b/src/resources/motives/xpath/sort-not-first.md
@@ -1,0 +1,28 @@
+# Sort not first
+
+`xsl:sort` declares the order of the sequence its `xsl:for-each` or
+`xsl:apply-templates` iterates, so it must come first, before any other
+content. One that follows other instructions is invalid: a processor rejects
+it, and some silently ignore it, so the output looks unsorted for no visible
+reason.
+
+The check is report-only: moving the `xsl:sort` to the front is a structural
+reorder that waits on the full-fidelity parser (#228).
+
+Incorrect:
+
+```xsl
+<xsl:for-each select="item">
+  <xsl:value-of select="."/>
+  <xsl:sort select="@name"/>
+</xsl:for-each>
+```
+
+Correct:
+
+```xsl
+<xsl:for-each select="item">
+  <xsl:sort select="@name"/>
+  <xsl:value-of select="."/>
+</xsl:for-each>
+```

--- a/test/resources/xpath-packs/sort-not-first.yaml
+++ b/test/resources/xpath-packs/sort-not-first.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: sort-not-first
+found:
+  amount: 1
+  positions: [ [ 7, 7 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template match="/objects">
+      <xsl:for-each select="item">
+        <xsl:value-of select="."/>
+        <xsl:sort select="@n"/>
+      </xsl:for-each>
+    </xsl:template>
+  </xsl:stylesheet>


### PR DESCRIPTION
Closes #372. An `xsl:sort` that follows other content in its `xsl:for-each`/`xsl:apply-templates` is invalid and silently ignored by some processors. Declarative XPath rule, severity error: `//xsl:sort[preceding-sibling::*[not(self::xsl:sort)]]`. Report-only, since moving it to the front is structural (#228). One YAML + pack + motive; 454 tests, coverage 100%.