### PR TITLE
Freeze variable-or-param-with-select-and-content, hold empty-choose back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,11 @@ Then run `npm test`, `npm run coverage`, and `npx grunt docs`.
   root/version guard belongs at the root step (`/*[guard]//x`), not nested in a
   per-node predicate; nest it only when it gates a sub-clause. This is
   machine-enforced by `test/conformance.test.js`.
+- **Selector hygiene.** A declarative selector must not test existence by
+  counting — write `x` and `not(x)`, never `count(x) > 0` or `count(x) = 0`,
+  the same anti-pattern `count-compared-to-zero` flags in a user's sheet.
+  A comparison that asks a real cardinality (`count(x) >= 2`) is fine. This is
+  machine-enforced by `test/conformance.test.js`.
 - **Fix in the same change.** If a check is fixable, land the fix with the
   detection — never defer it. A declarative rule gets a `node => fix` builder in
   `src/fixers.js`; a code-based linter attaches the `fix` to its defect. Mark it
@@ -305,5 +310,5 @@ the harness asserts too.
 | `src/helpers.js` | XML parsing (expands internal-subset entities), YAML parsing, file recursion |
 | `src/logger.js` | 4-level logger |
 | `scripts/generate-docs.js` | Builds the `docs/` site from checks + motives |
-| `test/conformance.test.js` | Enforces naming, motives, pack/test coverage, and the `mature` freeze across all kinds |
+| `test/conformance.test.js` | Enforces naming, motives, selector hygiene, pack/test coverage, and the `mature` freeze across all kinds |
 | `test/xcop.test.js` | Runs xcop over the inline XSL of every `*-packs` directory |

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ place:
 xslint --fix path/to/dir
 ```
 
-Today this covers nine checks:
+Today this covers ten checks:
 
 - `redundant-whitespace` — a doubled space is collapsed to one, and a space
   leading or trailing an XPath expression is removed.
@@ -328,6 +328,10 @@ Today this covers:
 - `leaking-result-namespace` — the leaking prefix is added to
   `exclude-result-prefixes`, which drops its declaration from the serialized
   output (offered only when a single prefix leaks).
+- `variable-or-param-with-select-and-content` — the `@select` is deleted,
+  leaving the body as the value, which binds a document node where the
+  expression bound its own type; dropping the body instead is the other
+  correction, and no single edit expresses it.
 
 Checks whose correction needs real judgment (a fresh name, a more specific
 path) stay report-only. A run without `--fix` reports how many defects each

--- a/README.md
+++ b/README.md
@@ -329,9 +329,9 @@ Today this covers:
   `exclude-result-prefixes`, which drops its declaration from the serialized
   output (offered only when a single prefix leaks).
 - `variable-or-param-with-select-and-content` — the `@select` is deleted,
-  leaving the body as the value, which binds a document node where the
-  expression bound its own type; dropping the body instead is the other
-  correction, and no single edit expresses it.
+  leaving the body as the value, which binds a tree where the expression bound
+  its own type; dropping the body instead is the other correction, and no
+  single edit expresses it.
 
 Checks whose correction needs real judgment (a fresh name, a more specific
 path) stay report-only. A run without `--fix` reports how many defects each

--- a/src/fixers.js
+++ b/src/fixers.js
@@ -170,6 +170,22 @@ const textOutsideXslText = function(node) {
 }
 
 /**
+ * Fix for `variable-or-param-with-select-and-content`: delete the `@select`,
+ * leaving the body as the only value. It is one of the two corrections the rule
+ * offers — dropping the body instead is structural, so no single edit expresses
+ * it — and the body binds a document node where the expression bound its own
+ * type, so it is a suggestion.
+ * @param {Element} node - The variable-binding element
+ * @return {object} - The suggestion fix
+ */
+const selectAndContent = function(node) {
+  return {
+    ...deletion(node.getAttributeNode('select')),
+    suggestion: true,
+  }
+}
+
+/**
  * Fix builders for declarative Xpath checks, keyed by check name. The per-file
  * linter attaches the fix a builder returns to the defect it found for that
  * check, so a rule stays declarative while still carrying a fix; a builder
@@ -186,6 +202,7 @@ const FIXERS = {
   'select-starts-with-double-slash': selectDoubleSlash,
   'confusing-variable-and-node': confusingVariable,
   'text-outside-xsl-text': textOutsideXslText,
+  'variable-or-param-with-select-and-content': selectAndContent,
 }
 
 module.exports = {

--- a/src/fixers.js
+++ b/src/fixers.js
@@ -173,8 +173,8 @@ const textOutsideXslText = function(node) {
  * Fix for `variable-or-param-with-select-and-content`: delete the `@select`,
  * leaving the body as the only value. It is one of the two corrections the rule
  * offers — dropping the body instead is structural, so no single edit expresses
- * it — and the body binds a document node where the expression bound its own
- * type, so it is a suggestion.
+ * it — and the body binds a tree where the expression bound its own type, so it
+ * is a suggestion.
  * @param {Element} node - The variable-binding element
  * @return {object} - The suggestion fix
  */

--- a/src/resources/checks/xpath/empty-choose.yaml
+++ b/src/resources/checks/xpath/empty-choose.yaml
@@ -4,3 +4,4 @@
 xpath: "//xsl:choose[not(xsl:when)]"
 severity: error
 message: "'xsl:choose' has no 'xsl:when' branch. Add one, or drop the 'xsl:choose' and keep its content directly."
+mature: true

--- a/src/resources/checks/xpath/empty-choose.yaml
+++ b/src/resources/checks/xpath/empty-choose.yaml
@@ -4,4 +4,3 @@
 xpath: "//xsl:choose[not(xsl:when)]"
 severity: error
 message: "'xsl:choose' has no 'xsl:when' branch. Add one, or drop the 'xsl:choose' and keep its content directly."
-mature: true

--- a/src/resources/checks/xpath/not-creating-attribute-correctly.yaml
+++ b/src/resources/checks/xpath/not-creating-attribute-correctly.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //xsl:attribute[not(contains(@name, '{'))][parent::*[not(self::xsl:*)]][count(*) = 0 or (count(*) = 1 and xsl:value-of)]
+xpath: //xsl:attribute[not(contains(@name, '{'))][parent::*[not(self::xsl:*)]][not(*) or (count(*) = 1 and xsl:value-of)]
 severity: warning
 message: xsl:attribute with a static name on a literal element can be a literal attribute (an AVT for a computed value). Write it inline.

--- a/src/resources/checks/xpath/not-using-output.yaml
+++ b/src/resources/checks/xpath/not-using-output.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: (/xsl:stylesheet | /xsl:transform)[count(xsl:template) > 0 and count(xsl:output) = 0]
+xpath: (/xsl:stylesheet | /xsl:transform)[xsl:template and not(xsl:output)]
 severity: error
 message: The xsl:output instruction is missing. Declare it to specify the serialization format explicitly.

--- a/src/resources/checks/xpath/null-output-from-stylesheet.yaml
+++ b/src/resources/checks/xpath/null-output-from-stylesheet.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: (/xsl:stylesheet | /xsl:transform)//xsl:template[starts-with(@match, '/')][count(xsl:variable) > 0 and (count(*) = count(xsl:variable)) and (normalize-space(string-join(text(), '')) = '')]
+xpath: (/xsl:stylesheet | /xsl:transform)//xsl:template[starts-with(@match, '/')][xsl:variable and (count(*) = count(xsl:variable)) and (normalize-space(string-join(text(), '')) = '')]
 severity: warning
 message: The root template contains only variable declarations and produces no output. Add instructions that write to the result tree.

--- a/src/resources/checks/xpath/stylesheet-has-no-templates.yaml
+++ b/src/resources/checks/xpath/stylesheet-has-no-templates.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: (/xsl:stylesheet | /xsl:transform)[count(xsl:template)=0 and count(xsl:function)=0 and count(xsl:variable)=0]
+xpath: (/xsl:stylesheet | /xsl:transform)[not(xsl:template | xsl:function | xsl:variable)]
 severity: error
 message: The stylesheet has no templates, functions, or variables and offers nothing. Add at least one template.

--- a/src/resources/checks/xpath/text-outside-xsl-text.yaml
+++ b/src/resources/checks/xpath/text-outside-xsl-text.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //xsl:*[count(text()[normalize-space()]) > 0 and not(local-name() = ('text','attribute','comment','processing-instruction','message','variable','param','with-param'))]
+xpath: //xsl:*[text()[normalize-space()] and not(local-name() = ('text','attribute','comment','processing-instruction','message','variable','param','with-param'))]
 severity: warning
 message: "Literal text appears directly inside an 'xsl:' instruction element. Wrap it in 'xsl:text'."

--- a/src/resources/checks/xpath/use-choose-without-otherwise.yaml
+++ b/src/resources/checks/xpath/use-choose-without-otherwise.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: "//xsl:choose[count(xsl:otherwise) = 0 and count(xsl:when) >= 2]"
+xpath: "//xsl:choose[not(xsl:otherwise) and count(xsl:when) >= 2]"
 severity: warning
 message: xsl:choose has no xsl:otherwise branch. Add xsl:otherwise to handle unmatched cases explicitly.

--- a/src/resources/checks/xpath/variable-or-param-with-select-and-content.yaml
+++ b/src/resources/checks/xpath/variable-or-param-with-select-and-content.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //(xsl:variable | xsl:param)[@select and (count(*)>0 or text()[normalize-space()])]
+xpath: //(xsl:variable | xsl:param)[@select and (* or text()[normalize-space()])]
 severity: error
 message: An xsl:variable or xsl:param has both a select attribute and a non-empty body. Use only one way to set the value.
+mature: true

--- a/src/resources/checks/xpath/variable-or-param-with-select-and-content.yaml
+++ b/src/resources/checks/xpath/variable-or-param-with-select-and-content.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //(xsl:variable | xsl:param)[@select and (* or text()[normalize-space()])]
+xpath: //(xsl:variable | xsl:param | xsl:with-param)[@select and (* or text()[normalize-space()])]
 severity: error
-message: An xsl:variable or xsl:param has both a select attribute and a non-empty body. Use only one way to set the value.
+message: An xsl:variable, xsl:param or xsl:with-param has both a select attribute and a non-empty body. Use only one way to set the value.
 mature: true

--- a/src/resources/motives/xpath/empty-choose.md
+++ b/src/resources/motives/xpath/empty-choose.md
@@ -6,20 +6,27 @@ rejects it; and even read loosely, an `xsl:choose` holding only an
 `xsl:otherwise` is a wrapper that always runs its single branch — the
 `xsl:choose` adds nothing.
 
-The check is report-only: the fix — deleting the `xsl:choose` and keeping its
-`xsl:otherwise` content directly, or adding the missing `xsl:when` — is a
-structural change and a judgement call.
+The check is report-only until the full-fidelity parser (#228). Both
+corrections — dropping the `xsl:choose` and keeping its `xsl:otherwise`
+content, or adding the missing `xsl:when` — rewrite element structure, which
+the fixer, editing one attribute or text span at a time, cannot express.
 
 Incorrect:
 
 ```xsl
