### PR TITLE
Add param-after-content check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Add the `param-after-content` check: an `xsl:param` that follows real
+  content in its `xsl:template` or `xsl:function` is invalid XSLT that XML
+  well-formedness never catches (only other params and an `xsl:context-item`
+  may precede it). Report-only, since moving the param up is structural
+  (#367).
+
 - Add the `sort-not-first` check: an `xsl:sort` that follows other content in
   its `xsl:for-each` or `xsl:apply-templates` is invalid and silently ignored
   by some processors. Report-only, since moving it to the front is structural

--- a/src/resources/checks/xpath/param-after-content.yaml
+++ b/src/resources/checks/xpath/param-after-content.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+xpath: "//xsl:template/xsl:param[preceding-sibling::*[not(self::xsl:param) and not(self::xsl:context-item)]] | //xsl:function/xsl:param[preceding-sibling::*[not(self::xsl:param) and not(self::xsl:context-item)]]"
+severity: error
+message: "'xsl:param' must be declared before any other content in its 'xsl:template' or 'xsl:function'. Move it above the content."

--- a/src/resources/motives/xpath/param-after-content.md
+++ b/src/resources/motives/xpath/param-after-content.md
@@ -1,0 +1,29 @@
+# Param after content
+
+`xsl:param` declares a parameter of its `xsl:template` or `xsl:function`, so it
+must come first — before any variable, instruction, or literal result. A param
+that follows real content is invalid XSLT, which a processor rejects and XML
+well-formedness never catches, since the element is well-formed on its own.
+(An `xsl:context-item`, and other `xsl:param` siblings, are the only things
+allowed before it.)
+
+The check is report-only: moving the param ahead of the content is a
+structural reorder that waits on the full-fidelity parser (#228).
+
+Incorrect:
+
+```xsl
+<xsl:template name="t">
+  <xsl:variable name="v" select="1"/>
+  <xsl:param name="p"/>
+</xsl:template>
+```
+
+Correct:
+
+```xsl
+<xsl:template name="t">
+  <xsl:param name="p"/>
+  <xsl:variable name="v" select="1"/>
+</xsl:template>
+```

--- a/test/resources/xpath-packs/param-after-content.yaml
+++ b/test/resources/xpath-packs/param-after-content.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: param-after-content
+found:
+  amount: 1
+  positions: [ [ 6, 5 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template name="helper">
+      <xsl:variable name="count" select="1"/>
+      <xsl:param name="value"/>
+      <xsl:value-of select="$value"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-packs/template-parameter-uses-not-in-their-scope.yaml
+++ b/test/resources/xpath-packs/template-parameter-uses-not-in-their-scope.yaml
@@ -13,9 +13,9 @@ input: |-
       <xsl:param name="o2"/>
     </xsl:template>
     <xsl:template match="/objects/o/o[1]/o[1]">
+      <xsl:param name="o2"/>
       <xsl:variable name="qw" as="xs:string" select="ooo"/>
       <xsl:copy-of select="$qw"/>
-      <xsl:param name="o2"/>
       <xsl:copy-of select="$o2"/>
     </xsl:template>
   </xsl:stylesheet>

--- a/test/resources/xpath-packs/with-param-use-with-another-prefix.yaml
+++ b/test/resources/xpath-packs/with-param-use-with-another-prefix.yaml
@@ -4,15 +4,15 @@
 pack: with-param-use-in-invalid-parent-node
 found:
   amount: 1
-  positions: [ [ 6, 5 ] ]
+  positions: [ [ 7, 5 ] ]
 input: |-
   <?xml version="1.0"?>
   <xslt:stylesheet xmlns:xslt="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
     <xslt:output encoding="UTF-8" method="xml"/>
     <xslt:import href="info.xsl"/>
     <xslt:template name="writer">
-      <xslt:with-param name="surname" select="'Shakespeare'"/>
       <xslt:param name="surname"/>
+      <xslt:with-param name="surname" select="'Shakespeare'"/>
       <p>
         <xslt:value-of select="$surname"/>
       </p>


### PR DESCRIPTION
Closes #367. An `xsl:param` that follows real content in its `xsl:template` or `xsl:function` is invalid XSLT that XML well-formedness never catches — only other `xsl:param` siblings and an `xsl:context-item` may precede it. Declarative XPath rule, severity **error**. Report-only, since moving the param to the front is structural (#228).

Two existing packs (`template-parameter-uses-not-in-their-scope`, `with-param-use-with-another-prefix`) had a param declared after content only as incidental scaffolding; I reordered them so the param comes first, leaving their own checks (and positions) intact — cleaner fixtures, no co-fire.

One YAML + pack + motive; docs regenerated (62 checks); 456 tests; coverage 100%.
