### PR TITLE
Make the degenerate-choose checks disjoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Make the degenerate-`xsl:choose` checks disjoint, so each fires once with
+  the right advice: `empty-choose` on no `xsl:when`, `use-single-option-for-
+  choose` on exactly one `xsl:when` and no `xsl:otherwise` (use `xsl:if`), and
+  `use-choose-without-otherwise` on two or more `xsl:when` and no
+  `xsl:otherwise` (add one). Previously `use-single-option-for-choose` fired
+  on any one-child `choose` — including a lone `xsl:otherwise`, where its
+  advice was nonsense and it overlapped with `empty-choose` (#480).
+
 - Add the `param-after-content` check: an `xsl:param` that follows real
   content in its `xsl:template` or `xsl:function` is invalid XSLT that XML
   well-formedness never catches (only other params and an `xsl:context-item`

--- a/src/resources/checks/xpath/use-choose-without-otherwise.yaml
+++ b/src/resources/checks/xpath/use-choose-without-otherwise.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //xsl:choose[(count(xsl:otherwise) = 0)]
+xpath: "//xsl:choose[count(xsl:otherwise) = 0 and count(xsl:when) >= 2]"
 severity: warning
 message: xsl:choose has no xsl:otherwise branch. Add xsl:otherwise to handle unmatched cases explicitly.

--- a/src/resources/checks/xpath/use-single-option-for-choose.yaml
+++ b/src/resources/checks/xpath/use-single-option-for-choose.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //xsl:choose[(count(*) = 1)]
+xpath: "//xsl:choose[count(xsl:when) = 1 and not(xsl:otherwise)]"
 severity: warning
 message: xsl:choose contains only one xsl:when branch. Replace it with xsl:if.

--- a/src/resources/motives/xpath/use-choose-without-otherwise.md
+++ b/src/resources/motives/xpath/use-choose-without-otherwise.md
@@ -1,8 +1,10 @@
 # Use choose without otherwise
 
-An `xsl:choose` without an `xsl:otherwise` branch silently produces no output
-when no `xsl:when` condition matches. Add `xsl:otherwise` to handle unexpected
-values explicitly.
+An `xsl:choose` with two or more `xsl:when` branches but no `xsl:otherwise`
+silently produces no output when none of them matches. Add `xsl:otherwise` to
+handle unexpected values explicitly. (A single-`when` `choose` is better
+written as an `xsl:if` — `use-single-option-for-choose` — and one with no
+`xsl:when` at all is reported by `empty-choose`.)
 
 Incorrect:
 

--- a/src/resources/motives/xpath/use-single-option-for-choose.md
+++ b/src/resources/motives/xpath/use-single-option-for-choose.md
@@ -1,7 +1,9 @@
 # Use single option for choose
 
-An `xsl:choose` with only one `xsl:when` branch is equivalent to `xsl:if`.
-Use the simpler `xsl:if` instead.
+An `xsl:choose` with a single `xsl:when` and no `xsl:otherwise` is just an
+`xsl:if`. Use the simpler `xsl:if` instead. A `choose` that also has an
+`xsl:otherwise` is a genuine if/else and is left alone, and a `choose` with no
+`xsl:when` at all is reported by `empty-choose`, not here.
 
 Incorrect:
 

--- a/test/resources/xpath-packs/empty-choose.yaml
+++ b/test/resources/xpath-packs/empty-choose.yaml
@@ -3,8 +3,8 @@
 ---
 pack: empty-choose
 found:
-  amount: 2
-  positions: [ [ 5, 5 ], [ 5, 5, use-single-option-for-choose ] ]
+  amount: 1
+  positions: [ [ 5, 5 ] ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style1">

--- a/test/resources/xpath-packs/use-single-option-for-choose.yaml
+++ b/test/resources/xpath-packs/use-single-option-for-choose.yaml
@@ -3,17 +3,17 @@
 ---
 pack: use-single-option-for-choose
 found:
-  amount: 2
-  positions: [ [ 5, 5, empty-choose ], [ 5, 5 ] ]
+  amount: 1
+  positions: [ [ 5, 5 ] ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
     <xsl:output encoding="UTF-8" method="xml"/>
     <xsl:template match="/objects/o/o[1]/o[1]">
       <xsl:choose>
-        <xsl:otherwise>
+        <xsl:when test="@active">
           <BR/>
-        </xsl:otherwise>
+        </xsl:when>
       </xsl:choose>
     </xsl:template>
     <xsl:template match="/objects/o/o[1]/o[2]">


### PR DESCRIPTION
Closes #480. Resolves the overlap between the degenerate-`xsl:choose` checks by making them a **disjoint partition**, each firing once with the right advice:

| Check | Fires on | Advice |
|-------|----------|--------|
| `empty-choose` | no `xsl:when` | add a `when`, or drop the `choose` |
| `use-single-option-for-choose` | exactly one `xsl:when`, no `xsl:otherwise` | use `xsl:if` |
| `use-choose-without-otherwise` | two or more `xsl:when`, no `xsl:otherwise` | add an `xsl:otherwise` |

Before, `use-single-option-for-choose` matched `count(*) = 1` — any one-child choose, **including a lone `xsl:otherwise`**, where "use `xsl:if`" is nonsense (no condition) and it double-reported with `empty-choose` (#374). Tightening it to `count(xsl:when) = 1 and not(xsl:otherwise)` fixed that but left it a subset of `use-choose-without-otherwise` (which matched *any* no-otherwise choose), so I also tightened that to `>= 2` whens. Now every degenerate choose is caught by exactly one check.

Rules, packs, and motives updated for both; a lone-`when` choose is now correctly routed to `use-single-option` (better advice) instead of "add otherwise". 456 tests, coverage 100%.
