### PR TITLE
Hoist the version guard out of function-use-in-xslt-1's predicate

### DIFF
--- a/src/resources/checks/xpath/function-use-in-xslt-1.yaml
+++ b/src/resources/checks/xpath/function-use-in-xslt-1.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: "//xsl:function[not(/*/@version = '2.0' or /*/@version = '3.0')]"
+xpath: "/*[not(@version = '2.0' or @version = '3.0')]//xsl:function"
 severity: error
 message: "'xsl:function' requires XSLT 2.0 or later, but this stylesheet is not version 2.0 or 3.0. Use a named template, or set the version to 2.0."


### PR DESCRIPTION
Closes #544. From the audit of every declarative selector, one clean "switch the root and non-root parts" optimization.

`function-use-in-xslt-1` read the whole-document `/*/@version` inside every `xsl:function`'s predicate:

```yaml
xpath: "//xsl:function[not(/*/@version = '2.0' or /*/@version = '3.0')]"
```

Because the version gates the entire rule (a single regime — it fires only when the root is not 2.0/3.0), it hoists to the root step, read once, and the `//xsl:function` subtree is skipped entirely on a 2.0/3.0 stylesheet:

```yaml
xpath: "/*[not(@version = '2.0' or @version = '3.0')]//xsl:function"
```

Verified equivalent across every case (1.0, 2.0, 3.0, unversioned, `xsl:transform` root, multiple functions) with the same reported node, so the packs are untouched. The `/*` root step is inherently root-name-agnostic, so it stays `xsl:transform`-robust without the explicit union the root checks need.

This hoist is clean only because the guard gates the whole rule. `empty-variable`, where the version gates just the `@as` sub-clause, keeps its guard nested on purpose — hoisting it would need a two-branch union with a duplicated predicate.