### PR TITLE
Fire function-use-in-xslt-1 on any non-2.0/3.0 stylesheet

### DIFF
--- a/src/resources/checks/xpath/function-use-in-xslt-1.yaml
+++ b/src/resources/checks/xpath/function-use-in-xslt-1.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: /xsl:stylesheet[@version="1.0"]//xsl:function
+xpath: "//xsl:function[not(/*/@version = '2.0' or /*/@version = '3.0')]"
 severity: error
-message: "'xsl:function' is declared in XSLT version 1.0. Use a named template or upgrade the stylesheet version to 2.0 instead."
+message: "'xsl:function' requires XSLT 2.0 or later, but this stylesheet is not version 2.0 or 3.0. Use a named template, or set the version to 2.0."

--- a/src/resources/motives/xpath/function-use-in-xslt-1.md
+++ b/src/resources/motives/xpath/function-use-in-xslt-1.md
@@ -1,35 +1,41 @@
-# Function use in XSLT version 1.0
+# Function use in a pre-2.0 stylesheet
 
-`xsl:function` does not exist in XSLT 1.0. Use a `xsl:template` with `name` attribute 
-or upgrade the stylesheet version to 2.0.
+`xsl:function` was introduced in XSLT 2.0. A stylesheet that declares
+`version="1.0"` (or `1.1`, or no version at all) but defines an `xsl:function`
+cannot run on a 1.0 processor — the instruction does not exist there. The check
+fires whenever the root — `xsl:stylesheet` or `xsl:transform` — is not
+`version="2.0"` or `version="3.0"`, so an unversioned or `1.1` stylesheet is
+caught too, not only an explicit `1.0`.
+
+Either replace the function with an `xsl:template` that has a `name`, or raise
+the stylesheet to `version="2.0"`.
 
 Incorrect:
 
 ```xsl
-  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
-    <xsl:output encoding="UTF-8" method="xml"/>
-    <xsl:function name="my:foo">
-      <!-- body logic -->
-    </xsl:function>
-  </xsl:stylesheet>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:function name="my:foo">
+    <!-- body logic -->
+  </xsl:function>
+</xsl:stylesheet>
 ```
 
 Correct:
 
 ```xsl
-  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
-    <xsl:output encoding="UTF-8" method="xml"/>
-    <xsl:template name="foo">
-      <!-- body logic -->
-    </xsl:template>
-  </xsl:stylesheet>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:template name="foo">
+    <!-- body logic -->
+  </xsl:template>
+</xsl:stylesheet>
 ```
+
 or:
+
 ```xsl
-  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
-    <xsl:output encoding="UTF-8" method="xml"/>
-    <xsl:function name="my:foo">
-      <!-- body logic -->
-    </xsl:function>
-  </xsl:stylesheet>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:function name="my:foo">
+    <!-- body logic -->
+  </xsl:function>
+</xsl:stylesheet>
 ```

--- a/test/resources/xpath-packs/function-in-transform-root.yaml
+++ b/test/resources/xpath-packs/function-in-transform-root.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: function-use-in-xslt-1
+found:
+  amount: 1
+  positions: [ [ 3, 3 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:my="urn:my" version="1.0">
+    <xsl:function name="my:calc">
+      <xsl:sequence select="1"/>
+    </xsl:function>
+  </xsl:transform>

--- a/test/resources/xpath-packs/function-in-unversioned-stylesheet.yaml
+++ b/test/resources/xpath-packs/function-in-unversioned-stylesheet.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: function-use-in-xslt-1
+found:
+  amount: 2
+  positions: [ [ 3, 3 ], [ 2, 1, missing-version-in-stylesheet ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:my="urn:my" id="s">
+    <xsl:function name="my:calc">
+      <xsl:sequence select="1"/>
+    </xsl:function>
+  </xsl:stylesheet>

--- a/test/resources/xpath-packs/function-in-xslt-2-0.yaml
+++ b/test/resources/xpath-packs/function-in-xslt-2-0.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: function-use-in-xslt-1
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:my="urn:my" version="2.0" id="s">
+    <xsl:function name="my:calc">
+      <xsl:sequence select="1"/>
+    </xsl:function>
+  </xsl:stylesheet>


### PR DESCRIPTION
Closes #532.

`function-use-in-xslt-1` keyed on `/xsl:stylesheet[@version="1.0"]//xsl:function`. `xsl:function` is a 2.0+ instruction, so declaring one where the stylesheet isn't 2.0/3.0 is the error — but the exact `@version="1.0"` + `/xsl:stylesheet` predicate missed real violations: an **unversioned** stylesheet, a `version="1.1"` one, and any `xsl:transform`-rooted sheet.

The selector is now:

```
//xsl:function[not(/*/@version = '2.0' or /*/@version = '3.0')]
```

`/*` matches either root (`xsl:stylesheet` or `xsl:transform`), and the predicate fires whenever the version isn't `2.0`/`3.0` — covering `1.0`, `1.1`, and unversioned — while leaving a genuine 2.0/3.0 function alone. Message and motive are generalised from "version 1.0" to "not 2.0/3.0" (per the #530 motive rule).

New packs cover the `xsl:transform` root, the unversioned stylesheet (whose unavoidable `missing-version` co-fire is expressed as a 3-element position), and a `2.0` negative that must stay silent. Full suite, 100% coverage, ESLint, and xcop stay green.