### PR TITLE
Gate the empty-variable @as exclusion on XSLT 2.0/3.0

### DIFF
--- a/src/resources/checks/xpath/empty-variable.yaml
+++ b/src/resources/checks/xpath/empty-variable.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //xsl:variable[not(@select) and not(node()) and not(@as)]
+xpath: //xsl:variable[not(@select) and not(node()) and not(@as and (/*/@version = '2.0' or /*/@version = '3.0'))]
 severity: warning
 message: An empty xsl:variable binds the empty string for no reason. Give it a @select or some content, or remove it.

--- a/src/resources/motives/xpath/empty-variable.md
+++ b/src/resources/motives/xpath/empty-variable.md
@@ -6,10 +6,12 @@ string — almost always a mistake, and at best a confusing way to declare an
 empty value. State the value explicitly or drop the declaration.
 
 A variable that declares a type with `@as` is a different case and is not
-flagged: `<xsl:variable name="acc" as="node()*"/>` in XSLT 2.0 or 3.0 binds the
-empty *sequence* of that type on purpose — a deliberate empty accumulator, not
-an accidental empty string. The `@as` attribute only exists in 2.0/3.0, so its
-presence is the signal that the emptiness is intentional.
+flagged **in XSLT 2.0 or 3.0**: `<xsl:variable name="acc" as="node()*"/>` binds
+the empty *sequence* of that type on purpose — a deliberate empty accumulator,
+not an accidental empty string. The exclusion is version-scoped: in XSLT 1.0
+`@as` is not a recognized attribute, so it is inert and the variable still binds
+the empty string. A `1.0` stylesheet with an empty `@as` variable is therefore
+still flagged — the `@as` does not do what its author expects.
 
 Incorrect:
 
@@ -29,7 +31,7 @@ or:
 <xsl:variable name="greeting">hello</xsl:variable>
 ```
 
-Also correct — a typed empty sequence:
+Also correct — a typed empty sequence in XSLT 2.0 or 3.0:
 
 ```xsl
 <xsl:variable name="acc" as="node()*"/>

--- a/test/resources/xpath-packs/empty-variable-in-xslt-1-0.yaml
+++ b/test/resources/xpath-packs/empty-variable-in-xslt-1-0.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: empty-variable
+found:
+  amount: 1
+  positions: [ [ 5, 5 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template match="/objects/o">
+      <xsl:variable name="acc" as="node()*"/>
+      <xsl:copy-of select="$acc"/>
+    </xsl:template>
+  </xsl:stylesheet>


### PR DESCRIPTION
A follow-up to #540. That change excluded `@as` from `empty-variable` unconditionally, but the exclusion's whole premise — a typed empty sequence is a deliberate empty accumulator — holds only under XSLT 2.0/3.0 semantics. In XSLT 1.0, `@as` is not a recognized attribute: it is inert, so `<xsl:variable name="acc" as="node()*"/>` still binds the empty string and is a genuine empty-variable defect. The unconditional exclusion silenced it.

Gate the exclusion on the stylesheet version, read root-robustly so an `xsl:transform` root works too:

```yaml
xpath: //xsl:variable[not(@select) and not(node()) and not(@as and (/*/@version = '2.0' or /*/@version = '3.0'))]
```

Now: a 2.0/3.0 typed empty sequence stays silent (deliberate), a 2.0/3.0 or 1.0 untyped empty variable fires, and a 1.0 variable whose `@as` is inert fires again. The motive states the exclusion is version-scoped, and a new 1.0 pack proves the inert-`@as` case is still flagged.
