### PR TITLE
Scope the attribute selector to XSLT elements and lex attribute value templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,14 @@ recursion). The staging is wired only in `src/xslint.js`: each linter is one
 list that `--suppress` and config globs match is *derived* from those entries, so
 a linter and its suppression names cannot drift apart.
 
+No code-based linter selects attributes by name on its own. `src/attributes.js`
+hands it every expression the attributes of a stylesheet carry: an XPath or
+pattern attribute *of an XSLT element*, whole, plus each expression an attribute
+value template encloses in braces, offset by where it starts inside the value
+(#579). An attribute a literal result element happens to call `test` or `select`
+holds text destined for the result tree, so it is left alone — reading it as
+XPath let `--fix` rewrite the output.
+
 XPath binds prefix `xsl:` to the XSLT namespace; `xslint:` is reserved in
 `src/xpath.js` for custom functions (none are registered now).
 
@@ -145,8 +153,11 @@ motive, or ships untested fails the build.
 - **validation/format check**: the logic is code (a validator, or a
   `src/*-linter.js` wired into `LINTERS`); the YAML only tunes `severity` and
   `message`. A code-based format linter builds its defects through `src/checks.js`
-  (`metaOf`, `suppressed`, `defect`) and scans `src/attributes.js`'s `SELECTOR`
-  (every XPath/pattern attribute) unless it has a documented reason to narrow.
+  (`metaOf`, `suppressed`, `defect`) and reads its expressions from
+  `src/attributes.js`'s `expressionsOf` (every XPath/pattern attribute of an XSLT
+  element, plus every expression an attribute value template encloses) unless it
+  has a documented reason to narrow — then it narrows through `selectorOf`, never
+  a hand-written `//@name`, which an ESLint `no-restricted-syntax` selector bans.
 
 Then run `npm test`, `npm run coverage`, and `npx grunt docs`.
 
@@ -288,9 +299,9 @@ the harness asserts too.
 | `src/corpus-linter.js` | Loads `checks/corpus/*.yaml`; cross-file rules |
 | `src/*-linter.js` | Code-based `checks/format/*.yaml`, one construct each (axis, namespace, count, name, ...); see the flow diagram |
 | `src/checks.js` | Shared for code-based linters: `metaOf`, `suppressed`, `defect(check, meta, file, node, offset, fix)` |
-| `src/attributes.js` | `ATTRIBUTES`/`SELECTOR` — every XPath/pattern attribute the scanners cover |
+| `src/attributes.js` | `expressionsOf(xsl)` — every expression the attributes carry, bare (`ATTRIBUTES` on an XSLT element) or enclosed in an AVT; `selectorOf(name)` for a linter that narrows |
 | `src/comparisons.js` | `comparedToZero` — shared scan for a call compared with `0`/`1` (count, string-length) |
-| `src/expressions.js` | `masked`/`closes` lexer helpers (node-set, double-negation, boolean-call) |
+| `src/expressions.js` | `masked`/`closes` lexer helpers (node-set, double-negation, boolean-call); `enclosed` — the expressions an AVT holds in its braces |
 | `src/tokens.js` | Positioned XPath lexer (`tokenized`, `TOKENS`), preserving whitespace |
 | `src/import-graph.js` | Resolves `xsl:import`/`xsl:include` hrefs: `importsOf`, `graphOf` |
 | `src/fixers.js` | Maps a declarative check name to a `node => fix` builder |

--- a/README.md
+++ b/README.md
@@ -389,6 +389,13 @@ Linters:
   parse are checked, so a malformed one is reported once by the validator and
   never nagged about its spacing.
 
+Every check that reads an expression reads it from an XPath or pattern attribute
+of an XSLT element (`select`, `test`, `match`, …) or from an attribute value
+template — `<div class="{count(item) = 0}"/>` is checked, and fixed, inside the
+braces. An attribute of your own output vocabulary that happens to share a name
+with an XSLT one, as in `<widget test="count(item) = 0"/>`, holds text destined
+for the result tree, so it is never read as XPath and never rewritten.
+
 ## Programmatic use
 
 `xslint` is embeddable — editors, build tools, and the

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -76,6 +76,11 @@ export default defineConfig([
           selector: "ImportDeclaration[source.value=/^node:/]",
           message:
             "Do not use the 'node:' prefix in import; use the bare name"
+        },
+        {
+          selector: "Literal[value=/\\/\\/@/]",
+          message:
+            "Do not select attributes with a bare '//@name' XPath, which reads a literal result element as XPath; go through src/attributes.js (expressionsOf, selectorOf)"
         }
       ]
     }

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
+const {nodes} = require('./xpath')
+const {enclosed} = require('./expressions')
+
 /**
  * Attributes that hold an XPath expression or a pattern — every place a
  * construct like an axis, a predicate, or a `count(...)` call can appear.
@@ -17,12 +20,49 @@ const ATTRIBUTES = [
 ]
 
 /**
- * XPath selecting every attribute that could hold XPath, across the document.
+ * XPath selecting the named attribute of every XSLT element, document-wide. The
+ * XSLT namespace belongs in the selector because only there does the name mean
+ * an expression: an attribute the output vocabulary happens to call `test` or
+ * `select` holds text destined for the result tree, not XPath.
+ * @param {string} name - Name of the attribute
+ * @return {string} - The Xpath selecting it
+ */
+const selectorOf = function(name) {
+  return `//xsl:*/@${name}`
+}
+
+/**
+ * XPath selecting every attribute that holds a bare XPath, across the document.
  * @type {string}
  */
