### PR TITLE
Run the whole test suite under Stryker and set a mutation break threshold

### DIFF
--- a/stryker.config.json
+++ b/stryker.config.json
@@ -7,6 +7,11 @@
     "html"
   ],
   "coverageAnalysis": "perTest",
+  "thresholds": {
+    "high": 80,
+    "low": 60,
+    "break": 60
+  },
   "mutate": [
     "src/**/*.js",
     "!src/xslint.js",
@@ -15,12 +20,7 @@
   ],
   "mochaOptions": {
     "spec": [
-      "test/tokens.test.js",
-      "test/xpath-linter.test.js",
-      "test/corpus-linter.test.js",
-      "test/xpath-validator.test.js",
-      "test/xsl-validator.test.js",
-      "test/xpath-format-linter.test.js"
+      "test/**/*.test.js"
     ]
   }
 }


### PR DESCRIPTION
Closes #504.

`stryker.config.json` mutated all of `src/` but its `mochaOptions.spec` listed only six of the thirty test files, so mutants injected into the other ~15 linters could never be killed — the mutation score was misleadingly low and gave no signal for most of the codebase. There was also no `thresholds.break`, so nothing failed on a regression.

The spec is now `test/**/*.test.js`. Because `coverageAnalysis` is already `perTest`, Stryker still runs only the tests that cover each mutant, so the added files bring kill power without rerunning irrelevant tests per mutant.

Measured over the full suite, the mutation score is **69%**. A `thresholds` block now guards it — `break: 60` (below the measured score, with headroom for timeout-mutant variance on a slower CI runner), plus `80`/`60` reporting bands. The floor can be raised as the suite's mutation coverage improves (the weakest modules — `fixers.js`, `fixes.js`, `name`/`string-length`/`result-namespace` linters — lack dedicated unit tests and are candidates for follow-up).

`mutation.yml` is scheduled weekly + manual dispatch, so this does not change PR latency.