-<xsl:choose>
-  <xsl:otherwise>fallback</xsl:otherwise>
-</xsl:choose>
+<xsl:template match="/objects">
+  <xsl:choose>
+    <xsl:otherwise>
+      <xsl:text>fallback</xsl:text>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
 ```
 
 Correct:
 
 ```xsl
-fallback
+<xsl:template match="/objects">
+  <xsl:text>fallback</xsl:text>
+</xsl:template>
 ```

--- a/src/resources/motives/xpath/variable-or-param-with-select-and-content.md
+++ b/src/resources/motives/xpath/variable-or-param-with-select-and-content.md
@@ -2,7 +2,12 @@
 
 An xsl:variable or xsl:param must not set its value both ways.
 When it carries a @select attribute and also has content, the
-binding is ambiguous, so keep only one.
+binding is ambiguous, so keep only one. It is a static error, which a
+conformant processor rejects, so this is graded an error.
+
+The check is report-only: which half to drop — the `@select` or the
+body — changes the value that gets bound, so it is a judgement call the
+tool cannot make for you.
 
 Incorrect:
 

--- a/src/resources/motives/xpath/variable-or-param-with-select-and-content.md
+++ b/src/resources/motives/xpath/variable-or-param-with-select-and-content.md
@@ -9,10 +9,12 @@ not run at all, on any version, hence the error severity. A body of nothing
 but whitespace and comments is not content, and is left alone.
 
 `--fix-suggestions` deletes the `@select` and leaves the body as the value. It
-is a suggestion rather than a safe fix, because the body binds a document node
-where the expression bound its own type: `$physicist` stops being a string.
-Dropping the body instead is the other correction, and no single edit expresses
-it — make that one by hand when the `@select` held the value you meant.
+is a suggestion rather than a safe fix: the body binds a tree — a document node
+on 2.0 and later, a result tree fragment on 1.0 — where the expression bound
+its own type, so `$physicist` stops being a string, and an `@as` the body
+cannot convert to turns the edit into a type error. Dropping the body instead
+is the other correction, and no single edit expresses it — make that one by
+hand when the `@select` held the value you meant.
 
 Incorrect:
 

--- a/src/resources/motives/xpath/variable-or-param-with-select-and-content.md
+++ b/src/resources/motives/xpath/variable-or-param-with-select-and-content.md
@@ -1,13 +1,18 @@
-# Using internal content and @select to set variable or param
+# Using internal content and @select to set a variable, param or with-param
 
-An xsl:variable or xsl:param must not set its value both ways.
-When it carries a @select attribute and also has content, the
-binding is ambiguous, so keep only one. It is a static error, which a
-conformant processor rejects, so this is graded an error.
+An xsl:variable, an xsl:param and an xsl:with-param — the variable-binding
+elements — take their value either from a @select expression or from their
+body, never from both. Given both, a processor holds two candidate values and
+no rule for choosing one, so XSLT forbids the combination outright: 1.0 calls
+it an error, 2.0 and 3.0 raise the static error XTSE0620. The stylesheet does
+not run at all, on any version, hence the error severity. A body of nothing
+but whitespace and comments is not content, and is left alone.
 
-The check is report-only: which half to drop — the `@select` or the
-body — changes the value that gets bound, so it is a judgement call the
-tool cannot make for you.
+`--fix-suggestions` deletes the `@select` and leaves the body as the value. It
+is a suggestion rather than a safe fix, because the body binds a document node
+where the expression bound its own type: `$physicist` stops being a string.
+Dropping the body instead is the other correction, and no single edit expresses
+it — make that one by hand when the `@select` held the value you meant.
 
 Incorrect:
 
@@ -16,11 +21,15 @@ Incorrect:
     Albert Einstein
 </xsl:variable>
 ```