-const SELECTOR = ATTRIBUTES.map((name) => `//@${name}`).join(' | ')
+const SELECTOR = ATTRIBUTES.map(selectorOf).join(' | ')
+
+/**
+ * Every expression the attributes of a stylesheet carry, in document order. An
+ * attribute holding a bare XPath contributes its whole value; any other
+ * attribute contributes each expression its braces enclose, an attribute value
+ * template being the only way an expression hides there. Each one names the
+ * attribute node, the offset it starts at inside that node's value, and its own
+ * text, so a defect in it is reported — and fixed — where it truly stands.
+ * @param {Document} xsl - XSL document parsed as {@link Document}
+ * @return {Array.<{node: Node, start: number, expression: string}>} - The
+ *  expressions found
+ */
+const expressionsOf = function(xsl) {
+  const bare = new Set(nodes(xsl, SELECTOR))
+  return nodes(xsl, '//*/@*').flatMap((attribute) =>
+    bare.has(attribute) ?
+      [{node: attribute, start: 0, expression: attribute.nodeValue}] :
+      enclosed(attribute.nodeValue).map((found) => ({
+        node: attribute,
+        start: found.offset,
+        expression: found.value,
+      })),
+  )
+}
 
 module.exports = {
   ATTRIBUTES,
-  SELECTOR,
+  selectorOf,
+  expressionsOf,
 }

--- a/src/count-linter.js
+++ b/src/count-linter.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes} = require('./xpath')
 const {comparedToZero} = require('./comparisons')
 const {metaOf, suppressed, defect} = require('./checks')
-const {SELECTOR} = require('./attributes')
+const {expressionsOf} = require('./attributes')
 const {logger} = require('./logger')
 
 /**
@@ -128,14 +127,12 @@ const lintByCount = function(corpus, suppressions = []) {
       const modern = MODERN.includes(
         xsl.documentElement.getAttribute('version'),
       )
-      for (const attribute of nodes(xsl, SELECTOR)) {
-        for (const {offset, value, test, argument} of comparisons(
-          attribute.nodeValue,
-        )) {
-          const whole = attribute.nodeName === 'test' &&
-            attribute.nodeValue.trim() === value
+      for (const {node, start, expression} of expressionsOf(xsl)) {
+        for (const {offset, value, test, argument} of comparisons(expression)) {
+          const whole = node.nodeName === 'test' &&
+            node.nodeValue.trim() === value
           defects.push(
-            defect(CHECK, META, file, attribute, offset, {
+            defect(CHECK, META, file, node, start + offset, {
               value: value,
               replacement: rewritten(test, argument, modern, whole),
             }),

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -46,7 +46,62 @@ const closes = function(expression, open) {
   return -1
 }
 
+/**
+ * Offset of the `}` that closes the expression enclosed from `from`, or -1 when
+ * it never closes. String and comment spans are blanked before the scan, so a
+ * brace inside a literal ends nothing, and a brace the expression opens itself
+ * — a map or array constructor — is balanced, so only an unmatched `}` closes
+ * it.
+ * @param {string} template - The attribute value
+ * @param {number} from - Offset of the first character of the expression
+ * @return {number} - Offset of the closing `}`, or -1
+ */
+const closing = function(template, from) {
+  const blanked = masked(template.slice(from))
+  let depth = 0
+  for (let at = 0; at < blanked.length; at++) {
+    if (blanked[at] === '{') {
+      depth++
+    } else if (blanked[at] === '}') {
+      if (depth === 0) {
+        return from + at
+      }
+      depth--
+    }
+  }
+  return -1
+}
+
+/**
+ * The expressions an attribute value template encloses in braces, each carrying
+ * the offset it starts at inside the value and its own text. A doubled brace is
+ * an escaped brace and encloses nothing; a brace that never closes ends the
+ * scan, since the value is then output text to its end.
+ * @param {string} template - The attribute value
+ * @return {Array.<{offset: number, value: string}>} - The expressions found
+ */
+const enclosed = function(template) {
+  const found = []
+  let at = 0
+  while (at < template.length) {
+    if (template[at] === '{' && template[at + 1] === '{') {
+      at += 2
+    } else if (template[at] === '{') {
+      const close = closing(template, at + 1)
+      if (close < 0) {
+        break
+      }
+      found.push({offset: at + 1, value: template.slice(at + 1, close)})
+      at = close + 1
+    } else {
+      at++
+    }
+  }
+  return found
+}
+
 module.exports = {
   masked,
   closes,
+  enclosed,
 }

