### PR TITLE
bug(#564): lex an axis with whitespace before its colons

### DIFF
--- a/src/tokens.js
+++ b/src/tokens.js
@@ -168,32 +168,29 @@ const opensComment = function(xpath, at) {
 }
 
 /**
- * Whether an axis opens at given offset.
+ * The axis opening at the given offset, or null when none does. XPath allows
+ * whitespace between the axis name and its `::`, so `child ::` names the same
+ * axis as `child::`; the name and the colons are matched across that gap and
+ * the length spans it, while the two colons themselves stay adjacent.
  * @param {string} xpath - Xpath expression
  * @param {number} at - Offset to test
- * @return {string} - Axis
+ * @return {?{name: string, length: number}} - The axis name and matched length
  */
 const opensAxis = function(xpath, at) {
-  let axis = ''
-  if (at < xpath.length && xpath[at].match(/[a-zA-Z]/)) {
-    do {
-      axis += xpath[at]
-      at++
-      if (xpath[at] === ':') {
-        if (xpath[at + 1] === ':') {
-          axis += xpath.slice(at, at + 2)
-          at++
-        } else {
-          axis = ''
-        }
-        break
-      }
-    } while (at < xpath.length && xpath[at].match(/[a-zA-Z\-:]/))
+  let end = at
+  while (end < xpath.length && xpath[end].match(/[a-zA-Z-]/)) {
+    end += 1
   }
-  if (!AXES[axis]) {
-    axis = ''
+  let colons = end
+  while (colons < xpath.length && WHITESPACE.includes(xpath[colons])) {
+    colons += 1
   }
-  return axis
+  const name = `${xpath.slice(at, end)}::`
+  if (end === at || xpath[colons] !== ':' || xpath[colons + 1] !== ':' ||
+    !AXES[name]) {
+    return null
+  }
+  return {name: name, length: colons + 2 - at}
 }
 
 /**
@@ -405,7 +402,7 @@ const tokenized = function(xpath) {
       type = TOKENS.WHITESPACE
       at = afterWhitespace(xpath, at)
     } else if (axis) {
-      type = AXES[axis]
+      type = AXES[axis.name]
       at += axis.length
     } else if (opensNumber(xpath, at)) {
       type = TOKENS.NUMBER

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -27,12 +27,14 @@ const META = metaOf(CHECK)
 const names = [CHECK]
 
 /**
- * The abbreviation of each single-token axis specifier.
- * @type {{[type: string]: {value: string, replacement: string}}}
+ * The abbreviation each single-token axis specifier collapses to. The verbatim
+ * text comes from the token, so a spaced `child ::` is stripped in full rather
+ * than leaving its whitespace behind.
+ * @type {{[type: string]: {replacement: string}}}
  */
 const SHORT = {
-  [TOKENS.CHILD]: {value: 'child::', replacement: ''},
-  [TOKENS.ATTRIBUTE]: {value: 'attribute::', replacement: '@'},
+  [TOKENS.CHILD]: {replacement: ''},
+  [TOKENS.ATTRIBUTE]: {replacement: '@'},
 }
 
 /**
@@ -49,7 +51,11 @@ const abbreviable = function(expression) {
   const found = []
   for (const token of tokenized(expression)) {
     if (SHORT[token.type]) {
-      found.push({offset: token.start, ...SHORT[token.type]})
+      found.push({
+        offset: token.start,
+        value: token.value,
+        replacement: SHORT[token.type].replacement,
+      })
     } else if (
       token.type === TOKENS.PARENT &&
       expression.slice(token.start, token.start + 14) === 'parent::node()'

--- a/test/resources/axis-packs/whitespaced-axis.yaml
+++ b/test/resources/axis-packs/whitespaced-axis.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 3
+  positions: [ [ 3, 26 ], [ 4, 29 ], [ 5, 27 ] ]
+  fixes: [ "", "", "@" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="R/child ::qwer">
+      <xsl:value-of select="a[child ::title]"/>
+      <xsl:value-of select="attribute ::name"/>
+      <xsl:value-of select="descendant ::x"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/using-namespace-axis-packs/whitespaced-namespace-axis.yaml
+++ b/test/resources/using-namespace-axis-packs/whitespaced-namespace-axis.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: using-namespace-axis
+found:
+  amount: 3
+  positions: [ [ 3, 26 ], [ 4, 26 ], [ 4, 42 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="*[namespace ::foo]">
+      <xsl:copy-of select="namespace ::a | namespace::b"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -66,11 +66,22 @@ const SCANS = [
     ],
   },
   {
+    name: 'finds an axis with whitespace before the colons',
+    count: 1,
+    pairs: [
+      ['child ::abc', TOKENS.CHILD],
+      ['namespace ::*', TOKENS.NAMESPACE],
+      ['attribute\t::ghi', TOKENS.ATTRIBUTE],
+      ['descendant-or-self\n::def', TOKENS.DESCENDANT_OR_SELF],
+    ],
+  },
+  {
     name: 'finds no axes',
     count: 0,
     pairs: [
       ['child:abc', TOKENS.CHILD],
       ['descendant-or-self', TOKENS.DESCENDANT_OR_SELF],
+      ['child : :abc', TOKENS.CHILD],
     ],
   },
 ]
@@ -110,6 +121,12 @@ describe('tokens', function() {
     assert.equal(
       tokenized('a  b').find((token) => token.type === TOKENS.WHITESPACE).start,
       1,
+    )
+  })
+  it('keeps the whitespace before the colons inside an axis token value', function() {
+    assert.equal(
+      tokenized('child ::x').find((token) => token.type === TOKENS.CHILD).value,
+      'child ::',
     )
   })
   it('keeps a string literal whole despite the spaces inside it', function() {


### PR DESCRIPTION
XPath lets whitespace sit between an axis name and its `::`, so `child ::` names
the same axis as `child::`. The shared lexer did not: `opensAxis` demanded the
colons immediately after the name, so a spaced `child ::`, `attribute ::`, or
`namespace ::` tokenized as ordinary text and slipped past both `unabbreviated-axis`
and `using-namespace-axis`. That is the whitespace half of #564.

`opensAxis` now matches the name, skips any whitespace, and requires the two
colons (which themselves stay adjacent), returning the canonical name plus the
real matched length so offsets stay exact:

```js
const name = `${xpath.slice(at, end)}::`
if (end === at || xpath[colons] !== ':' || xpath[colons + 1] !== ':' ||
  !AXES[name]) {
  return null
}
return {name: name, length: colons + 2 - at}
```

`unabbreviated-axis` now takes the verbatim text from the token, so a spaced
`child ::` is stripped in full instead of leaving its whitespace behind. New
lexer cases and integration packs cover both checks; the whole suite passes at
100% branch coverage.

Partial fix for #564 — the `self::node()` abbreviation is a separate gap and is
left for a follow-up. It also clears the false-negative blocker in #595, leaving
`using-namespace-axis` one motive edit away from maturity.
