### PR TITLE
Skip a fix that overlaps one already accepted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,12 @@ the harness asserts too.
   applied only by `--fix-suggestions`. `--fix-dry-run` writes nothing.
   `src/fixer.js` locates each fix by decode-walking the raw source, so a `>`
   written `&gt;` (#518) or a span shifted by an earlier entity (#525) still fixes,
-  and an already-edited span is skipped rather than corrupted.
+  and an already-edited span is skipped rather than corrupted. Two fixes whose
+  spans overlap cannot both be applied in one run (#571): the left-most wins,
+  the wider of two that start together wins, and the loser is announced and left
+  in the report for a later run — so a `.fixed.xsl` fixture may still hold a
+  defect, and every one of them is parsed back by `test/fixer.test.js` to prove
+  no run left broken XML behind.
 
 ## Key files
 

--- a/README.md
+++ b/README.md
@@ -333,6 +333,11 @@ Checks whose correction needs real judgment (a fresh name, a more specific
 path) stay report-only. A run without `--fix` reports how many defects each
 option would fix.
 
+Where two corrections cover the same piece of an expression — the redundant
+whitespace in `d[position()  =  1]` sits inside the predicate that becomes
+`d[1]` — only the wider one is applied, and the other is announced as skipped.
+Run `--fix` again to take care of whatever the first run left.
+
 Pass `--fix-dry-run` to see what would remain after fixing, without writing any
 file:
 

--- a/src/fixer.js
+++ b/src/fixer.js
@@ -89,6 +89,39 @@ const decodes = function(content, from, value) {
 }
 
 /**
+ * The edits that overlap none already accepted, in source order. Two fixes
+ * whose spans intersect cannot both be applied: the second would splice the
+ * text with offsets the first has already shifted, swallowing whatever now sits
+ * at the tail of its stale span. The left-most span wins, and where two start
+ * together the wider one does — an outer fix replaces the very text its inner
+ * neighbour would have edited, so the neighbour is moot rather than merely
+ * postponed. A dropped edit is announced and its defect stays in the report,
+ * for a later run to fix.
+ * @param {Array.<{defect: object, start: number, end: number}>} edits - Edits,
+ *  each already verified against the file as it was read
+ * @return {Array.<{defect: object, start: number, end: number}>} - The ones
+ *  that do not overlap
+ */
+const disjoint = function(edits) {
+  const kept = []
+  let border = 0
+  for (const edit of [...edits].sort(
+    (left, right) => left.start - right.start || right.end - left.end,
+  )) {
+    if (edit.start < border) {
+      logger.warn(
+        `Skipped fixing ${edit.defect.name} at ` +
+        `${edit.defect.file}:${edit.defect.fix.line}, it overlaps another fix`,
+      )
+    } else {
+      kept.push(edit)
+      border = edit.end
+    }
+  }
+  return kept
+}
+
+/**
  * Apply the fixes carried by defects to their sources, returning the rewritten
  * content of each changed file and the defects whose fix was applied. Each fix
  * names a source position, a decoded `value`, and its replacement. The fixer
@@ -96,8 +129,11 @@ const decodes = function(content, from, value) {
  * fix's decoded `offset`, so it lands on the match even when an entity ahead of
  * it shifts the column, then matches `value` decoding as it goes — a `>`
  * written `&gt;` matches alike. A fix whose source no longer decodes to `value`
- * (an already-edited file) is skipped rather than corrupting. Fixes for one
- * file are applied from the end backwards so earlier offsets stay valid.
+ * (an already-edited file) is skipped rather than corrupting, and so is one
+ * overlapping a fix already accepted in the same run — the spans are proved
+ * against the file as read, which says nothing about what an earlier edit has
+ * since moved. Fixes for one file are applied from the end backwards so earlier
+ * offsets stay valid.
  * @param {Array.<{file: string, content: string}>} sources - Original sources
  * @param {Array.<{file: string, fix: {line: number, col: number, offset:
  *  number, value: string, replacement: string, suggestion: boolean}}>}
@@ -115,31 +151,34 @@ const fixed = function(sources, defects, suggestions = false) {
   const contents = new Map()
   const applied = []
   for (const {file, content} of sources) {
-    const edits = fixable
-      .filter((defect) => defect.file === file)
-      .map((defect) => {
-        const offset = defect.fix.offset || 0
-        const base = offsetAt(content, defect.fix.line, defect.fix.col - offset)
-        const start = skip(content, base, offset)
-        return {
-          defect: defect,
-          start: start,
-          end: decodes(content, start, defect.fix.value),
-        }
-      })
-      .filter(({defect, end}) => {
-        if (end < 0) {
-          logger.warn(
-            `Skipped fixing ${defect.name} at ${file}:${defect.fix.line}, ` +
-            `the source no longer matches`,
+    const edits = disjoint(
+      fixable
+        .filter((defect) => defect.file === file)
+        .map((defect) => {
+          const offset = defect.fix.offset || 0
+          const base = offsetAt(
+            content, defect.fix.line, defect.fix.col - offset,
           )
-        }
-        return end >= 0
-      })
-      .sort((left, right) => right.start - left.start)
+          const start = skip(content, base, offset)
+          return {
+            defect: defect,
+            start: start,
+            end: decodes(content, start, defect.fix.value),
+          }
+        })
+        .filter(({defect, end}) => {
+          if (end < 0) {
+            logger.warn(
+              `Skipped fixing ${defect.name} at ${file}:${defect.fix.line}, ` +
+              `the source no longer matches`,
+            )
+          }
+          return end >= 0
+        }),
+    )
     if (edits.length > 0) {
       let text = content
-      for (const {defect, start, end} of edits) {
+      for (const {defect, start, end} of [...edits].reverse()) {
         text =
           text.slice(0, start) +
           defect.fix.replacement +

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -264,6 +264,16 @@ const xslint = function(pths, options) {
     overrides: overrides,
   })
   if (options.fix || options.fixDryRun || options.fixSuggestions) {
+    /**
+     * @todo #571:60min Fix over several passes, until a pass changes nothing.
+     *  A fix that `fixer.js` skips for overlapping another is never applied
+     *  here, so `--fix` under-delivers and then reports a defect the winning
+     *  fix has already removed from the file. Re-lint the rewritten contents
+     *  and fix again, capped at ten passes, stopping early when a pass
+     *  reproduces the content of the pass before last, the way ESLint and
+     *  RuboCop both reach a fixpoint without looping forever over two checks
+     *  that undo each other.
+     */
     const {contents, applied} = fixed(sources, reported, options.fixSuggestions)
     for (const [file, content] of contents) {
       if (!options.fixDryRun) {

--- a/test/fixer.test.js
+++ b/test/fixer.test.js
@@ -5,6 +5,7 @@
 
 const {runXslint, xslintStreams} = require('./helpers')
 const {fixed} = require('../src/fixer')
+const {xml} = require('../src/helpers')
 const assert = require('assert')
 const fs = require('fs')
 const os = require('os')
@@ -36,6 +37,45 @@ const scratch = function(content) {
   fs.writeFileSync(file, content)
   return file
 }
+
+/**
+ * Every rewritten stylesheet the fixer is expected to produce. A fix spliced
+ * with a stale offset eats whatever sits at the tail of its span — an
+ * attribute's closing quote, most often — so each of these is parsed back to
+ * prove the fixer left valid XML behind.
+ * @type {Array.<string>}
+ */
+const REWRITTEN = fs
+  .readdirSync(path.resolve(__dirname, 'resources', 'fix'))
+  .filter((name) => name.endsWith('.fixed.xsl'))
+
+/**
+ * Cases where two fixes contend for one span, with the text the winner leaves
+ * behind. The loser is listed first, so a run that merely keeps the order it
+ * was given fails.
+ * @type {Array.<{name: string, content: string, fixes: Array.<object>,
+ *  after: string}>}
+ */
+const CONTENDING = [
+  {
+    name: 'cannot apply a fix that overlaps an accepted one',
+    content: 'XYZ',
+    fixes: [
+      {name: 'inner', fix: {line: 1, col: 2, value: 'YZ', replacement: 'W'}},
+      {name: 'outer', fix: {line: 1, col: 1, value: 'XYZ', replacement: 'Q'}},
+    ],
+    after: 'Q',
+  },
+  {
+    name: 'should prefer the wider of two fixes that start together',
+    content: 'XYZ',
+    fixes: [
+      {name: 'narrow', fix: {line: 1, col: 1, value: 'X', replacement: 'Q'}},
+      {name: 'wider', fix: {line: 1, col: 1, value: 'XYZ', replacement: 'W'}},
+    ],
+    after: 'W',
+  },
+]
 
 /**
  * Cases where a flag rewrites the `before` fixture into the `after` one.
@@ -128,6 +168,19 @@ const APPLIED = [
     flag: '--fix',
     before: 'count-shifted-comparison.xsl',
     after: 'count-shifted-comparison.fixed.xsl',
+  },
+  {
+    name: 'should keep the widest of the fixes that overlap with --fix',
+    flag: '--fix',
+    before: 'overlapping-fixes.xsl',
+    after: 'overlapping-fixes.fixed.xsl',
+  },
+  {
+    name: 'should unwrap only the outer of two nested double negations with ' +
+      '--fix',
+    flag: '--fix',
+    before: 'nested-double-negation.xsl',
+    after: 'nested-double-negation.fixed.xsl',
   },
   {
     name: 'should rewrite a string-length comparison to != / = with ' +
@@ -510,5 +563,42 @@ describe('fixer', function() {
         [{file: 'a.xsl', fix: {line: 1, col: 1, value: 'XY', replacement: 'Z'}}],
       ).contents.has('a.xsl'),
     )
+  })
+  CONTENDING.forEach(({name, content, fixes, after}) => {
+    it(name, function() {
+      assert.equal(
+        fixed(
+          [{file: 'a.xsl', content: content}],
+          fixes.map((defect) => ({file: 'a.xsl', ...defect})),
+        ).contents.get('a.xsl'),
+        after,
+      )
+    })
+  })
+  it('cannot count a skipped overlapping fix as applied', function() {
+    assert.deepEqual(
+      fixed(
+        [{file: 'a.xsl', content: 'XYZ'}],
+        CONTENDING[0].fixes.map((defect) => ({file: 'a.xsl', ...defect})),
+      ).applied.map((defect) => defect.name),
+      ['outer'],
+    )
+  })
+  it('should announce a fix skipped for overlapping another', function() {
+    const file = scratch(fixture('overlapping-fixes.xsl'))
+    assert.ok(
+      xslintStreams(['--fix', file]).stderr.includes('overlaps another fix'),
+    )
+  })
+  it('cannot drop a skipped overlapping defect from the report', function() {
+    const file = scratch(fixture('overlapping-fixes.xsl'))
+    assert.ok(
+      xslintStreams(['--fix', file]).stdout.includes('redundant-whitespace'),
+    )
+  })
+  REWRITTEN.forEach((name) => {
+    it(`cannot leave ${name} malformed`, function() {
+      assert.doesNotThrow(() => xml.parsedFromString(fixture(name)))
+    })
   })
 })

--- a/test/resources/fix/nested-double-negation.fixed.xsl
+++ b/test/resources/fix/nested-double-negation.fixed.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:if test="not(not(@enabled))">
+      <xsl:value-of select="@enabled"/>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/nested-double-negation.xsl
+++ b/test/resources/fix/nested-double-negation.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:if test="not(not(not(not(@enabled))))">
+      <xsl:value-of select="@enabled"/>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/overlapping-fixes.fixed.xsl
+++ b/test/resources/fix/overlapping-fixes.fixed.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:value-of select="row[1]"/>
+    <xsl:if test="exists( row )">
+      <xsl:value-of select="row[last()]"/>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/overlapping-fixes.xsl
+++ b/test/resources/fix/overlapping-fixes.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:value-of select="row[position()  =  1]"/>
+    <xsl:if test="count( row )  &gt;  0">
+      <xsl:value-of select="row[position()  =  last()]"/>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
`fixed` proved every span against the file as it was read from disk, then
spliced them into a text that earlier edits had already shortened. Disjoint
spans survive that, since the edits run from the end backwards, but a nested
one does not: `<xsl:value-of select="d[position()  =  1]"/>` came out as
`<xsl:value-of select="d[1`, and `count( d )  &gt;  0` took the closing quote
of its attribute with it. Both rewritten files then failed to parse, so the
next run reported `malformed-stylesheet` and nothing else.

Overlapping fixes are now settled before anything is written. The left-most
span wins, the wider of two that start together wins, and the rest are
announced and left in the report:

```js
if (edit.start < border) {
  logger.warn(...)
} else {
  kept.push(edit)
  border = edit.end
}
```

Widest-first is what makes one pass enough in the common case — the predicate
fix replaces the very whitespace its neighbour wanted to collapse, so `d[1]`
falls out immediately rather than after a second run. It is not enough
everywhere: nested `not(not(not(not(@enabled))))` still needs two runs, which
is what the `@todo` in `xslint.js` is for. Re-linting to a fixpoint belongs
there, not in `fixer.js`, since `lint` and `fixed` are both pure and the
embedder in #336 wants them single-pass.

Two fixture pairs cover the overlaps, and every `*.fixed.xsl` in the tree is
now parsed back — that assertion fails on all three corrupted outputs, and
would have caught this the day the second fixable expression linter landed.

Closes #571
