### PR TITLE
Stop the count/string-length checks firing on an arithmetic operand

### DIFF
--- a/src/comparisons.js
+++ b/src/comparisons.js
@@ -6,17 +6,23 @@
 const {masked, closes} = require('./expressions')
 
 /**
- * The comparison that follows a call: an operator and a `0` or `1`.
+ * The comparison that follows a call: an operator, then a `0` or `1` as the
+ * whole right operand. The two lookaheads keep the digit off the tail of a
+ * longer number (`0.5`, `10`) and off the head of a wider arithmetic operand
+ * (`+`, `-`, `*`, `div`, `mod`), so `count(x) > 0 + $n` does not match on `0`.
  * @type {RegExp}
  */
-const TAIL = /^\s*(!=|<=|>=|=|<|>)\s*([01])(?![\w.])/
+const TAIL = /^\s*(!=|<=|>=|=|<|>)\s*([01])(?![\w.])(?!\s*(?:[-+*]|div\b|mod\b))/
 
 /**
  * The operand-reversed comparison just before a call, as in `0 < f(x)`. The
- * leading group keeps the digit from being the tail of a longer number.
+ * digit is the whole left operand only when what precedes it — past
+ * whitespace — starts the expression, opens `(`/`[`/`,`, or closes a boolean
+ * operator (`and`, `or`); an arithmetic operator before it makes the digit
+ * part of a wider operand, so `$max + 1 > count(x)` does not match on `1`.
  * @type {RegExp}
  */