--- a/src/name-linter.js
+++ b/src/name-linter.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes} = require('./xpath')
 const {masked, closes} = require('./expressions')
 const {metaOf, suppressed, defect} = require('./checks')
-const {SELECTOR} = require('./attributes')
+const {expressionsOf} = require('./attributes')
 const {logger} = require('./logger')
 
 /**
@@ -144,13 +143,13 @@ const lintByName = function(corpus, suppressions = []) {
       const modern = MODERN.includes(
         xsl.documentElement.getAttribute('version'),
       )
-      for (const attribute of nodes(xsl, SELECTOR)) {
+      for (const {node, start, expression} of expressionsOf(xsl)) {
         for (const {offset, value, replacement} of comparisons(
-          attribute.nodeValue, modern,
+          expression, modern,
         )) {
           defects.push(
             defect(
-              CHECK, META, file, attribute, offset,
+              CHECK, META, file, node, start + offset,
               replacement === null ?
                 undefined : {value, replacement, suggestion: true},
             ),

--- a/src/node-set-linter.js
+++ b/src/node-set-linter.js
@@ -6,6 +6,7 @@
 const {nodes} = require('./xpath')
 const {masked, closes} = require('./expressions')
 const {metaOf, suppressed, defect} = require('./checks')
+const {selectorOf} = require('./attributes')
 const {logger} = require('./logger')
 
 /**
@@ -66,7 +67,10 @@ const wrappers = function(select) {
 /**
  * Lint the corpus for the `node-set()` extension used in XSLT 2.0 or 3.0, where
  * a variable is already a node sequence, reporting one defect per call with the
- * fix that unwraps it.
+ * fix that unwraps it. Only the `@select` of an XSLT element is read: the
+ * `select` a literal result element carries is output text, and a call standing
+ * in another expression attribute, or inside an attribute value template, is
+ * not looked for.
  * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
  * @param {Array.<string>} suppressions - Array of suppressed checks
  * @return {{name: string, severity: string, message: string, file: string,
@@ -78,7 +82,7 @@ const lintByNodeSet = function(corpus, suppressions = []) {
   if (!suppressed(CHECK, suppressions)) {
     for (const {file, xsl} of corpus) {
       if (MODERN.includes(xsl.documentElement.getAttribute('version'))) {
-        for (const attribute of nodes(xsl, '//@select')) {
+        for (const attribute of nodes(xsl, selectorOf('select'))) {
           for (const {offset, value, replacement} of wrappers(
             attribute.nodeValue,
           )) {

--- a/src/predicate-position-linter.js
+++ b/src/predicate-position-linter.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes} = require('./xpath')
 const {tokenized, TOKENS} = require('./tokens')
 const {metaOf, suppressed, defect} = require('./checks')
-const {SELECTOR} = require('./attributes')
+const {expressionsOf} = require('./attributes')
 const {logger} = require('./logger')
 
 /**
@@ -132,12 +131,12 @@ const lintByPredicatePosition = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const {file, xsl} of corpus) {
-      for (const attribute of nodes(xsl, SELECTOR)) {
-        for (const {offset, value, replacement} of literals(
-          attribute.nodeValue,
-        )) {
+      for (const {node, start, expression} of expressionsOf(xsl)) {
+        for (const {offset, value, replacement} of literals(expression)) {
           defects.push(
-            defect(CHECK, META, file, attribute, offset, {value, replacement}),
+            defect(
+              CHECK, META, file, node, start + offset, {value, replacement},
+            ),
           )
         }
       }

--- a/src/redundant-boolean-call-linter.js
+++ b/src/redundant-boolean-call-linter.js
@@ -6,6 +6,7 @@
 const {nodes} = require('./xpath')
 const {masked, closes} = require('./expressions')
 const {metaOf, suppressed, defect} = require('./checks')
+const {selectorOf} = require('./attributes')
 const {logger} = require('./logger')
 
 /**
@@ -64,8 +65,12 @@ const stripped = function(test) {
 }
 
 /**
- * Lint the corpus for a whole `@test` that is a single `boolean(...)` call,
- * reporting one defect per test with the safe fix that strips the wrapper.
+ * Lint the corpus for a whole `@test` of an XSLT element that is a single
+ * `boolean(...)` call, reporting one defect per test with the safe fix that
+ * strips the wrapper. Nothing outside such a test coerces the value, so neither
+ * a literal result element's `test` — output text — nor the expression of an
+ * attribute value template, where the wrapper decides whether `true`/`false` or
+ * the node's own text is printed, is read.
  * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
  * @param {Array.<string>} suppressions - Array of suppressed checks
  * @return {{name: string, severity: string, message: string, file: string,
@@ -76,7 +81,7 @@ const lintByBooleanCall = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const {file, xsl} of corpus) {
-      for (const attribute of nodes(xsl, '//@test')) {
+      for (const attribute of nodes(xsl, selectorOf('test'))) {
         const strip = stripped(attribute.nodeValue)
         if (strip) {
           defects.push(

--- a/src/redundant-double-negation-linter.js
+++ b/src/redundant-double-negation-linter.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes} = require('./xpath')
 const {masked, closes} = require('./expressions')
 const {metaOf, suppressed, defect} = require('./checks')
-const {SELECTOR} = require('./attributes')
+const {expressionsOf} = require('./attributes')
 const {logger} = require('./logger')
 
 /**
@@ -93,14 +92,12 @@ const lintByDoubleNegation = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const {file, xsl} of corpus) {
-      for (const attribute of nodes(xsl, SELECTOR)) {
-        for (const {offset, value, argument} of negations(
-          attribute.nodeValue,
-        )) {
-          const bare = attribute.nodeName === 'test' &&
-            attribute.nodeValue.trim() === value
+      for (const {node, start, expression} of expressionsOf(xsl)) {
+        for (const {offset, value, argument} of negations(expression)) {
+          const bare = node.nodeName === 'test' &&
+            node.nodeValue.trim() === value
           defects.push(
-            defect(CHECK, META, file, attribute, offset, {
+            defect(CHECK, META, file, node, start + offset, {
               value: value,
               replacement: bare ? argument : `boolean(${argument})`,
             }),

--- a/src/resources/checks/format/count-compared-to-zero.yaml
+++ b/src/resources/checks/format/count-compared-to-zero.yaml
@@ -3,4 +3,3 @@
 ---
 severity: warning
 message: count(...) is compared with 0 to test existence, which walks the whole sequence. Test existence directly instead (exists()/empty() on XSLT 2.0+, boolean()/not() on 1.0).
-mature: true

--- a/src/resources/checks/format/predicate-position-literal.yaml
+++ b/src/resources/checks/format/predicate-position-literal.yaml
@@ -3,4 +3,3 @@
 ---
 severity: warning
 message: A positional predicate is written the long way; [position() = N] is just [N] and [position() = last()] is just [last()]. Shorten it.
-mature: true

--- a/src/resources/checks/format/redundant-double-negation.yaml
+++ b/src/resources/checks/format/redundant-double-negation.yaml
@@ -3,4 +3,3 @@
 ---
 severity: warning
 message: A double negation not(not(x)) is redundant; it is just boolean(x), and in a test simply x. Replace it.
-mature: true

--- a/src/resources/checks/format/string-length-compared-to-zero.yaml
+++ b/src/resources/checks/format/string-length-compared-to-zero.yaml
@@ -3,4 +3,3 @@
 ---
 severity: warning
 message: string-length(...) is compared with 0 to test emptiness, which measures the whole string. Compare the value with '' instead.
-mature: true

--- a/src/resources/motives/format/count-compared-to-zero.md
+++ b/src/resources/motives/format/count-compared-to-zero.md
@@ -40,3 +40,10 @@ The operand order does not matter: `0 &lt; count($items)` and
 `0 = count($items)` are flagged the same way. A comparison that is not an
 existence test — `count($x) &gt; 1`, `count($x) = 5` — is a genuine count and is
 left alone.
+
+The comparison is caught in the XPath and pattern attributes of XSLT elements and
+inside an attribute value template, where `&lt;div empty="{count($items) = 0}"/&gt;`
+holds a real expression; both a comparison and its rewrite print `true`/`false`
+there, so the fix stays safe. An attribute of your output vocabulary that happens
+to be called `test` or `select` carries text for the result tree, not XPath, and
+is never touched.

--- a/src/resources/motives/format/redundant-boolean-call.md
+++ b/src/resources/motives/format/redundant-boolean-call.md
@@ -9,6 +9,12 @@ dropping it is always safe, so `--fix` removes it. A `boolean(...)` that is only
 part of a larger expression — `a = boolean(b)` — is left alone, because there
 the coercion can change what the comparison means.
 
+Only the `@test` of an XSLT element is read. Nothing coerces the expression of an
+attribute value template, so `&lt;div flag="{boolean(x)}"/&gt;` prints `true` or
+`false` where a bare `{x}` would print the node's own text — the wrapper is doing
+real work there and is kept. An attribute of your output vocabulary called `test`
+is text for the result tree, and is never read as XPath.
+
 Incorrect:
 
 ```xsl

--- a/src/resources/motives/format/using-namespace-axis.md
+++ b/src/resources/motives/format/using-namespace-axis.md
@@ -6,11 +6,15 @@ some 3.0 processors drop it entirely. Use the standard functions
 bindings instead. In XSLT 1.0 the axis is not deprecated and is not flagged, so
 this check fires only on a stylesheet declaring version 2.0 or 3.0.
 
-The axis is caught in every XPath and pattern attribute — a template `match`, a
-`select`, a `test`, a `use` — not only in `match`/`select`. Because the
-expression is tokenized, a `namespace::` inside a string literal is left alone,
-and the lookalike functions `in-scope-prefixes()` and
-`namespace-uri-for-prefix()` are never mistaken for the axis.
+The axis is caught in every XPath and pattern attribute of an XSLT element — a
+template `match`, a `select`, a `test`, a `use` — not only in `match`/`select`,
+and inside an attribute value template, where `&lt;div id="{namespace::*}"/&gt;`
+holds an expression as surely as a `select` does. An attribute of the output
+vocabulary that merely shares one of those names carries text for the result
+tree, not XPath, so it is left alone. Because the expression is tokenized, a
+`namespace::` inside a string literal is left alone too, and the lookalike
+functions `in-scope-prefixes()` and `namespace-uri-for-prefix()` are never
+mistaken for the axis.
 
 Incorrect:
 

--- a/src/string-length-linter.js
+++ b/src/string-length-linter.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes} = require('./xpath')
 const {comparedToZero} = require('./comparisons')
 const {metaOf, suppressed, defect} = require('./checks')
-const {SELECTOR} = require('./attributes')
+const {expressionsOf} = require('./attributes')
 const {logger} = require('./logger')
 
 /**
@@ -127,13 +126,11 @@ const lintByStringLength = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const {file, xsl} of corpus) {
-      for (const attribute of nodes(xsl, SELECTOR)) {
-        for (const {offset, value, replacement} of comparisons(
-          attribute.nodeValue,
-        )) {
+      for (const {node, start, expression} of expressionsOf(xsl)) {
+        for (const {offset, value, replacement} of comparisons(expression)) {
           defects.push(
             defect(
-              CHECK, META, file, attribute, offset,
+              CHECK, META, file, node, start + offset,
               replacement === null ?
                 undefined : {value, replacement, suggestion: true},
             ),

--- a/src/translate-linter.js
+++ b/src/translate-linter.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes} = require('./xpath')
 const {masked, closes} = require('./expressions')
 const {metaOf, suppressed, defect} = require('./checks')
-const {SELECTOR} = require('./attributes')
+const {expressionsOf} = require('./attributes')
 const {logger} = require('./logger')
 
 /**
@@ -154,13 +153,11 @@ const lintByTranslate = function(corpus, suppressions = []) {
   if (!suppressed(CHECK, suppressions)) {
     for (const {file, xsl} of corpus) {
       if (MODERN.includes(xsl.documentElement.getAttribute('version'))) {
-        for (const attribute of nodes(xsl, SELECTOR)) {
-          for (const {offset, value, replacement} of folded(
-            attribute.nodeValue,
-          )) {
+        for (const {node, start, expression} of expressionsOf(xsl)) {
+          for (const {offset, value, replacement} of folded(expression)) {
             defects.push(
               defect(
-                CHECK, META, file, attribute, offset,
+                CHECK, META, file, node, start + offset,
                 {value, replacement, suggestion: true},
               ),
             )

--- a/src/using-namespace-axis-linter.js
+++ b/src/using-namespace-axis-linter.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes} = require('./xpath')
 const {tokenized, TOKENS} = require('./tokens')
 const {metaOf, suppressed, defect} = require('./checks')
-const {SELECTOR} = require('./attributes')
+const {expressionsOf} = require('./attributes')
 const {logger} = require('./logger')
 
 /**
@@ -63,9 +62,9 @@ const lintByNamespaceAxis = function(corpus, suppressions = []) {
   if (!suppressed(CHECK, suppressions)) {
     for (const {file, xsl} of corpus) {
       if (MODERN.includes(xsl.documentElement.getAttribute('version'))) {
-        for (const attribute of nodes(xsl, SELECTOR)) {
-          for (const offset of axes(attribute.nodeValue)) {
-            defects.push(defect(CHECK, META, file, attribute, offset))
+        for (const {node, start, expression} of expressionsOf(xsl)) {
+          for (const offset of axes(expression)) {
+            defects.push(defect(CHECK, META, file, node, start + offset))
           }
         }
       }

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes} = require('./xpath')
 const {tokenized, TOKENS} = require('./tokens')
 const {metaOf, suppressed, defect} = require('./checks')
-const {SELECTOR} = require('./attributes')
+const {expressionsOf} = require('./attributes')
 const {logger} = require('./logger')
 
 /**
@@ -74,12 +73,12 @@ const lintByAxis = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const {file, xsl} of corpus) {
-      for (const attribute of nodes(xsl, SELECTOR)) {
-        for (const {offset, value, replacement} of abbreviable(
-          attribute.nodeValue,
-        )) {
+      for (const {node, start, expression} of expressionsOf(xsl)) {
+        for (const {offset, value, replacement} of abbreviable(expression)) {
           defects.push(
-            defect(CHECK, META, file, attribute, offset, {value, replacement}),
+            defect(
+              CHECK, META, file, node, start + offset, {value, replacement},
+            ),
           )
         }
       }

--- a/test/attributes.test.js
+++ b/test/attributes.test.js
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {expressionsOf} = require('../src/attributes')
+const {xml} = require('../src/helpers')
+const path = require('path')
+const fs = require('fs')
+const assert = require('assert')
+
+/**
+ * The stylesheet whose XSLT attributes, literal result elements, and attribute
+ * value templates the spans are read from.
+ * @type {Document}
+ */
+const SHEET = xml.parsedFromString(
+  fs.readFileSync(
+    path.resolve(
+      __dirname, 'resources', 'attributes', 'literal-result-and-templates.xsl',
+    ),
+    'utf-8',
+  ),
+)
+
+describe('attributes', function() {
+  it('reads every bare and enclosed expression in document order', function() {
+    assert.deepEqual(
+      expressionsOf(SHEET).map(
+        (found) => [found.node.nodeName, found.start, found.expression],
+      ),
+      [
+        ['match', 0, 'section'],
+        ['label', 1, 'count(item) = 0'],
+        ['name', 1, 'name(.)'],
+        ['select', 0, '@x'],
+      ],
+      'cannot read the expressions of the stylesheet',
+    )
+  })
+  it('cannot read a literal result attribute as an expression', function() {
+    assert.ok(
+      expressionsOf(SHEET).every((found) => found.node.nodeName !== 'test'),
+      'reads output text on a literal result element as an expression',
+    )
+  })
+})

