### PR TITLE
Freeze audited checks behind a mature marker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,33 @@ Then run `npm test`, `npm run coverage`, and `npx grunt docs`.
   usage, the `--fix`/suggestion lists), this file (architecture), and the docs
   site (`npx grunt docs`).
 
+### Maturity (`mature: true`)
+
+A check that has passed a full maturity audit carries `mature: true` in its
+YAML. It is *frozen*: do not re-audit or churn it, and change its behavior only
+by first removing the flag — a "perfect" check that changes must re-earn the
+mark. A check is mature only when it meets every bar below; the last three are a
+human attestation the flag records, the rest are visible in the tree:
+
+- no false positive and no false negative (non-`xsl` prefixes, both roots, every
+  version, the construct buried / 3+ times / beside a lookalike negative);
+- the motive fully teaches it (see **Motive quality**);
+- if fixable, the fix is implemented, correctly tiered, and tested — otherwise it
+  is report-only *by nature* (no safe deterministic fix can exist) and says so, a
+  fix merely deferred to a future capability (#228, #486, #461, #460) does not
+  qualify;
+- the pack exercises the hard cases (see **Test packs**);
+- version-dependence handled wherever the construct or fix needs it;
+- the selector is optimal (no needless `//`, no `name()=`/`local-name()` where a
+  namespace-bound node test works);
+- it does not overlap another check.
+
+`test/conformance.test.js` enforces the machine-checkable floor for a `mature`
+check: its motive carries an `Incorrect:`/`Correct:` pair, and if it is fixable
+(a `src/fixers.js` entry or a `test/resources/fix/<name>.xsl` fixture) that
+fixture pair exists and `fixer.test.js` runs it. The opinionated checks tracked
+in #499 are not marked mature until that issue is settled.
+
 ## Test packs
 
 Each linter owns a `test/resources/<name>-packs/` directory, auto-discovered by
@@ -273,5 +300,5 @@ the harness asserts too.
 | `src/helpers.js` | XML parsing (expands internal-subset entities), YAML parsing, file recursion |
 | `src/logger.js` | 4-level logger |
 | `scripts/generate-docs.js` | Builds the `docs/` site from checks + motives |
-| `test/conformance.test.js` | Enforces naming, motives, and pack/test coverage across all kinds |
+| `test/conformance.test.js` | Enforces naming, motives, pack/test coverage, and the `mature` freeze across all kinds |
 | `test/xcop.test.js` | Runs xcop over the inline XSL of every `*-packs` directory |

--- a/src/resources/checks/format/count-compared-to-zero.yaml
+++ b/src/resources/checks/format/count-compared-to-zero.yaml
@@ -3,3 +3,4 @@
 ---
 severity: warning
 message: count(...) is compared with 0 to test existence, which walks the whole sequence. Test existence directly instead (exists()/empty() on XSLT 2.0+, boolean()/not() on 1.0).
+mature: true

--- a/src/resources/checks/format/predicate-position-literal.yaml
+++ b/src/resources/checks/format/predicate-position-literal.yaml
@@ -3,3 +3,4 @@
 ---
 severity: warning
 message: A positional predicate is written the long way; [position() = N] is just [N] and [position() = last()] is just [last()]. Shorten it.
+mature: true

--- a/src/resources/checks/format/redundant-double-negation.yaml
+++ b/src/resources/checks/format/redundant-double-negation.yaml
@@ -3,3 +3,4 @@
 ---
 severity: warning
 message: A double negation not(not(x)) is redundant; it is just boolean(x), and in a test simply x. Replace it.
+mature: true

--- a/src/resources/checks/format/string-length-compared-to-zero.yaml
+++ b/src/resources/checks/format/string-length-compared-to-zero.yaml
@@ -3,3 +3,4 @@
 ---
 severity: warning
 message: string-length(...) is compared with 0 to test emptiness, which measures the whole string. Compare the value with '' instead.
+mature: true

--- a/src/resources/checks/validation/invalid-xpath-expression.yaml
+++ b/src/resources/checks/validation/invalid-xpath-expression.yaml
@@ -3,3 +3,4 @@
 ---
 severity: error
 message: An XPath expression is malformed and cannot be parsed. Fix its syntax.
+mature: true

--- a/src/resources/checks/validation/malformed-stylesheet.yaml
+++ b/src/resources/checks/validation/malformed-stylesheet.yaml
@@ -3,3 +3,4 @@
 ---
 severity: error
 message: The stylesheet is not well-formed XML and cannot be parsed. Fix its syntax.
+mature: true

--- a/test/conformance.test.js
+++ b/test/conformance.test.js
@@ -4,6 +4,7 @@
  */
 
 const {allFilesFrom, yaml} = require('../src/helpers')
+const {FIXERS} = require('../src/fixers')
 const path = require('path')
 const fs = require('fs')
 const assert = require('assert')
@@ -78,6 +79,40 @@ describe('conformance', function() {
           fs.existsSync(path.join(MOTIVES, kind, `${name}.md`)),
           `${kind}/${name} has no motive`,
         )
+      }
+    }
+  })
+  it('freezes every mature check behind a complete motive and working fix', function() {
+    const fixerSuite = fs.readFileSync(
+      path.join(__dirname, 'fixer.test.js'), 'utf-8',
+    )
+    for (const kind of KINDS) {
+      for (const name of names(kind)) {
+        const check = yaml.parsedFromFile(
+          path.join(CHECKS, kind, `${name}.yaml`),
+        )
+        if (check.mature !== true) {
+          continue
+        }
+        const motive = fs.readFileSync(
+          path.join(MOTIVES, kind, `${name}.md`), 'utf-8',
+        )
+        assert.ok(
+          /^Incorrect/im.test(motive) && /^Correct/im.test(motive),
+          `mature ${kind}/${name} has no Incorrect/Correct example in its motive`,
+        )
+        const before = path.join(RESOURCES, 'fix', `${name}.xsl`)
+        if (Object.hasOwn(FIXERS, name) || fs.existsSync(before)) {
+          assert.ok(
+            fs.existsSync(before) &&
+              fs.existsSync(path.join(RESOURCES, 'fix', `${name}.fixed.xsl`)),
+            `mature ${kind}/${name} is fixable but has no fix fixture pair`,
+          )
+          assert.ok(
+            fixerSuite.includes(name),
+            `mature ${kind}/${name} is fixable but fixer.test.js never runs it`,
+          )
+        }
       }
     }
   })


