### PR TITLE
Run ESLint before the tests in the default grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,5 +27,5 @@ module.exports = function(grunt) {
   grunt.registerTask('docs', 'Generate documentation site', function() {
     require('./scripts/generate-docs')
   })
-  grunt.registerTask('default', ['mochacli', 'eslint'])
+  grunt.registerTask('default', ['eslint', 'mochacli'])
 }


### PR DESCRIPTION
Closes #511.

`Gruntfile.js` registered the default task as `['mochacli', 'eslint']`, and grunt stops at the first failing task — so a lint-only regression was masked whenever a test also failed. `npm test` (used locally and by `daily.yml`/`release.yml`) inherited that ordering.

Reordered to `['eslint', 'mochacli']`. ESLint is fast and deterministic, so running it first costs nothing and guarantees a lint regression surfaces even when tests fail. (In the `grunt` CI workflow, lint and tests are already separate jobs since #509; this fixes the `npm test` path.)