### PR TITLE
bug(#595): harden using-namespace-axis, defer maturity to #603

### DIFF
--- a/src/resources/checks/format/using-namespace-axis.yaml
+++ b/src/resources/checks/format/using-namespace-axis.yaml
@@ -3,4 +3,3 @@
 ---
 severity: warning
 message: "The namespace:: axis is deprecated in XSLT 2.0 and later. Use in-scope-prefixes() and namespace-uri-for-prefix() instead."
-mature: true

--- a/src/resources/checks/format/using-namespace-axis.yaml
+++ b/src/resources/checks/format/using-namespace-axis.yaml
@@ -3,3 +3,4 @@
 ---
 severity: warning
 message: "The namespace:: axis is deprecated in XSLT 2.0 and later. Use in-scope-prefixes() and namespace-uri-for-prefix() instead."
+mature: true

--- a/src/resources/motives/format/using-namespace-axis.md
+++ b/src/resources/motives/format/using-namespace-axis.md
@@ -1,20 +1,10 @@
 # Using namespace axis
 
-The `namespace::` axis is deprecated in XSLT 2.0 and stays deprecated in 3.0 —
-some 3.0 processors drop it entirely. Use the standard functions
-`in-scope-prefixes()` and `namespace-uri-for-prefix()` to inspect namespace
-bindings instead. In XSLT 1.0 the axis is not deprecated and is not flagged, so
-this check fires only on a stylesheet declaring version 2.0 or 3.0.
-
-The axis is caught in every XPath and pattern attribute of an XSLT element — a
-template `match`, a `select`, a `test`, a `use` — not only in `match`/`select`,
-and inside an attribute value template, where `&lt;div id="{namespace::*}"/&gt;`
-holds an expression as surely as a `select` does. An attribute of the output
-vocabulary that merely shares one of those names carries text for the result
-tree, not XPath, so it is left alone. Because the expression is tokenized, a
-`namespace::` inside a string literal is left alone too, and the lookalike
-functions `in-scope-prefixes()` and `namespace-uri-for-prefix()` are never
-mistaken for the axis.
+The `namespace::` axis is deprecated in XSLT 2.0 and remains so in 3.0, where
+some processors drop it entirely — a stylesheet that leans on it may not run at
+all. Inspect namespace bindings with the standard functions `in-scope-prefixes()`
+and `namespace-uri-for-prefix()` instead. In XSLT 1.0 the axis is standard, so
+the concern begins at 2.0.
 
 Incorrect:
 
@@ -42,14 +32,12 @@ Correct:
 </xsl:stylesheet>
 ```
 
-Rewriting the axis has no single form, because a namespace node carries two
-different values — its name is a prefix, its string value the namespace URI —
-and which one to reach for depends on how the surrounding expression consumes it.
-`namespace-uri-for-prefix('foo', .)` gives the URI a `namespace::foo` was read
-for; `in-scope-prefixes(.)` enumerates the prefixes a `namespace::*` walked;
-`count(namespace::*)` collapses toward `count(in-scope-prefixes(.))`; and a
-`namespace::foo` handed to `xsl:copy-of` has no string form at all, since it
-writes a namespace node into the result tree. No safe deterministic edit can
-pick among these from the axis alone — even the `count` case is not equivalent,
-raising a type error where the context node is not an element — so the check
-reports rather than rewrites, and a full-fidelity parser would not change that.
+Which function replaces the axis depends on what the namespace node was read for:
+its name is a prefix, its string value the namespace URI. A `namespace::*` walked
+for its prefixes becomes `in-scope-prefixes(.)`; a `namespace::foo` read for its
+URI becomes `namespace-uri-for-prefix('foo', .)`. Two cases need care:
+`count(namespace::*)` becomes `count(in-scope-prefixes(.))`, but that raises a
+type error on a context node that is not an element, where the axis merely
+yielded nothing; and a `namespace::foo` copied by `xsl:copy-of` writes a
+namespace node into the result tree, which no function returns — declare the
+namespace on the output element instead.

--- a/src/resources/motives/format/using-namespace-axis.md
+++ b/src/resources/motives/format/using-namespace-axis.md
@@ -42,8 +42,13 @@ Correct:
 </xsl:stylesheet>
 ```
 
-Rewriting the axis to those functions changes what the step selects — namespace
-nodes become prefix strings — and forces every expression that consumes the
-result to change with it. That is a semantic restructuring, not a span edit, so
-no safe deterministic `--fix` can exist for it: the check is report-only by
-nature, and a full-fidelity parser would not make it fixable.
+Rewriting the axis has no single form, because a namespace node carries two
+different values: its name is a prefix, its string value the namespace URI. So
+`namespace::foo` becomes `namespace-uri-for-prefix('foo', .)` where the URI is
+wanted but `in-scope-prefixes(.)` where the prefix is, `count(namespace::*)`
+folds into `count(in-scope-prefixes(.))`, and a `namespace::foo` handed to
+`xsl:copy-of` has no string replacement at all — it writes a namespace node into
+the result tree, which a URI string cannot do. Which rewrite is correct depends
+on how the surrounding expression consumes the node, so no single local edit,
+safe or suggested, can stand in for it. The check is report-only by nature, and
+a full-fidelity parser would not make it fixable.

--- a/src/resources/motives/format/using-namespace-axis.md
+++ b/src/resources/motives/format/using-namespace-axis.md
@@ -42,6 +42,8 @@ Correct:
 </xsl:stylesheet>
 ```
 
-Rewriting the axis to those functions is a structural change, not a one-span
-edit, so this check reports without a `--fix` until the full-fidelity parser
-(#228) lands.
+Rewriting the axis to those functions changes what the step selects — namespace
+nodes become prefix strings — and forces every expression that consumes the
+result to change with it. That is a semantic restructuring, not a span edit, so
+no safe deterministic `--fix` can exist for it: the check is report-only by
+nature, and a full-fidelity parser would not make it fixable.

--- a/src/resources/motives/format/using-namespace-axis.md
+++ b/src/resources/motives/format/using-namespace-axis.md
@@ -25,8 +25,9 @@ Correct:
 <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:output method="html"/>
   <xsl:template match="*">
-    <xsl:for-each select="in-scope-prefixes(.)">
-      <xsl:value-of select="namespace-uri-for-prefix(., current())"/>
+    <xsl:variable name="element" select="."/>
+    <xsl:for-each select="in-scope-prefixes($element)">
+      <xsl:value-of select="namespace-uri-for-prefix(., $element)"/>
     </xsl:for-each>
   </xsl:template>
 </xsl:stylesheet>
@@ -39,5 +40,6 @@ URI becomes `namespace-uri-for-prefix('foo', .)`. Two cases need care:
 `count(namespace::*)` becomes `count(in-scope-prefixes(.))`, but that raises a
 type error on a context node that is not an element, where the axis merely
 yielded nothing; and a `namespace::foo` copied by `xsl:copy-of` writes a
-namespace node into the result tree, which no function returns — declare the
-namespace on the output element instead.
+namespace node into the result tree, which no function returns — recreate it with
+`xsl:namespace`, as
+`<xsl:namespace name="foo" select="namespace-uri-for-prefix('foo', .)"/>`.

--- a/src/resources/motives/format/using-namespace-axis.md
+++ b/src/resources/motives/format/using-namespace-axis.md
@@ -43,12 +43,13 @@ Correct:
 ```
 
 Rewriting the axis has no single form, because a namespace node carries two
-different values: its name is a prefix, its string value the namespace URI. So
-`namespace::foo` becomes `namespace-uri-for-prefix('foo', .)` where the URI is
-wanted but `in-scope-prefixes(.)` where the prefix is, `count(namespace::*)`
-folds into `count(in-scope-prefixes(.))`, and a `namespace::foo` handed to
-`xsl:copy-of` has no string replacement at all — it writes a namespace node into
-the result tree, which a URI string cannot do. Which rewrite is correct depends
-on how the surrounding expression consumes the node, so no single local edit,
-safe or suggested, can stand in for it. The check is report-only by nature, and
-a full-fidelity parser would not make it fixable.
+different values — its name is a prefix, its string value the namespace URI —
+and which one to reach for depends on how the surrounding expression consumes it.
+`namespace-uri-for-prefix('foo', .)` gives the URI a `namespace::foo` was read
+for; `in-scope-prefixes(.)` enumerates the prefixes a `namespace::*` walked;
+`count(namespace::*)` collapses toward `count(in-scope-prefixes(.))`; and a
+`namespace::foo` handed to `xsl:copy-of` has no string form at all, since it
+writes a namespace node into the result tree. No safe deterministic edit can
+pick among these from the axis alone — even the `count` case is not equivalent,
+raising a type error where the context node is not an element — so the check
+reports rather than rewrites, and a full-fidelity parser would not change that.

--- a/test/resources/using-namespace-axis-packs/namespace-axis-in-attribute-value-template.yaml
+++ b/test/resources/using-namespace-axis-packs/namespace-axis-in-attribute-value-template.yaml
@@ -5,6 +5,7 @@ pack: using-namespace-axis
 found:
   amount: 3
   positions: [ [ 4, 41 ], [ 5, 26 ], [ 5, 41 ] ]
+  fixes: [ null, null, null ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">

--- a/test/resources/using-namespace-axis-packs/namespace-axis-in-xslt-1-0.yaml
+++ b/test/resources/using-namespace-axis-packs/namespace-axis-in-xslt-1-0.yaml
@@ -5,6 +5,7 @@ pack: using-namespace-axis
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" id="style1">

--- a/test/resources/using-namespace-axis-packs/namespace-axis-in-xslt-3-0.yaml
+++ b/test/resources/using-namespace-axis-packs/namespace-axis-in-xslt-3-0.yaml
@@ -5,6 +5,7 @@ pack: using-namespace-axis
 found:
   amount: 1
   positions: [ [ 5, 26 ] ]
+  fixes: [ null ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" id="style1">

--- a/test/resources/using-namespace-axis-packs/namespace-axis-non-xsl-prefix.yaml
+++ b/test/resources/using-namespace-axis-packs/namespace-axis-non-xsl-prefix.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: using-namespace-axis
+found:
+  amount: 2
+  positions: [ [ 3, 27 ], [ 4, 28 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <xslt:transform xmlns:xslt="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xslt:template match="*[namespace::foo]">
+      <xslt:value-of select="namespace::bar"/>
+    </xslt:template>
+  </xslt:transform>

--- a/test/resources/using-namespace-axis-packs/namespace-axis-non-xsl-prefix.yaml
+++ b/test/resources/using-namespace-axis-packs/namespace-axis-non-xsl-prefix.yaml
@@ -5,6 +5,7 @@ pack: using-namespace-axis
 found:
   amount: 2
   positions: [ [ 3, 27 ], [ 4, 28 ] ]
+  fixes: [ null, null ]
 input: |-
   <?xml version="1.0"?>
   <xslt:transform xmlns:xslt="http://www.w3.org/1999/XSL/Transform" version="2.0">

--- a/test/resources/using-namespace-axis-packs/using-namespace-axis.yaml
+++ b/test/resources/using-namespace-axis-packs/using-namespace-axis.yaml
@@ -5,6 +5,7 @@ pack: using-namespace-axis
 found:
   amount: 5
   positions: [ [ 4, 27 ], [ 5, 26 ], [ 5, 41 ], [ 5, 56 ], [ 6, 19 ] ]
+  fixes: [ null, null, null, null, null ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style1">

--- a/test/resources/using-namespace-axis-packs/whitespaced-namespace-axis.yaml
+++ b/test/resources/using-namespace-axis-packs/whitespaced-namespace-axis.yaml
@@ -5,6 +5,7 @@ pack: using-namespace-axis
 found:
   amount: 3
   positions: [ [ 3, 26 ], [ 4, 26 ], [ 4, 42 ] ]
+  fixes: [ null, null, null ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">

--- a/test/using-namespace-axis-linter.test.js
+++ b/test/using-namespace-axis-linter.test.js
@@ -28,6 +28,13 @@ describe('using-namespace-axis-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
+        const fixes = yml.found.fixes || []
+        fixes.forEach((expected, index) => {
+          assert.equal(
+            defects[index].fix ? defects[index].fix.replacement : null,
+            expected,
+          )
+        })
       })
     })
   })


### PR DESCRIPTION
This began as the PR marking `using-namespace-axis` mature. Auditing against the
bar in CLAUDE.md — not just the diff — turned up a remaining false negative, so
maturity is deferred and this PR keeps only the hardening that stands on its own.

The gap: a simplified stylesheet (a literal result element root carrying
`xsl:version`) returns `null` from `documentElement.getAttribute('version')`, so
the file is skipped and a valid XSLT 2.0 stylesheet using the deprecated axis
goes unreported. It is shared by all five version-sensitive linters and wants a
single shared version reader, tracked in #603.

What lands here:

- The motive rewritten to teach the construct only (per #604) — the harm and the
  hand-migration to `in-scope-prefixes()`, `namespace-uri-for-prefix()`, and
  `xsl:namespace`, with no fix tier and no scanner or parser internals. Its
  `Correct:` example is also fixed: `current()` inside an `xsl:for-each` is the
  loop item (a prefix string), not the matched element, so the old
  `namespace-uri-for-prefix(., current())` was `XPTY0004`; the element is now held
  in a variable.
- A pack driving a non-`xsl` prefix on an `xsl:transform` root.
- `found.fixes` assertions across every namespace-axis pack, so the report-only
  contract breaks the build if a fix is ever attached by accident.

The two blockers named in #595 are resolved — the motive here, the
whitespaced-axis false negative in #599 — but the check stays unfrozen until #603
lands. Rides on the motive policy in #604/#605.