### PR DESCRIPTION
Eight checks have now passed a full maturity audit — no false positive or negative, a complete motive, a working fix or report-only-by-nature status, rich test packs, correct version handling, an optimal selector, and no overlap. They carry `mature: true` and are frozen.

Six were mature as-is: `count-compared-to-zero`, `string-length-compared-to-zero`, `predicate-position-literal`, `redundant-double-negation`, `invalid-xpath-expression`, `malformed-stylesheet`.

Two were brought up to the bar in this PR: `empty-choose` gains a richer pack (three occurrences, two buried in `xsl:if`/`xsl:for-each`, plus a valid `choose`-with-`when` negative neighbour), and `variable-or-param-with-select-and-content` drops the `count(*) > 0` anti-pattern from its selector in favour of `*` and states its report-only tier in the motive.

A new conformance test enforces the machine-checkable floor for any mature check — its motive must carry an `Incorrect:`/`Correct:` pair, and if it is fixable the fix fixture pair must exist and `fixer.test.js` must run it:

```js
if (check.mature !== true) {
  continue
}
assert.ok(
  /^Incorrect/im.test(motive) && /^Correct/im.test(motive),
  `mature ${kind}/${name} has no Incorrect/Correct example in its motive`,
)
```

The semantic criteria (no FP/FN, optimal selector, no overlap) stay a human attestation the flag records; CLAUDE.md documents the bar and the freeze under "Maturity". Every other check's remaining gap is tracked separately — the opinionated set in #499, new per-check findings in #553-#567, thin packs in #567, and motive tiers in #551/#552.

Closes #568.