--- a/test/expressions.test.js
+++ b/test/expressions.test.js
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {enclosed} = require('../src/expressions')
+const assert = require('assert')
+
+/**
+ * Attribute values paired with the expressions their braces enclose, each
+ * expected as `[offset, expression]`.
+ * @type {Array.<{name: string, value: string,
+ *  found: Array.<[number, string]>}>}
+ */
+const TEMPLATES = [
+  {
+    name: 'encloses a whole value written as one expression',
+    value: '{count(item) = 0}',
+    found: [[1, 'count(item) = 0']],
+  },
+  {
+    name: 'encloses three expressions among literal text',
+    value: 'a{$x}b{$y}c{$z}',
+    found: [[2, '$x'], [7, '$y'], [12, '$z']],
+  },
+  {
+    name: 'keeps a brace inside a string literal out of an expression',
+    value: 'x{concat("}", $y)}z',
+    found: [[2, 'concat("}", $y)']],
+  },
+  {
+    name: 'balances the braces a map constructor opens',
+    value: '{map{"a": 1}("a")}',
+    found: [[1, 'map{"a": 1}("a")']],
+  },
+  {
+    name: 'reads a doubled brace as an escaped one',
+    value: '{{count(item) = 0}}',
+    found: [],
+  },
+  {
+    name: 'encloses an expression standing after an escaped brace',
+    value: '{{literal}} {$x}',
+    found: [[13, '$x']],
+  },
+  {
+    name: 'encloses nothing when a brace never closes',
+    value: 'a{count(item) = 0',
+    found: [],
+  },
+  {
+    name: 'encloses nothing in a value carrying no brace',
+    value: 'plain output text',
+    found: [],
+  },
+]
+
+describe('expressions', function() {
+  TEMPLATES.forEach(({name, value, found}) => {
+    it(name, function() {
+      assert.deepEqual(
+        enclosed(value).map(
+          (expression) => [expression.offset, expression.value],
+        ),
+        found,
+        `cannot enclose the expressions of "${value}"`,
+      )
+    })
+  })
+})

