### PR TITLE
Demote the starts-with-double-slash fix to a suggestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ publication date only; detailed notes begin with the Unreleased section.
 
 ## Unreleased
 
+- Move the `starts-with-double-slash` fix behind `--fix-suggestions`. Dropping
+  the leading `//` off a `@match` keeps the matched nodes but not the default
+  priority — a pattern with a `/` step is 0.5, a lone name test 0 — so a plain
+  `--fix` could hand a conflict to a rule the template used to outrank. A
+  pattern of nothing but the slashes now gets no fix, since emptying it would
+  trade one broken pattern for another (#583).
+
 - Add the `redundant-double-negation` check: `not(not(x))` is a redundant
   double negation — exactly `boolean(x)`. Reported in any `@test`/`@select`,
   with a safe `--fix` that rewrites it to `boolean(x)` (always equivalent). An

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Given a stylesheet like this:
 xslint points at each problem with its exact position and how to fix it:
 
 ```text
+[WARNING] sheet.xsl(2:1) The '@id' attribute is missing in the 'xsl:stylesheet' element. Declare it to specify the unique identifier explicitly. (missing-id-in-stylesheet)
 [ERROR] sheet.xsl(2:1) The xsl:output instruction is missing. Declare it to specify the serialization format explicitly. (not-using-output)
-[WARNING] sheet.xsl(3:3) The match attribute of xsl:template starts with //, which scans the entire document tree. Use a more specific pattern. (starts-with-double-slash)
 [WARNING] sheet.xsl(4:5) A variable, function, or template has a single-character name. Use a descriptive name that reveals intent. (short-names)
+[WARNING] sheet.xsl(3:3) The match attribute of xsl:template starts with //, which is redundant since an unanchored pattern already matches at any depth. Remove the leading //. (starts-with-double-slash)
 ```
 
 In CI, use the [GitHub Action](https://github.com/xslint/xslint-action) to
@@ -248,7 +249,7 @@ place:
 xslint --fix path/to/dir
 ```
 
-Today this covers ten checks:
+Today this covers nine checks:
 
 - `redundant-whitespace` — a doubled space is collapsed to one, and a space
   leading or trailing an XPath expression is removed.
@@ -263,9 +264,6 @@ Today this covers ten checks:
   `exists($x)` and `count($x) = 0` becomes `empty($x)`; on 1.0 (where those
   functions don't exist), `boolean($x)` — or a bare `$x` in a whole `@test` —
   and `not($x)`.
-- `starts-with-double-slash` — the redundant leading `//` of a template's
-  `@match` is dropped: `match="//para"` becomes `match="para"`, which selects
-  the same nodes.
 - `redundant-import` — a duplicate `xsl:import`/`xsl:include` of a module
   already imported in the same stylesheet is removed; the module stays imported
   by the first reference.
@@ -305,6 +303,11 @@ Today this covers:
 - `select-starts-with-double-slash` — the leading `//` of a `@select` is
   anchored as `.//`: `select="//title"` becomes `select=".//title"`, scanning
   descendants of the context node instead of the whole document.
+- `starts-with-double-slash` — the redundant leading `//` of a template's
+  `@match` is dropped: `match="//para"` becomes `match="para"`, which selects
+  the same nodes. A suggestion because the priority does not survive the edit:
+  a template matching `//para` defaults to priority 0.5 and one matching
+  `para` to 0, so a rule it used to beat, or tie with, can start winning.
 - `confusing-variable-and-node` — a bare variable name used as a node selector
   gets its `$`: `<xsl:apply-templates select="items"/>` becomes
   `select="$items"`, assuming the variable was meant over a child element.

--- a/src/fixers.js
+++ b/src/fixers.js
@@ -68,20 +68,26 @@ const modeOrPriority = function(node) {
 
 /**
  * Fix for `starts-with-double-slash`: drop the leading `//` of the template's
- * `@match`. In a match pattern the leading `//` is redundant — a pattern is
- * already unanchored — so removing it preserves the matched nodes, which makes
- * this a safe fix rather than a suggestion.
+ * `@match`. The pattern selects the same nodes either way, since a pattern is
+ * matched unanchored, but the template's default priority falls from 0.5 to 0
+ * once the leading step is gone, handing a conflict to whichever rule it used
+ * to tie with — a suggestion, then, rather than a safe fix. A pattern of
+ * nothing but the slashes reaches no XPath validator, so it arrives here too;
+ * emptying it would trade one broken pattern for another, and it gets no fix.
  * @param {Element} node - The `xsl:template` element
- * @return {object} - The safe fix
+ * @return {?object} - The suggestion fix, or null
  */
 const startsWithDoubleSlash = function(node) {
   const match = node.getAttributeNode('match')
-  return {
-    line: match.lineNumber,
-    col: match.columnNumber - match.name.length - 1,
-    value: `${match.name}="${match.value}"`,
-    replacement: `${match.name}="${match.value.slice(2)}"`,
-  }
+  return match.value.length > 2 ?
+    {
+      line: match.lineNumber,
+      col: match.columnNumber - match.name.length - 1,
+      value: `${match.name}="${match.value}"`,
+      replacement: `${match.name}="${match.value.slice(2)}"`,
+      suggestion: true,
+    } :
+    null
 }
 
 /**

--- a/src/resources/motives/xpath/starts-with-double-slash.md
+++ b/src/resources/motives/xpath/starts-with-double-slash.md
@@ -1,10 +1,15 @@
 # Starts with double slash
 
-A leading `//` on a `match` pattern is redundant: a template pattern is not
-anchored, so `match="//item"` already selects exactly the same nodes as
-`match="item"` — every `item`, at any depth. The `//` adds nothing but noise
-(and, read carelessly, suggests a document scan that never happens). Drop it
-and let the pattern say plainly which element it matches.
+A leading `//` on a `match` pattern buys nothing and costs something. Every XSLT
+pattern is matched unanchored — a node matches when the pattern selects it from
+some ancestor-or-self of it — so `match="//item"` already selects exactly what
+`match="item"` selects: every `item`, at any depth. What the `//` does change is
+the pattern's *default priority*. A pattern built from a single name test has
+priority 0; put a `/` step in front of it and the whole pattern jumps to 0.5. So
+`match="//item"` quietly outranks a plain `match="item"` and ties with a
+considered `match="list/item"` — and a tie is an error the processor may either
+signal or resolve by taking whichever rule was declared last. Sooner or later a
+rule you meant to be specific loses to one you meant as a catch-all.
 
 Incorrect:
 
@@ -21,3 +26,14 @@ Correct:
   <xsl:value-of select="."/>
 </xsl:template>
 ```
+
+An inner `//` (`list//item`) is a different defect — vague rather than redundant
+— and belongs to `use-double-slash`, while a `//` opening a `@select`, where it
+really is a whole-document scan, belongs to `select-starts-with-double-slash`.
+
+Dropping the slashes is offered as a **suggestion**, applied by
+`--fix-suggestions` and never by plain `--fix`, for the reason above: the node
+set survives the edit, the default priority does not, so a stylesheet whose
+templates compete over a node can transform differently afterwards. A pattern of
+nothing but the slashes gets no fix at all — emptying it would trade one broken
+pattern for another.

--- a/src/resources/motives/xpath/use-double-slash.md
+++ b/src/resources/motives/xpath/use-double-slash.md
@@ -22,3 +22,8 @@ Correct:
   <xsl:value-of select="."/>
 </xsl:template>
 ```
+
+A pattern that *opens* with `//` is a different defect — redundant rather than
+vague — and belongs to `starts-with-double-slash`, which is where its fix lives
+too. This check stays report-only: only the author knows which path was meant,
+so there is nothing deterministic to rewrite `root//item` into.

--- a/test/fixer.test.js
+++ b/test/fixer.test.js
@@ -101,12 +101,6 @@ const APPLIED = [
     after: 'redundant-namespace-declarations.fixed.xsl',
   },
   {
-    name: 'should drop the redundant leading slashes of a match with --fix',
-    flag: '--fix',
-    before: 'starts-with-double-slash.xsl',
-    after: 'starts-with-double-slash.fixed.xsl',
-  },
-  {
     name: 'should delete a redundant import with --fix',
     flag: '--fix',
     before: 'redundant-import.xsl',
@@ -244,6 +238,13 @@ const APPLIED = [
     after: 'select-starts-with-double-slash.fixed.xsl',
   },
   {
+    name: 'should drop the redundant leading slashes of a match with ' +
+      '--fix-suggestions',
+    flag: '--fix-suggestions',
+    before: 'starts-with-double-slash.xsl',
+    after: 'starts-with-double-slash.fixed.xsl',
+  },
+  {
     name: 'should prepend $ to a bare variable name with --fix-suggestions',
     flag: '--fix-suggestions',
     before: 'confusing-variable-and-node.xsl',
@@ -289,8 +290,8 @@ const APPLIED = [
 ]
 
 /**
- * Cases where a flag leaves the `sheet` fixture untouched — a dry run, or a
- * plain `--fix` declining a suggestion.
+ * Cases where a flag leaves the `sheet` fixture untouched — a dry run, a plain
+ * `--fix` declining a suggestion, or a defect whose builder offers no fix.
  * @type {Array.<{name: string, flag: string, sheet: string}>}
  */
 const UNCHANGED = [
@@ -375,6 +376,17 @@ const UNCHANGED = [
     sheet: 'select-starts-with-double-slash.xsl',
   },
   {
+    name: 'cannot drop the leading slashes of a match with plain --fix',
+    flag: '--fix',
+    sheet: 'starts-with-double-slash.xsl',
+  },
+  {
+    name: 'cannot empty a pattern that is nothing but slashes with ' +
+      '--fix-suggestions',
+    flag: '--fix-suggestions',
+    sheet: 'starts-with-double-slash-degenerate.xsl',
+  },
+  {
     name: 'cannot prepend $ to a bare variable name with plain --fix',
     flag: '--fix',
     sheet: 'confusing-variable-and-node.xsl',
@@ -410,7 +422,7 @@ const DROPPED = [
   {
     name: 'should drop the fixed starts-with-double-slash defect from the ' +
       'report',
-    flag: '--fix',
+    flag: '--fix-suggestions',
     sheet: 'starts-with-double-slash.xsl',
     check: 'starts-with-double-slash',
   },

--- a/test/resources/fix/starts-with-double-slash-degenerate.xsl
+++ b/test/resources/fix/starts-with-double-slash-degenerate.xsl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="//">
+    <xsl:copy-of select="."/>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
A plain `--fix` was rewriting `match="//item"` into `match="item"` and silently
reranking the stylesheet. The two patterns select the same nodes — every XSLT
pattern is matched unanchored — but a pattern carrying a `/` step defaults to
priority 0.5 and a lone name test to 0, so the template stops outranking rules
it used to beat. On this sheet xsltproc prints `DOUBLESLASH` before the fix and
`SPECIFIC` after it:

```xsl
<xsl:template match="list/item">SPECIFIC</xsl:template>
<xsl:template match="//item">DOUBLESLASH</xsl:template>
```

So the edit moves behind `--fix-suggestions`. A pattern of nothing but the
slashes now gets no fix either — patterns reach no XPath validator, so
`match="//"` arrives at the builder, and emptying it would trade one broken
pattern for another. Both motives gain the priority argument, the fix tier, and
the line between the two double-slash checks; the README sample output was
quoting a message the check stopped emitting and was missing a defect it
reports.

This is the tier half of #583 and deliberately not the rest. The issue also
asks for a widened selector and `mature: true`, and both belong in a
token-based rewrite instead: detection by `contains()` over raw attribute text
cannot tell a step from a `//` inside a string literal (`match="a[@n = 'p//q']"`
reports today) or inside an XPath comment, and cannot see a `//` opening a union
branch (`match="a | //b"` lands in `use-double-slash` with the wrong advice).
`src/tokens.js` already resolves all three. A follow-up will move both checks
onto it and earn the maturity flag there.

Refs #583