-const HEAD = /(^|[^\w.])([01])\s*(!=|<=|>=|=|<|>)\s*$/
+const HEAD = /(^\s*|[([,]\s*|\b(?:and|or)\b\s*)([01])\s*(!=|<=|>=|=|<|>)\s*$/
 
 /**
  * Each operator with its sides swapped, so a reversed `0 < f(x)` reads as

--- a/src/resources/checks/format/count-compared-to-zero.yaml
+++ b/src/resources/checks/format/count-compared-to-zero.yaml
@@ -3,4 +3,3 @@
 ---
 severity: warning
 message: count(...) is compared with 0 to test existence, which walks the whole sequence. Test existence directly instead (exists()/empty() on XSLT 2.0+, boolean()/not() on 1.0).
-mature: true

--- a/src/resources/checks/format/string-length-compared-to-zero.yaml
+++ b/src/resources/checks/format/string-length-compared-to-zero.yaml
@@ -3,4 +3,3 @@
 ---
 severity: warning
 message: string-length(...) is compared with 0 to test emptiness, which measures the whole string. Compare the value with '' instead.
-mature: true

--- a/src/resources/motives/format/count-compared-to-zero.md
+++ b/src/resources/motives/format/count-compared-to-zero.md
@@ -39,4 +39,7 @@ gets them too.
 The operand order does not matter: `0 &lt; count($items)` and
 `0 = count($items)` are flagged the same way. A comparison that is not an
 existence test — `count($x) &gt; 1`, `count($x) = 5` — is a genuine count and is
-left alone.
+left alone. So is a `0` or `1` that is only part of a wider operand: in
+`$max + 1 &gt; count($x)` the left side is `$max + 1`, and in
+`count($x) &gt; 0 + $n` the right side is `0 + $n`, so neither compares the call
+against a bare `0` or `1`.

--- a/src/resources/motives/format/string-length-compared-to-zero.md
+++ b/src/resources/motives/format/string-length-compared-to-zero.md
@@ -21,7 +21,10 @@ Correct:
 ```
 
 The operand order does not matter (`0 &lt; string-length(@name)` is flagged the
-same way). When the argument is not a single operand — a union such as
+same way). A `0` or `1` that is only part of a wider arithmetic operand — the
+`1` in `$max + 1 &gt; string-length(@a)`, the `0` in
+`string-length(@a) &gt; 0 + $n` — does not compare the call against zero, and is
+left alone. When the argument is not a single operand — a union such as
 `string-length($a | $b)`, where `X != ''` would not mean the same thing — the
 comparison is still reported but carries no fix.
 

--- a/test/resources/count-packs/count-reversed-past-boundary.yaml
+++ b/test/resources/count-packs/count-reversed-past-boundary.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: count-compared-to-zero
+found:
+  amount: 5
+  positions: [ [ 4, 37 ], [ 5, 41 ], [ 6, 41 ], [ 7, 43 ], [ 8, 42 ] ]
+  fixes: [ "exists(x)", "empty(x)", "exists(x)", "empty(x)", "exists(x)" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <xsl:variable name="a" select="(0 &lt; count(x))"/>
+      <xsl:variable name="b" select="($y, 0 = count(x))"/>
+      <xsl:variable name="c" select="item[0 != count(x)]"/>
+      <xsl:variable name="d" select="$a and 0 &gt;= count(x)"/>
+      <xsl:variable name="e" select="$a or 0 &lt; count(x)"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/count-packs/count-with-arithmetic-operand.yaml
+++ b/test/resources/count-packs/count-with-arithmetic-operand.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: count-compared-to-zero
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <xsl:variable name="a" select="$max + 1 &gt; count(item)"/>
+      <xsl:variable name="b" select="$max - 1 &lt;= count(item)"/>
+      <xsl:variable name="c" select="$n * 1 &gt; count(item)"/>
+      <xsl:variable name="d" select="count(item) &gt; 0 + $n"/>
+      <xsl:variable name="e" select="count(item) = 0 div $n"/>
+      <xsl:variable name="f" select="count(item) != 0 mod $n"/>
+      <xsl:variable name="g" select="count(item) &lt;= 0 * $n"/>
+      <xsl:variable name="h" select="item[$max + 1 &gt; count(child)]"/>
+      <xsl:variable name="i" select="$a + 1 &gt; count(x) and count(y) &lt; 0 + $b or count(z) = 0 + 1"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/string-length-packs/string-length-with-arithmetic-operand.yaml
+++ b/test/resources/string-length-packs/string-length-with-arithmetic-operand.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: string-length-compared-to-zero
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <xsl:variable name="a" select="$max + 1 &gt; string-length(@a)"/>
+      <xsl:variable name="b" select="$lo - 1 &lt;= string-length(@a)"/>
+      <xsl:variable name="c" select="$n * 1 &gt; string-length(@a)"/>
+      <xsl:variable name="d" select="string-length(@a) &gt; 0 + $n"/>
+      <xsl:variable name="e" select="string-length(@a) = 0 div $n"/>
+      <xsl:variable name="f" select="string-length(@a) != 0 mod $n"/>
+      <xsl:variable name="g" select="string-length(@a) &lt;= 0 * $n"/>
+      <xsl:variable name="h" select="item[$max + 1 &gt; string-length(@id)]"/>
+      <xsl:variable name="i" select="$a + 1 &gt; string-length(@x) and string-length(@y) &lt; 0 + $b"/>
+    </xsl:template>
+  </xsl:stylesheet>


### PR DESCRIPTION
`comparedToZero` matched a `0` or `1` next to a call without establishing it was the whole operand. In `$max + 1 > count(item)` the left side is `$max + 1`, but the scan saw `1 > count(item)`, flipped it to `count(item) < 1`, and reported an existence smell — then the safe `--fix` rewrote the whole thing to `$max + empty(item)`, quietly changing what the expression computes. The forward side had the mirror gap, so `count(item) > 0 + $n` turned into `exists(item) + $n`. Both `count-compared-to-zero` and `string-length-compared-to-zero` share the scan, so both misfired.

The two regexes now bound the operand. On the reversed side the digit counts only when what precedes it — past whitespace — starts the expression, opens a `(`/`[`/`,`, or closes an `and`/`or`; on the forward side a trailing arithmetic operator (`+ - * div mod`) rejects the match.

```js
const HEAD = /(^\s*|[([,]\s*|\b(?:and|or)\b\s*)([01])\s*(!=|<=|>=|=|<|>)\s*$/
```

Both checks carried `mature: true`. A false positive whose safe fix changes an expression's meaning is exactly what that flag is meant to rule out, so it comes off until the bar is earned again. New packs pin the arithmetic-operand cases to zero on both linters and guard that the reversed forms still fire past every boundary.

Closes #573.