--- a/test/fixer.test.js
+++ b/test/fixer.test.js
@@ -130,6 +130,20 @@ const APPLIED = [
     after: 'count-shifted-comparison.fixed.xsl',
   },
   {
+    name: 'should rewrite a count comparison inside an attribute value ' +
+      'template, leaving the output text of the same line alone, with --fix',
+    flag: '--fix',
+    before: 'count-in-result-attribute.xsl',
+    after: 'count-in-result-attribute.fixed.xsl',
+  },
+  {
+    name: 'should rewrite both count comparisons of one attribute value, the ' +
+      'second shifted by the entity in the first, with --fix',
+    flag: '--fix',
+    before: 'count-in-attribute-value-templates.xsl',
+    after: 'count-in-attribute-value-templates.fixed.xsl',
+  },
+  {
     name: 'should rewrite a string-length comparison to != / = with ' +
       '--fix-suggestions',
     flag: '--fix-suggestions',

--- a/test/resources/attributes/literal-result-and-templates.xsl
+++ b/test/resources/attributes/literal-result-and-templates.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="templates">
+  <xsl:template match="section">
+    <widget test="count(item) = 0" label="{count(item) = 0}"/>
+    <xsl:element name="{name(.)}">
+      <xsl:value-of select="@x"/>
+    </xsl:element>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/axis-packs/axis-in-attribute-value-template.yaml
+++ b/test/resources/axis-packs/axis-in-attribute-value-template.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 3
+  positions: [ [ 4, 37 ], [ 5, 20 ], [ 5, 34 ] ]
+  fixes: [ "", "@", ".." ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <widget test="child::x" label="{child::x}"/>
+      <widget note="{attribute::y}{parent::node()}"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/count-packs/count-in-attribute-value-template.yaml
+++ b/test/resources/count-packs/count-in-attribute-value-template.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: count-compared-to-zero
+found:
+  amount: 4
+  positions: [ [ 4, 44 ], [ 5, 20 ], [ 5, 35 ], [ 6, 25 ] ]
+  fixes: [ "empty(item)", "exists(a)", "empty(b)", "exists(c)" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <widget test="count(item) = 0" label="{count(item) = 0}"/>
+      <widget note="{count(a) &gt; 0}-{count(b) = 0}"/>
+      <xsl:element name="{count(c) &gt; 0}"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/fix/count-in-attribute-value-templates.fixed.xsl
+++ b/test/resources/fix/count-in-attribute-value-templates.fixed.xsl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="count-avts">
+  <xsl:template match="/">
+    <widget note="{exists(a)}-{empty(b)}" test="count(c) = 0"/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/count-in-attribute-value-templates.xsl
+++ b/test/resources/fix/count-in-attribute-value-templates.xsl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="count-avts">
+  <xsl:template match="/">
+    <widget note="{count(a) &gt; 0}-{count(b) = 0}" test="count(c) = 0"/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/count-in-result-attribute.fixed.xsl
+++ b/test/resources/fix/count-in-result-attribute.fixed.xsl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="count-avt">
+  <xsl:template match="/">
+    <widget test="count(item) = 0" label="{empty(item)}"/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/count-in-result-attribute.xsl
+++ b/test/resources/fix/count-in-result-attribute.xsl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="count-avt">
+  <xsl:template match="/">
+    <widget test="count(item) = 0" label="{count(item) = 0}"/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/name-packs/name-in-attribute-value-template.yaml
+++ b/test/resources/name-packs/name-in-attribute-value-template.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: name-compared-to-string
+found:
+  amount: 2
+  positions: [ [ 4, 44 ], [ 5, 20 ] ]
+  fixes: [ "self::para", "not(self::*:row)" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <widget test="name() = 'para'" label="{name() = 'para'}"/>
+      <widget note="{local-name() != 'row'}"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/node-set-packs/node-set-in-result-attribute.yaml
+++ b/test/resources/node-set-packs/node-set-in-result-attribute.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: use-node-set-extension
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <widget select="exsl:node-set($v)/x"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/predicate-position-packs/predicate-position-in-attribute-value-template.yaml
+++ b/test/resources/predicate-position-packs/predicate-position-in-attribute-value-template.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: predicate-position-literal
+found:
+  amount: 3
+  positions: [ [ 4, 48 ], [ 5, 22 ], [ 5, 46 ] ]
+  fixes: [ "1", "last()", "2" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <widget test="x[position() = 1]" label="{x[position() = 1]}"/>
+      <widget note="{a[position() = last()]}{b[position() = 2]}"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/redundant-boolean-call-packs/boolean-call-in-result-attribute.yaml
+++ b/test/resources/redundant-boolean-call-packs/boolean-call-in-result-attribute.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: redundant-boolean-call
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <widget test="boolean(@x)" label="{boolean(@x)}"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/redundant-double-negation-packs/double-negation-in-attribute-value-template.yaml
+++ b/test/resources/redundant-double-negation-packs/double-negation-in-attribute-value-template.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: redundant-double-negation
+found:
+  amount: 3
+  positions: [ [ 4, 41 ], [ 5, 20 ], [ 5, 34 ] ]
+  fixes: [ "boolean(@x)", "boolean(@a)", "boolean(@b)" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <widget test="not(not(@x))" label="{not(not(@x))}"/>
+      <widget note="{not(not(@a))}{not(not(@b))}"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/string-length-packs/string-length-in-attribute-value-template.yaml
+++ b/test/resources/string-length-packs/string-length-in-attribute-value-template.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: string-length-compared-to-zero
+found:
+  amount: 3
+  positions: [ [ 4, 50 ], [ 5, 20 ], [ 5, 44 ] ]
+  fixes: [ "@x = ''", "@a != ''", "@b = ''" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <widget test="string-length(@x) = 0" label="{string-length(@x) = 0}"/>
+      <widget note="{string-length(@a) != 0}{string-length(@b) = 0}"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/translate-packs/translate-in-attribute-value-template.yaml
+++ b/test/resources/translate-packs/translate-in-attribute-value-template.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: translate-for-case
+found:
+  amount: 2
+  positions: [ [ 5, 21 ], [ 6, 25 ] ]
+  fixes: [ "lower-case(@y)", "upper-case(@z)" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <widget test="translate(@x, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"/>
+      <widget label="{translate(@y, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')}"/>
+      <xsl:element name="{translate(@z, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')}"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/using-namespace-axis-packs/namespace-axis-in-attribute-value-template.yaml
+++ b/test/resources/using-namespace-axis-packs/namespace-axis-in-attribute-value-template.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: using-namespace-axis
+found:
+  amount: 3
+  positions: [ [ 4, 41 ], [ 5, 26 ], [ 5, 41 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <widget test="namespace::*" label="{namespace::*}"/>
+      <widget note="{count(namespace::*)}{namespace::x}"/>
+    </xsl:template>
+  </xsl:stylesheet>


### PR DESCRIPTION
Closes #579.

The attribute selector matched by name and nothing else, so on a literal result
element it read output text as XPath while ignoring the one place an expression
really hides. `<widget test="count(item) = 0" label="{count(item) = 0}"/>` came
out of plain `--fix` as `test="empty(item)"` — the result tree rewritten — with
the AVT left untouched. `src/attributes.js` now answers one question for every
code-based linter instead:

```js
const expressionsOf = function(xsl) {
  const bare = new Set(nodes(xsl, SELECTOR))
  return nodes(xsl, '//*/@*').flatMap((attribute) =>
    bare.has(attribute) ?
      [{node: attribute, start: 0, expression: attribute.nodeValue}] :
      enclosed(attribute.nodeValue).map((found) => ({...})),
  )
}
```

`SELECTOR` is `//xsl:*/@name` now, and `enclosed` (in `src/expressions.js`) lexes
each `{...}` out of a value — `{{` escaped, a brace inside a string literal or a
map constructor balanced — so every expression carries the offset it starts at
and reported columns and applied fixes still land where they should. Ten linters
switch over: the eight that shared the selector, plus `node-set` and
`redundant-boolean-call`, which hand-rolled `//@select` and `//@test` and had the
same inversion. Those two keep their narrowing through `selectorOf`, since a
`{boolean(x)}` in an AVT is doing real work; the docblocks say so. A
`no-restricted-syntax` selector now bans a hand-written `//@name` in JS, so the
next linter cannot reintroduce this.

Tests: unit packs for `enclosed` and `expressionsOf`, an AVT pack for each of the
eight checks (plus a negative pack for the two narrowed ones), and two fixer
fixture pairs — the issue's own line, and two AVTs in one value where the second
is shifted by the `&gt;` in the first. The four `mature: true` markers on the
checks whose scope this changes are removed, per the freeze rule; they can be
re-earned after a re-audit.

Two things I did not fix here, both pre-existing and worth their own issues:
`use-node-set-extension` still looks only at `@select`, so the extension in a
`@test` or an AVT goes unreported; and `name-compared-to-string` suggests
`self::x` for `name() = 'x'` regardless of context, which turns a boolean into a
node-set in an AVT or a `value-of/@select` — the same hole it has on master, only
now reachable from one more place.
