### PR TITLE
Unfreeze the two validation checks that fail the maturity bar

### DIFF
--- a/src/resources/checks/validation/invalid-xpath-expression.yaml
+++ b/src/resources/checks/validation/invalid-xpath-expression.yaml
@@ -3,4 +3,3 @@
 ---
 severity: error
 message: An XPath expression is malformed and cannot be parsed. Fix its syntax.
-mature: true

--- a/src/resources/checks/validation/malformed-stylesheet.yaml
+++ b/src/resources/checks/validation/malformed-stylesheet.yaml
@@ -3,4 +3,3 @@
 ---
 severity: error
 message: The stylesheet is not well-formed XML and cannot be parsed. Fix its syntax.
-mature: true


### PR DESCRIPTION
Two of the three checks carrying `mature: true` still have open bugs against
their detection, and the flag is a freeze — CLAUDE.md promises a mature check
has no false negative and is not to be re-audited. So the freeze currently sits
around the bug.

```yaml
 severity: error
 message: The stylesheet is not well-formed XML and cannot be parsed. Fix its syntax.
-mature: true
```

`malformed-stylesheet` misses the two commonest ways a hand-written stylesheet
stops being XML. `<a>Tom & Jerry</a>` runs to "No defects found" where
`xmllint` reports `xmlParseEntityRef: no name`, and `<xsl:value-of
select=$broken/>` is repaired by the parser into `select="$broken"` — graded a
warning, so `parserFor` lets it through — after which the linters go to work on
an attribute nobody wrote. That is #574, which already says the flag cannot
hold.

`invalid-xpath-expression` never sees a pattern or an attribute value template,
while `src/attributes.js` hands both to every code-based linter regardless. On
`match="a[count(b) = 0"`, one bracket short, the run reports only
`count-compared-to-zero`, a plain `--fix` writes back `match="a[empty(b)"`, and
the second run calls the file clean. Filed as #589; #576 is the same hole from
the arity side.

Nothing else moves. `test/conformance.test.js` tightens only on checks that
carry the flag, so the suite is unchanged at 586 passing with coverage still
100% on all four metrics. The third mature check,
`variable-or-param-with-select-and-content`, holds up under the same audit and
keeps its flag — its one wart is that `setting-value-of-variable-incorrectly`
double-reports the same node with contradictory advice, and the narrowing
belongs in that selector, filed as #590.

Both checks earn the flag back when #574, #576 and #589 close.

Closes #588
