### PR TITLE
Flag XSLT 2.0 constructs used in a version=1.0 stylesheet

### DIFF
--- a/src/resources/checks/xpath/modern-construct-in-xslt-1.yaml
+++ b/src/resources/checks/xpath/modern-construct-in-xslt-1.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+xpath: "(/xsl:stylesheet | /xsl:transform)[@version = '1.0']//(xsl:for-each-group | xsl:sequence | xsl:analyze-string | xsl:next-match | xsl:perform-sort | xsl:namespace | xsl:character-map | xsl:result-document | xsl:import-schema | xsl:*[@as])"
+severity: error
+message: "This XSLT 2.0 construct is used in a stylesheet declared version 1.0, which a conformant 1.0 processor rejects. Use a 1.0 equivalent, or set the version to 2.0."

--- a/src/resources/motives/xpath/modern-construct-in-xslt-1.md
+++ b/src/resources/motives/xpath/modern-construct-in-xslt-1.md
@@ -1,0 +1,53 @@
+# Modern construct in a 1.0 stylesheet
+
+A stylesheet that declares `version="1.0"` must run on an XSLT 1.0 processor,
+where the instructions and syntax introduced in XSLT 2.0 simply do not exist. A
+1.0 processor (or Saxon-HE in 1.0 mode) rejects them, so a declared-1.0
+stylesheet that reaches for a 2.0 construct is a real portability bug — it will
+not run where its own version attribute promises it will.
+
+This check flags a curated set of 2.0-only XSLT **instructions** —
+`xsl:for-each-group`, `xsl:sequence`, `xsl:analyze-string`, `xsl:next-match`,
+`xsl:perform-sort`, `xsl:namespace`, `xsl:character-map`, `xsl:result-document`,
+`xsl:import-schema` — and the 2.0 **`as` sequence-type attribute** on any XSLT
+element, whenever the stylesheet root (`xsl:stylesheet` or `xsl:transform`)
+declares `version="1.0"`. Only elements in the XSLT namespace are examined for
+`@as`, so a literal result element that legitimately carries an `as` attribute —
+`<link rel="preload" as="script"/>` in HTML output — is never mistaken for the
+sequence-type attribute.
+
+`xsl:function` is deliberately left out: it has its own check,
+`function-use-in-xslt-1`, which also catches an unversioned or `1.1` stylesheet.
+The 2.0 functions and operators that live *inside* XPath expressions
+(`lower-case()`, `matches()`, `||`, `if/then/else`, `*:name`) are not flagged
+yet — telling a reserved 2.0 built-in from a user-namespaced call needs
+token-aware parsing, which waits on the full-fidelity parser (#228).
+
+Either rewrite the construct with its 1.0 equivalent — a Muenchian grouping key
+for `xsl:for-each-group`, a named template for `xsl:sequence` — or raise the
+stylesheet to `version="2.0"`. Because that rewrite is structural, this check
+reports without a `--fix`.
+
+Incorrect:
+
+```xsl
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:template match="/objects">
+    <xsl:for-each-group select="*" group-by="@key">
+      <xsl:sequence select="current-group()"/>
+    </xsl:for-each-group>
+  </xsl:template>
+</xsl:stylesheet>
+```
+
+Correct:
+
+```xsl
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:template match="/objects">
+    <xsl:for-each-group select="*" group-by="@key">
+      <xsl:sequence select="current-group()"/>
+    </xsl:for-each-group>
+  </xsl:template>
+</xsl:stylesheet>
+```

--- a/test/resources/xpath-packs/empty-variable-in-xslt-1-0.yaml
+++ b/test/resources/xpath-packs/empty-variable-in-xslt-1-0.yaml
@@ -3,8 +3,8 @@
 ---
 pack: empty-variable
 found:
-  amount: 1
-  positions: [ [ 5, 5 ] ]
+  amount: 2
+  positions: [ [ 5, 5 ], [ 5, 5, modern-construct-in-xslt-1 ] ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" id="style1">

--- a/test/resources/xpath-packs/function-in-transform-root.yaml
+++ b/test/resources/xpath-packs/function-in-transform-root.yaml
@@ -3,8 +3,8 @@
 ---
 pack: function-use-in-xslt-1
 found:
-  amount: 1
-  positions: [ [ 3, 3 ] ]
+  amount: 2
+  positions: [ [ 3, 3 ], [ 4, 5, modern-construct-in-xslt-1 ] ]
 input: |-
   <?xml version="1.0"?>
   <xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:my="urn:my" version="1.0" id="fn">

--- a/test/resources/xpath-packs/function-use-in-xslt-1.yaml
+++ b/test/resources/xpath-packs/function-use-in-xslt-1.yaml
@@ -3,8 +3,8 @@
 ---
 pack: function-use-in-xslt-1
 found:
-  amount: 1
-  positions: [ [ 4, 3 ] ]
+  amount: 2
+  positions: [ [ 4, 3 ], [ 6, 5, modern-construct-in-xslt-1 ] ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" id="style1">

--- a/test/resources/xpath-packs/literal-as-in-xslt-1.yaml
+++ b/test/resources/xpath-packs/literal-as-in-xslt-1.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: modern-construct-in-xslt-1
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" id="s">
+    <xsl:output encoding="UTF-8" method="html"/>
+    <xsl:template match="/objects">
+      <link rel="preload" as="script"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-packs/modern-construct-in-xslt-1.yaml
+++ b/test/resources/xpath-packs/modern-construct-in-xslt-1.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: modern-construct-in-xslt-1
+found:
+  amount: 4
+  positions: [ [ 5, 5 ], [ 6, 5 ], [ 7, 7 ], [ 9, 5 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" id="s">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template match="/objects">
+      <xsl:variable name="items" as="node()*" select="*"/>
+      <xsl:for-each-group select="$items" group-by="@key">
+        <xsl:sequence select="current-group()"/>
+      </xsl:for-each-group>
+      <xsl:analyze-string select="text()" regex="[0-9]+">
+        <xsl:matching-substring>
+          <hit/>
+        </xsl:matching-substring>
+      </xsl:analyze-string>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-packs/modern-construct-in-xslt-2-0.yaml
+++ b/test/resources/xpath-packs/modern-construct-in-xslt-2-0.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: modern-construct-in-xslt-1
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template match="/objects">
+      <xsl:variable name="items" as="node()*" select="*"/>
+      <xsl:for-each-group select="$items" group-by="@key">
+        <xsl:sequence select="current-group()"/>
+      </xsl:for-each-group>
+      <xsl:analyze-string select="text()" regex="[0-9]+">
+        <xsl:matching-substring>
+          <hit/>
+        </xsl:matching-substring>
+      </xsl:analyze-string>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/xpath-packs/stylesheet-has-templates.yaml
+++ b/test/resources/xpath-packs/stylesheet-has-templates.yaml
@@ -7,7 +7,7 @@ found:
   positions: [ ]
 input: |-
   <?xml version="1.0"?>
-  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0" id="style1">
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
     <xsl:output encoding="UTF-8" method="xml"/>
     <xsl:template match="/objects/o/o[1]/o[1]">
       <xsl:copy-of select="."/>


### PR DESCRIPTION
Closes #533. `function-use-in-xslt-1` was the *only* check flagging a 2.0+ construct in a declared-1.0 stylesheet, so other 2.0-only constructs were silently accepted — a real portability bug, since a conformant 1.0 processor rejects them and the XPath validator can't catch them (it compiles under a 3.1 engine by design, so 1.0 numeric coercion isn't a false positive).

The new `modern-construct-in-xslt-1` check flags, on a `version="1.0"` root, a curated set of 2.0 instructions plus the `as` sequence-type attribute:

```yaml
xpath: "(/xsl:stylesheet | /xsl:transform)[@version = '1.0']//(xsl:for-each-group | xsl:sequence | xsl:analyze-string | xsl:next-match | xsl:perform-sort | xsl:namespace | xsl:character-map | xsl:result-document | xsl:import-schema | xsl:*[@as])"
```

Deliberate scope decisions:

- **Only `xsl:`-namespace elements are examined for `@as`**, so a literal result element that legitimately carries one — `<link rel="preload" as="script"/>` in HTML output — is never a false positive. A pack proves this.
- **`xsl:function` is left to `function-use-in-xslt-1`** (which also catches unversioned/`1.1`), so the two checks don't double-flag.
- **The 2.0 functions/operators inside XPath** (`lower-case()`, `||`, `if/then/else`, `*:name`) are not flagged — telling a reserved built-in from a user-namespaced call needs token-aware parsing, which waits on the full-fidelity parser (#228). The motive says so.
- **Report-only**, since rewriting a 2.0 construct to its 1.0 equivalent is structural.

Three packs cover it (a 1.0 sheet firing on four constructs, a 2.0 sheet that stays silent, the literal-`as` guard). Four existing 1.0-with-2.0-construct fixtures record the new co-fire, except `stylesheet-has-templates` whose incidental `@as` scaffolding moves to `version="2.0"`.