### PR TITLE
Require a test for every format and validation check in conformance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ The `--fix` behavior of every fixable check is covered end-to-end in `test/fixer
 
 ## Adding a New Rule
 
-Rule names are kebab-case with no `template-match-` (or other noise) prefix. Every rule needs a motive and at least one test pack. `test/conformance.test.js` enforces all three across `xpath` and `corpus` (naming and motives are enforced for `validation` and `format` too), so a rule that misnames itself, drops its motive, or ships without a pack fails the build.
+Rule names are kebab-case with no `template-match-` (or other noise) prefix. Every rule needs a motive and at least one test. `test/conformance.test.js` enforces naming and motives across all four kinds, and pack/test coverage for each: an `xpath`/`corpus` check needs a pack in its own `*-packs` dir; a `format` check needs a pack whose `pack:` field matches its name *somewhere* under `test/resources` (its packs are scattered across the per-linter dirs); and a `validation` check needs its name to appear in some `*.test.js` (it is tested by a bespoke harness, not a name-matching pack). So a rule that misnames itself, drops its motive, or ships with no test fails the build.
 
 Per-file rule:
 1. Create `src/resources/checks/xpath/<rule-name>.yaml` with `xpath`, `severity`, `message`.

--- a/test/conformance.test.js
+++ b/test/conformance.test.js
@@ -33,8 +33,11 @@ const RESOURCES = path.resolve(__dirname, 'resources')
 const KINDS = ['xpath', 'corpus', 'validation', 'format']
 
 /**
- * Kinds authored as rules, paired with the directory holding their packs. The
- * validation and format checks are code-driven and tested elsewhere.
+ * Rule kinds paired with the one directory holding their packs. The code-driven
+ * kinds are enforced separately: a format check's packs are scattered across
+ * the per-linter directories (so it is matched by `pack:` name across them),
+ * and a validation check is tested by a bespoke harness (so it is matched by
+ * its name appearing in a test file).
  * @type {{[kind: string]: string}}
  */
 const PACKED = {xpath: 'xpath-packs', corpus: 'corpus-packs'}
@@ -88,6 +91,25 @@ describe('conformance', function() {
       for (const name of names(kind)) {
         assert.ok(packed.has(name), `${kind}/${name} has no test pack`)
       }
+    }
+  })
+  it('gives every format check a test pack somewhere', function() {
+    const packed = new Set(
+      allFilesFrom(RESOURCES)
+        .filter((file) => file.endsWith('.yaml'))
+        .map((file) => yaml.parsedFromFile(file).pack),
+    )
+    for (const name of names('format')) {
+      assert.ok(packed.has(name), `format/${name} has no test pack`)
+    }
+  })
+  it('tests every validation check by name in a test file', function() {
+    const suite = allFilesFrom(path.resolve(__dirname))
+      .filter((file) => file.endsWith('.test.js'))
+      .map((file) => fs.readFileSync(file, 'utf-8'))
+      .join('\n')
+    for (const name of names('validation')) {
+      assert.ok(suite.includes(name), `validation/${name} is tested nowhere`)
     }
   })
   it('maps every motive and pack back to a real check', function() {


### PR DESCRIPTION
Closes #507.

`conformance.test.js` enforced "every rule has a test pack" only for `PACKED = {xpath, corpus}`, so a new `format` or `validation` check could ship with a motive but no test — the only backstop was the 100% coverage gate forcing *some* test to touch the code, not that the check itself is exercised.

Two new assertions close that:

- **format** — every format check must have a pack whose `pack:` field equals its name, matched *anywhere* under `test/resources` (a format check's packs live in the scattered per-linter dirs, e.g. `count-compared-to-zero` in `count-packs/`, not a single `format-packs/`).
- **validation** — every validation check must be named in some `*.test.js` (`malformed-stylesheet` and `invalid-xpath-expression` are tested by bespoke harnesses with descriptive pack names / inline sources, not a name-matching pack).

All 14 format checks and both validators already satisfy this, so the build stays green; the guard bites only when a future check ships testless. Full suite, 100% coverage, and ESLint pass. CLAUDE.md updated.