### PR TITLE
Stop empty-variable flagging a typed empty sequence

### DIFF
--- a/src/resources/checks/xpath/empty-variable.yaml
+++ b/src/resources/checks/xpath/empty-variable.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //xsl:variable[not(@select) and not(node())]
+xpath: //xsl:variable[not(@select) and not(node()) and not(@as)]
 severity: warning
 message: An empty xsl:variable binds the empty string for no reason. Give it a @select or some content, or remove it.

--- a/src/resources/motives/xpath/empty-variable.md
+++ b/src/resources/motives/xpath/empty-variable.md
@@ -5,6 +5,12 @@ sequence constructor inside it. With neither, the variable binds to an empty
 string — almost always a mistake, and at best a confusing way to declare an
 empty value. State the value explicitly or drop the declaration.
 
+A variable that declares a type with `@as` is a different case and is not
+flagged: `<xsl:variable name="acc" as="node()*"/>` in XSLT 2.0 or 3.0 binds the
+empty *sequence* of that type on purpose — a deliberate empty accumulator, not
+an accidental empty string. The `@as` attribute only exists in 2.0/3.0, so its
+presence is the signal that the emptiness is intentional.
+
 Incorrect:
 
 ```xsl
@@ -21,4 +27,10 @@ or:
 
 ```xsl
 <xsl:variable name="greeting">hello</xsl:variable>
+```
+
+Also correct — a typed empty sequence:
+
+```xsl
+<xsl:variable name="acc" as="node()*"/>
 ```

--- a/test/resources/xpath-packs/empty-variable.yaml
+++ b/test/resources/xpath-packs/empty-variable.yaml
@@ -17,4 +17,8 @@ input: |-
       <xsl:variable name="qw"/>
       <xsl:copy-of select="$qw"/>
     </xsl:template>
+    <xsl:template match="/objects/o/o[1]/o[3]">
+      <xsl:variable name="acc" as="node()*"/>
+      <xsl:copy-of select="$acc"/>
+    </xsl:template>
   </xsl:stylesheet>


### PR DESCRIPTION
`empty-variable` flags `//xsl:variable[not(@select) and not(node())]` — a variable with neither a `@select` nor content, which binds the empty string. But a variable that declares a type is a different case: `<xsl:variable name="acc" as="node()*"/>` in XSLT 2.0/3.0 binds the empty *sequence* of that type on purpose (a deliberate empty accumulator), and the check was reporting it as an accidental empty string.

Exclude `not(@as)`:

```yaml
xpath: //xsl:variable[not(@select) and not(node()) and not(@as)]
```

The `@as` attribute exists only in 2.0/3.0, so its presence is itself the signal that the emptiness is intentional — no separate version gate is needed. The motive gains the typed-empty-sequence case, and the pack a negative neighbour that must stay silent.

This addresses the `empty-variable`/`@as` item of #499; the rest of that tracker's opinionated-check decisions remain open.