+
 or:
+
 ```xsl
-<xsl:param name="physicist" select="'J.J. Thomson'">
+<xsl:call-template name="cite">
+  <xsl:with-param name="physicist" select="'J.J. Thomson'">
     Max Planck
-</xsl:param>
+  </xsl:with-param>
+</xsl:call-template>
 ```
 
 Correct:
@@ -30,17 +39,9 @@ Correct:
     Marie Curie
 </xsl:variable>
 ```
+
 or:
+
 ```xsl
 <xsl:variable name="physicist" select="'Ernest Rutherford'"/>
-```
-or:
-```xsl
-<xsl:param name="physicist">
-    Galileo Galilei
-</xsl:param>
-```
-or:
-```xsl
-<xsl:param name="physicist" select="'Lev Landau'"/>
 ```

--- a/test/conformance.test.js
+++ b/test/conformance.test.js
@@ -44,10 +44,26 @@ const KINDS = ['xpath', 'corpus', 'validation', 'format']
 const PACKED = {xpath: 'xpath-packs', corpus: 'corpus-packs'}
 
 /**
+ * Rule kinds paired with the YAML keys holding their selectors, so a check's
+ * own XPath is audited wherever it is written.
+ * @type {{[kind: string]: Array.<string>}}
+ */
+const SELECTORS = {xpath: ['xpath'], corpus: ['declaration', 'usage']}
+
+/**
  * Kebab-case with no leading or trailing hyphen.
  * @type {RegExp}
  */
 const KEBAB = /^[a-z0-9]+(-[a-z0-9]+)*$/
+
+/**
+ * A `count(...)` call compared with zero — the existence test spelled the slow
+ * way, which `count-compared-to-zero` flags in a user's stylesheet and a
+ * check's own selector must therefore not commit. One level of nested
+ * parentheses is enough for the argument of a count.
+ * @type {RegExp}
+ */
+const COUNTED = /count\((?:[^()]|\([^()]*\))*\)\s*(?:!?=|[<>]=?)\s*0(?!\d)/
 
 /**
  * Names of the checks of a kind.
@@ -147,11 +163,26 @@ describe('conformance', function() {
       assert.ok(suite.includes(name), `validation/${name} is tested nowhere`)
     }
   })
+  it('tests existence directly, never by counting, in every selector', function() {
+    for (const [kind, keys] of Object.entries(SELECTORS)) {
+      for (const name of names(kind)) {
+        const check = yaml.parsedFromFile(
+          path.join(CHECKS, kind, `${name}.yaml`),
+        )
+        for (const key of keys) {
+          assert.ok(
+            !check[key] || !COUNTED.test(check[key]),
+            `${kind}/${name} compares count(...) with 0 in its ${key}; ` +
+              'write the node test itself, as count-compared-to-zero asks',
+          )
+        }
+      }
+    }
+  })
   it('pairs every root xsl:stylesheet with an xsl:transform', function() {
     const rooted = /(?<!\/)\/xsl:stylesheet/
     const paired = /(?<!\/)\/xsl:transform/
-    const fields = {xpath: ['xpath'], corpus: ['declaration', 'usage']}
-    for (const [kind, keys] of Object.entries(fields)) {
+    for (const [kind, keys] of Object.entries(SELECTORS)) {
       for (const name of names(kind)) {
         const check = yaml.parsedFromFile(
           path.join(CHECKS, kind, `${name}.yaml`),

--- a/test/fixer.test.js
+++ b/test/fixer.test.js
@@ -265,6 +265,13 @@ const APPLIED = [
     before: 'mode-or-priority-without-match.xsl',
     after: 'mode-or-priority-without-match.fixed.xsl',
   },
+  {
+    name: 'should delete the select of a variable, param and with-param that ' +
+      'also have a body with --fix-suggestions',
+    flag: '--fix-suggestions',
+    before: 'variable-or-param-with-select-and-content.xsl',
+    after: 'variable-or-param-with-select-and-content.fixed.xsl',
+  },
 ]
 
 /**
@@ -367,6 +374,11 @@ const UNCHANGED = [
     name: 'cannot apply a suggestion with plain --fix',
     flag: '--fix',
     sheet: 'using-disable-output-escaping.xsl',
+  },
+  {
+    name: 'cannot delete a select beside a body with plain --fix',
+    flag: '--fix',
+    sheet: 'variable-or-param-with-select-and-content.xsl',
   },
 ]
 

--- a/test/resources/fix/variable-or-param-with-select-and-content.fixed.xsl
+++ b/test/resources/fix/variable-or-param-with-select-and-content.fixed.xsl
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:template name="city">
+    <xsl:param name="region">
+      <region>Kaluga</region>
+    </xsl:param>
+    <xsl:variable name="mayor">
+      <mayor>Petrov</mayor>
+    </xsl:variable>
+    <xsl:value-of select="$region"/>
+    <xsl:value-of select="$mayor"/>
+  </xsl:template>
+  <xsl:template match="/city">
+    <xsl:call-template name="city">
+      <xsl:with-param name="region">
+        <region>Tula</region>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/variable-or-param-with-select-and-content.xsl
+++ b/test/resources/fix/variable-or-param-with-select-and-content.xsl
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:template name="city">
+    <xsl:param name="region" select="'Bryansk'">
+      <region>Kaluga</region>
+    </xsl:param>
+    <xsl:variable name="mayor" select="'Ivanov'">
+      <mayor>Petrov</mayor>
+    </xsl:variable>
+    <xsl:value-of select="$region"/>
+    <xsl:value-of select="$mayor"/>
+  </xsl:template>
+  <xsl:template match="/city">
+    <xsl:call-template name="city">
+      <xsl:with-param name="region" select="'Tver'">
+        <region>Tula</region>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/xpath-packs/empty-choose.yaml
+++ b/test/resources/xpath-packs/empty-choose.yaml
@@ -3,17 +3,39 @@
 ---
 pack: empty-choose
 found:
-  amount: 1
-  positions: [ [ 5, 5 ] ]
+  amount: 3
+  positions: [ [ 13, 5 ], [ 19, 7 ], [ 26, 7 ] ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style1">
     <xsl:output encoding="UTF-8" method="xml"/>
     <xsl:template match="/objects">
       <xsl:choose>
+        <xsl:when test="@a">
+          <p>ok</p>
+        </xsl:when>
+        <xsl:otherwise>
+          <p>fallback</p>
+        </xsl:otherwise>
+      </xsl:choose>
+      <xsl:choose>
         <xsl:otherwise>
           <p>y</p>
         </xsl:otherwise>
       </xsl:choose>
+      <xsl:if test="@b">
+        <xsl:choose>
+          <xsl:otherwise>
+            <p>z</p>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:if>
+      <xsl:for-each select="o">
+        <xsl:choose>
+          <xsl:otherwise>
+            <p>w</p>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:for-each>
     </xsl:template>
   </xsl:stylesheet>

--- a/test/resources/xpath-packs/param-have-select-or-internal-content.yaml
+++ b/test/resources/xpath-packs/param-have-select-or-internal-content.yaml
@@ -20,6 +20,17 @@ input: |-
       <xsl:copy-of select="$chemist"/>
     </xsl:template>
     <xsl:template match="/objects/o/o[1]/o[1]">
-      <xsl:call-template name="scientist"/>
+      <xsl:variable name="mathematician" select="'Sofya Kovalevskaya'">
+        <!-- a comment is not content -->
+      </xsl:variable>
+      <xsl:copy-of select="$mathematician"/>
+      <xsl:call-template name="scientist">
+        <xsl:with-param name="chemist" select="'Alexander Butlerov'"/>
+      </xsl:call-template>
+      <xsl:call-template name="scientist2">
+        <xsl:with-param name="chemist">
+          Nikolay Zinin
+        </xsl:with-param>
+      </xsl:call-template>
     </xsl:template>
   </xsl:stylesheet>

--- a/test/resources/xpath-packs/variable-buried-have-select-and-internal-content.yaml
+++ b/test/resources/xpath-packs/variable-buried-have-select-and-internal-content.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: variable-or-param-with-select-and-content
+found:
+  amount: 3
+  positions: [ [ 6, 7 ], [ 12, 7 ], [ 18, 7 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <x:transform xmlns:x="http://www.w3.org/1999/XSL/Transform" version="1.0" id="style1">
+    <x:output encoding="UTF-8" method="xml"/>
+    <x:template match="/objects">
+      <x:if test="@chemist">
+        <x:variable name="chemist" select="'Dmitri Mendeleev'">
+          Antoine-Laurent Lavoisier
+        </x:variable>
+        <x:copy-of select="$chemist"/>
+      </x:if>
+      <x:for-each select="o">
+        <x:variable name="physicist" select="'Lev Landau'">
+          <name>Pyotr Kapitsa</name>
+        </x:variable>
+        <x:copy-of select="$physicist"/>
+      </x:for-each>
+      <x:variable name="outer">
+        <x:variable name="biologist" select="'Ilya Mechnikov'">
+          Ivan Pavlov
+        </x:variable>
+        <x:copy-of select="$biologist"/>
+      </x:variable>
+      <x:copy-of select="$outer"/>
+    </x:template>
+  </x:transform>

--- a/test/resources/xpath-packs/with-param-have-select-and-internal-content.yaml
+++ b/test/resources/xpath-packs/with-param-have-select-and-internal-content.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: variable-or-param-with-select-and-content
+found:
+  amount: 1
+  positions: [ [ 10, 7 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style1">
+    <xsl:output encoding="UTF-8" method="xml"/>
+    <xsl:template name="scientist">
+      <xsl:param name="chemist"/>
+      <xsl:copy-of select="$chemist"/>
+    </xsl:template>
+    <xsl:template match="/objects">
+      <xsl:call-template name="scientist">
+        <xsl:with-param name="chemist" select="'Nikolay Zinin'">
+          Alexander Butlerov
+        </xsl:with-param>
+      </xsl:call-template>
+    </xsl:template>
+  </xsl:stylesheet>


### PR DESCRIPTION
Follow-up to #568 (the mature freeze marker). An audit of the two candidates found one of them not ready, so this extends the frozen set by one check rather than two, and clears the gaps the audit turned up.

### `empty-choose` — flag dropped, pack kept

Its report-only status is a fix *deferred* to #228, not report-only by nature: both corrections rewrite element structure, and `@xmldom/xmldom` exposes only a start position, so the current `{line, col, value, replacement}` fix format cannot express the span. The maturity bar rules that out explicitly — "a fix merely deferred to a future capability (#228, ...) does not qualify". The motive now names the deferral instead of calling the fix "a judgement call", and its `Correct:` block is valid XSLT rather than a bare word. The enriched pack stays: it is the #567 work, mature flag or not.

### `variable-or-param-with-select-and-content` — flag earned

Three gaps closed:

- **False negative.** `xsl:with-param` is the third variable-binding element (XSLT 1.0 §11; XTSE0620 in 2.0/3.0), so `<xsl:with-param name="x" select="'a'">b</xsl:with-param>` is the same static error — and was flagged by no check (`text-outside-xsl-text` excludes it; the other `with-param-*` checks cover name and parent only). The selector now covers all three.
- **Not report-only.** Deleting the `@select` is a one-span edit through the existing `deletion()` helper, and "one of several corrections" is the definition of the suggestion tier — `mode-or-priority-without-match` is the same shape. It now carries that `--fix-suggestions` fix, with a committed fixture pair exercising all three element kinds, plus `APPLIED` and `UNCHANGED` rows.
- **Thin packs.** They topped out at two top-level occurrences. A new pack adds three occurrences buried in `xsl:if`, `xsl:for-each` and another variable's body, on a non-`xsl` prefix, an `xsl:transform` root and version 1.0; another covers `with-param`; the negative pack gains a `with-param` with `@select` only, one with a body only, and a `@select` beside a comment-only body, which is not content and must not fire.

### Selector hygiene, machine-enforced

The `count(*) > 0` cleanup that prompted this PR was one instance of six. `conformance.test.js` now fails on any check selector that compares `count(...)` with `0`, and the remaining six are rewritten: `text-outside-xsl-text`, `stylesheet-has-no-templates`, `null-output-from-stylesheet`, `use-choose-without-otherwise`, `not-using-output`, `not-creating-attribute-correctly`. A cardinality comparison such as `count(x) >= 2` is still fine. Each rewrite was differential-tested against its original over all 270 fixture documents plus 29 purpose-built edge cases (empty sheets, both roots, foreign prefix, 0/1/2 whens, 0/1/2 attribute children, whitespace-only text, comment and CDATA bodies) — identical node sets everywhere.

`README.md` gains the new suggestion (and its `--fix` list header, which said nine over ten bullets, is corrected); `CLAUDE.md` gains the selector-hygiene rule.
