### PR TITLE
Audit starts-with-double-slash to maturity

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Given a stylesheet like this:
 xslint points at each problem with its exact position and how to fix it:
 
 ```text
+[WARNING] sheet.xsl(2:1) The '@id' attribute is missing in the 'xsl:stylesheet' element. Declare it to specify the unique identifier explicitly. (missing-id-in-stylesheet)
 [ERROR] sheet.xsl(2:1) The xsl:output instruction is missing. Declare it to specify the serialization format explicitly. (not-using-output)
-[WARNING] sheet.xsl(3:3) The match attribute of xsl:template starts with //, which scans the entire document tree. Use a more specific pattern. (starts-with-double-slash)
 [WARNING] sheet.xsl(4:5) A variable, function, or template has a single-character name. Use a descriptive name that reveals intent. (short-names)
+[WARNING] sheet.xsl(3:23) The pattern starts with //, which is redundant since a pattern already matches at any depth. Remove it, minding that it lowers a template's default priority. (starts-with-double-slash)
 ```
 
 In CI, use the [GitHub Action](https://github.com/xslint/xslint-action) to
@@ -263,9 +264,6 @@ Today this covers nine checks:
   `exists($x)` and `count($x) = 0` becomes `empty($x)`; on 1.0 (where those
   functions don't exist), `boolean($x)` — or a bare `$x` in a whole `@test` —
   and `not($x)`.
-- `starts-with-double-slash` — the redundant leading `//` of a template's
-  `@match` is dropped: `match="//para"` becomes `match="para"`, which selects
-  the same nodes.
 - `redundant-import` — a duplicate `xsl:import`/`xsl:include` of a module
   already imported in the same stylesheet is removed; the module stays imported
   by the first reference.
@@ -305,6 +303,11 @@ Today this covers:
 - `select-starts-with-double-slash` — the leading `//` of a `@select` is
   anchored as `.//`: `select="//title"` becomes `select=".//title"`, scanning
   descendants of the context node instead of the whole document.
+- `starts-with-double-slash` — the redundant leading `//` of a pattern is
+  dropped: `match="//para"` becomes `match="para"`, which selects the same
+  nodes. A suggestion because the priority does not survive the edit: a
+  template matching `//para` defaults to priority 0.5 and one matching `para`
+  to 0, so a rule it used to beat, or tie with, can start winning.
 - `confusing-variable-and-node` — a bare variable name used as a node selector
   gets its `$`: `<xsl:apply-templates select="items"/>` becomes
   `select="$items"`, assuming the variable was meant over a child element.

--- a/src/fixers.js
+++ b/src/fixers.js
@@ -67,21 +67,28 @@ const modeOrPriority = function(node) {
 }
 
 /**
- * Fix for `starts-with-double-slash`: drop the leading `//` of the template's
- * `@match`. In a match pattern the leading `//` is redundant — a pattern is
- * already unanchored — so removing it preserves the matched nodes, which makes
- * this a safe fix rather than a suggestion.
- * @param {Element} node - The `xsl:template` element
- * @return {object} - The safe fix
+ * Fix for `starts-with-double-slash`: drop the leading `//` of the pattern,
+ * together with whatever whitespace precedes it. The pattern selects the same
+ * nodes either way, since a pattern is matched unanchored, but a template's
+ * default priority falls from 0.5 to 0 once the leading step is gone, handing
+ * a conflict to whichever rule it used to tie with — a suggestion, then,
+ * rather than a safe fix. Pattern attributes reach no Xpath validator, so a
+ * pattern of nothing but the slashes arrives here too; emptying it would only
+ * trade one broken pattern for another, and it gets no fix.
+ * @param {Node} node - The pattern attribute
+ * @return {?object} - The suggestion fix, or null
  */
 const startsWithDoubleSlash = function(node) {
-  const match = node.getAttributeNode('match')
-  return {
-    line: match.lineNumber,
-    col: match.columnNumber - match.name.length - 1,
-    value: `${match.name}="${match.value}"`,
-    replacement: `${match.name}="${match.value.slice(2)}"`,
-  }
+  const lead = node.value.length - node.value.trimStart().length
+  return node.value.trim().length > 2 ?
+    {
+      line: node.lineNumber,
+      col: node.columnNumber + 1,
+      value: node.value.slice(0, lead + 2),
+      replacement: '',
+      suggestion: true,
+    } :
+    null
 }
 
 /**

--- a/src/resources/checks/xpath/starts-with-double-slash.yaml
+++ b/src/resources/checks/xpath/starts-with-double-slash.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //xsl:template[starts-with(@match, '//')]
+xpath: ((//xsl:template | //xsl:key | //xsl:accumulator-rule)/@match | //xsl:number/(@count | @from) | //xsl:for-each-group/(@group-starting-with | @group-ending-with))[starts-with(normalize-space(), '//')]
 severity: warning
-message: The match attribute of xsl:template starts with //, which is redundant since an unanchored pattern already matches at any depth. Remove the leading //.
+message: The pattern starts with //, which is redundant since a pattern already matches at any depth. Remove it, minding that it lowers a template's default priority.
+mature: true

--- a/src/resources/checks/xpath/use-double-slash.yaml
+++ b/src/resources/checks/xpath/use-double-slash.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //xsl:template[not(starts-with(@match, '//')) and contains(@match, '//')]
+xpath: //xsl:template[not(starts-with(normalize-space(@match), '//')) and contains(@match, '//')]
 severity: warning
 message: The match attribute of xsl:template contains //, which matches at any depth and is broader than intended. Use a specific path.

--- a/src/resources/motives/xpath/starts-with-double-slash.md
+++ b/src/resources/motives/xpath/starts-with-double-slash.md
@@ -1,10 +1,15 @@
 # Starts with double slash
 
-A leading `//` on a `match` pattern is redundant: a template pattern is not
-anchored, so `match="//item"` already selects exactly the same nodes as
-`match="item"` — every `item`, at any depth. The `//` adds nothing but noise
-(and, read carelessly, suggests a document scan that never happens). Drop it
-and let the pattern say plainly which element it matches.
+A leading `//` on a pattern buys nothing and costs something. Every XSLT
+pattern is matched unanchored — a node matches when the pattern selects it from
+some ancestor-or-self of it — so `match="//item"` already selects exactly what
+`match="item"` selects: every `item`, at any depth. What the `//` does change is
+the pattern's *default priority*. A pattern built from a single name test has
+priority 0; put a `/` step in front of it and the whole pattern jumps to 0.5. So
+`match="//item"` quietly outranks a plain `match="item"` and ties with a
+considered `match="list/item"` — and a tie is an error the processor may either
+signal or resolve by taking whichever rule was declared last. Sooner or later a
+rule you meant to be specific loses to one you meant as a catch-all.
 
 Incorrect:
 
@@ -21,3 +26,18 @@ Correct:
   <xsl:value-of select="."/>
 </xsl:template>
 ```
+
+The check reads every attribute that holds a pattern, not only a template's:
+`xsl:key/@match`, `xsl:accumulator-rule/@match`, `xsl:number/@count` and
+`@from`, and `@group-starting-with`/`@group-ending-with` on
+`xsl:for-each-group`. Whitespace in front of the slashes does not hide them. An
+inner `//` (`list//item`) belongs to `use-double-slash`, and a `//` opening a
+`@select` — where it really is a whole-document scan — to
+`select-starts-with-double-slash`.
+
+Dropping the slashes is offered as a **suggestion**, applied by
+`--fix-suggestions` and never by plain `--fix`, for the reason above: the node
+set survives the edit, the default priority does not, so a stylesheet whose
+templates compete over a node can transform differently afterwards. On a key, an
+accumulator rule, or a numbering or grouping pattern no priority is at stake and
+the edit is purely cosmetic, but the check offers one tier rather than two.

--- a/src/resources/motives/xpath/use-double-slash.md
+++ b/src/resources/motives/xpath/use-double-slash.md
@@ -22,3 +22,7 @@ Correct:
   <xsl:value-of select="."/>
 </xsl:template>
 ```
+
+A pattern that *opens* with `//`, with or without whitespace before it, is a
+different defect — redundant rather than vague — and belongs to
+`starts-with-double-slash`, which is where its fix lives too.

--- a/test/fixer.test.js
+++ b/test/fixer.test.js
@@ -101,12 +101,6 @@ const APPLIED = [
     after: 'redundant-namespace-declarations.fixed.xsl',
   },
   {
-    name: 'should drop the redundant leading slashes of a match with --fix',
-    flag: '--fix',
-    before: 'starts-with-double-slash.xsl',
-    after: 'starts-with-double-slash.fixed.xsl',
-  },
-  {
     name: 'should delete a redundant import with --fix',
     flag: '--fix',
     before: 'redundant-import.xsl',
@@ -230,6 +224,13 @@ const APPLIED = [
     after: 'select-starts-with-double-slash.fixed.xsl',
   },
   {
+    name: 'should drop the redundant leading slashes of every pattern with ' +
+      '--fix-suggestions',
+    flag: '--fix-suggestions',
+    before: 'starts-with-double-slash.xsl',
+    after: 'starts-with-double-slash.fixed.xsl',
+  },
+  {
     name: 'should prepend $ to a bare variable name with --fix-suggestions',
     flag: '--fix-suggestions',
     before: 'confusing-variable-and-node.xsl',
@@ -268,8 +269,8 @@ const APPLIED = [
 ]
 
 /**
- * Cases where a flag leaves the `sheet` fixture untouched — a dry run, or a
- * plain `--fix` declining a suggestion.
+ * Cases where a flag leaves the `sheet` fixture untouched — a dry run, a plain
+ * `--fix` declining a suggestion, or a defect whose builder offers no fix.
  * @type {Array.<{name: string, flag: string, sheet: string}>}
  */
 const UNCHANGED = [
@@ -354,6 +355,17 @@ const UNCHANGED = [
     sheet: 'select-starts-with-double-slash.xsl',
   },
   {
+    name: 'cannot drop the leading slashes of a match with plain --fix',
+    flag: '--fix',
+    sheet: 'starts-with-double-slash.xsl',
+  },
+  {
+    name: 'cannot empty a pattern that is nothing but slashes with ' +
+      '--fix-suggestions',
+    flag: '--fix-suggestions',
+    sheet: 'starts-with-double-slash-degenerate.xsl',
+  },
+  {
     name: 'cannot prepend $ to a bare variable name with plain --fix',
     flag: '--fix',
     sheet: 'confusing-variable-and-node.xsl',
@@ -384,7 +396,7 @@ const DROPPED = [
   {
     name: 'should drop the fixed starts-with-double-slash defect from the ' +
       'report',
-    flag: '--fix',
+    flag: '--fix-suggestions',
     sheet: 'starts-with-double-slash.xsl',
     check: 'starts-with-double-slash',
   },

--- a/test/resources/fix/starts-with-double-slash-degenerate.xsl
+++ b/test/resources/fix/starts-with-double-slash-degenerate.xsl
@@ -4,11 +4,7 @@
 * SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-  <xsl:key name="lookup" match="//keyed" use="@id"/>
-  <xsl:template match="//objects">
+  <xsl:template match="//">
     <xsl:copy-of select="."/>
-  </xsl:template>
-  <xsl:template match="  //nested/deep">
-    <xsl:number count="//numbered" from="//started"/>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/resources/fix/starts-with-double-slash.fixed.xsl
+++ b/test/resources/fix/starts-with-double-slash.fixed.xsl
@@ -4,7 +4,11 @@
 * SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:key name="lookup" match="keyed" use="@id"/>
   <xsl:template match="objects">
     <xsl:copy-of select="."/>
+  </xsl:template>
+  <xsl:template match="nested/deep">
+    <xsl:number count="numbered" from="started"/>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/resources/xpath-packs/pattern-attributes-start-with-double-slash.yaml
+++ b/test/resources/xpath-packs/pattern-attributes-start-with-double-slash.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: starts-with-double-slash
+found:
+  amount: 6
+  positions: [ [ 4, 30 ], [ 6, 31 ], [ 9, 21 ], [ 9, 39 ], [ 10, 57 ], [ 13, 55 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <t:transform xmlns:t="http://www.w3.org/1999/XSL/Transform" version="3.0" id="style2">
+    <t:output encoding="UTF-8" method="xml"/>
+    <t:key name="lookup" match="//keyed" use="@id"/>
+    <t:accumulator name="total" initial-value="0">
+      <t:accumulator-rule match="//counted" select="$value + 1"/>
+    </t:accumulator>
+    <t:template match="objects">
+      <t:number count="//numbered" from="//started"/>
+      <t:for-each-group select="item" group-starting-with="//grouped">
+        <t:copy-of select="."/>
+      </t:for-each-group>
+      <t:for-each-group select="item" group-ending-with="//ended">
+        <t:copy-of select="."/>
+      </t:for-each-group>
+    </t:template>
+  </t:transform>

--- a/test/resources/xpath-packs/starts-with-double-slash.yaml
+++ b/test/resources/xpath-packs/starts-with-double-slash.yaml
@@ -3,17 +3,25 @@
 ---
 pack: starts-with-double-slash
 found:
-  amount: 1
-  positions: [ [ 4, 3 ] ]
+  amount: 4
+  positions: [ [ 4, 23 ], [ 7, 23 ], [ 10, 23 ], [ 16, 3, use-double-slash ] ]
 input: |-
   <?xml version="1.0"?>
-  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" id="style1">
     <xsl:output encoding="UTF-8" method="xml"/>
     <xsl:template match="//objects">
       <xsl:copy-of select="."/>
     </xsl:template>
-    <xsl:template match="/objects/o/o[1]/o[1]">
-      <xsl:variable name="qw" as="xs:string" select="ooo" />
-      <xsl:copy-of select="$qw"/>
+    <xsl:template match="  //nested/deep[@id]">
+      <xsl:copy-of select="."/>
+    </xsl:template>
+    <xsl:template match="//third[parent::objects]">
+      <xsl:copy-of select="."/>
+    </xsl:template>
+    <xsl:template match="/objects/deep[1]">
+      <xsl:copy-of select="."/>
+    </xsl:template>
+    <xsl:template match="objects//deep">
+      <xsl:copy-of select="."/>
     </xsl:template>
   </xsl:stylesheet>

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -31,7 +31,7 @@ describe('xslint', function() {
       'Processed files: 1',
       '(16:3) A variable is assigned via a nested xsl:value-of instead of the select attribute. Use select syntax instead. (setting-value-of-variable-incorrectly)',
       '(16:3) A variable, function, or template has a single-character name. Use a descriptive name that reveals intent. (short-names)',
-      '(31:3) The match attribute of xsl:template starts with //, which is redundant since an unanchored pattern already matches at any depth. Remove the leading //. (starts-with-double-slash)',
+      '(31:23) The pattern starts with //, which is redundant since a pattern already matches at any depth. Remove it, minding that it lowers a template\'s default priority. (starts-with-double-slash)',
       '(45:3) A named template is never invoked via xsl:call-template. Remove it or call it. (unused-named-template)',
     ]
     expected.forEach((str) => assert.ok(stdout.includes(str)))
@@ -107,7 +107,7 @@ describe('xslint', function() {
       'Processed files: 1',
       '(16:3) A variable is assigned via a nested xsl:value-of instead of the select attribute. Use select syntax instead. (setting-value-of-variable-incorrectly)',
       '(16:3) A variable, function, or template has a single-character name. Use a descriptive name that reveals intent. (short-names)',
-      '(31:3) The match attribute of xsl:template starts with //, which is redundant since an unanchored pattern already matches at any depth. Remove the leading //. (starts-with-double-slash)',
+      '(31:23) The pattern starts with //, which is redundant since a pattern already matches at any depth. Remove it, minding that it lowers a template\'s default priority. (starts-with-double-slash)',
       '(45:3) A named template is never invoked via xsl:call-template. Remove it or call it. (unused-named-template)',
     ]
     assert.ok(stdout.includes('Empty suppress is incorrect. Delete this "--suppress" or use another one.'))


### PR DESCRIPTION
The `--fix` for this check was not safe. Dropping the leading `//` off a
`match` keeps the node set but not the priority: a pattern with a `/` step
defaults to 0.5, a lone name test to 0. On this sheet xsltproc printed
`DOUBLESLASH` before a plain `--fix` and `SPECIFIC` after it.

```xsl
<xsl:template match="list/item">SPECIFIC</xsl:template>
<xsl:template match="//item">DOUBLESLASH</xsl:template>
```

So the edit moves behind `--fix-suggestions`, and it now deletes only the
whitespace and the slashes rather than rebuilding the whole attribute. A
pattern that is nothing but slashes gets no fix at all — emptying it would
trade one broken pattern for another, and patterns reach no XPath validator.

The selector moves off the element and onto the pattern attributes
themselves, which picks up the five it never saw — `xsl:key/@match`,
`xsl:accumulator-rule/@match`, `xsl:number/@count` and `@from`, and the
grouping patterns of `xsl:for-each-group` — and yields one defect per
attribute, so `<xsl:number count="//a" from="//b"/>` reports and fixes both.
Leading whitespace no longer hides the slashes either; `match=" //x"` used to
slip through to `use-double-slash`, which told the author to "use a specific
path" when the `//` was merely redundant. That check normalizes its negation
now so the two stay disjoint.

Both motives are rewritten around the priority shift, the fix tier, and the
line between the two checks. The README sample output was quoting a message
the check stopped emitting some time ago, and the check moves from the `--fix`
list to the suggestions list. Packs grow to the hard-case bar — whitespace,
buried, three or more, negative neighbours, a non-`xsl` prefix, an
`xsl:transform` root, XSLT 1.0/2.0/3.0 — with a new pack for the non-template
patterns. The check carries `mature: true`.

Locally: 590 tests pass, coverage is 100% on all four metrics, and xcop,
yamllint, markdownlint, typos and the fixtures gate are clean.

One thing left alone, worth its own issue: a `//` opening a later union branch
(`match="a | //b"`) still lands in `use-double-slash` with the wrong wording,
and that check is still confined to `xsl:template`.

Closes #583
