### PR TITLE
Fail the lint when a call omits a required argument

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,16 @@ run by the `lint` job) enforces: spaced operators, no single-letter names
 names in `require`/`import` (no `node:` prefix), no redundant return variable
 (`const x = expr; return x` is banned — return the expression), and no missing
 argument (a call must fill every parameter the callee declares without a
-default, so a report-only `defect(...)` spells its sixth argument `undefined`).
-The last two are project-local rules in `eslint-local-rules.js`, unit-tested in
-`test/eslint-local-rules.test.js`; the arity of the callee is read from its
-declaration in the same file, or by loading the module a relative `require`
-names.
+default). The last two are project-local rules in `eslint-local-rules.js`,
+unit-tested in `test/eslint-local-rules.test.js`; the arity of the callee is
+read from its declaration in the same file, or by loading the module a relative
+`require` names.
+
+A parameter a caller may leave out therefore says so in the signature, with a
+default — `fix = undefined` on `defect` in `src/checks.js`. A JSDoc `[fix]`
+alone does not count: the rule weighs `Function.length`, so an optional
+parameter that the runtime signature calls required is a lint error at every
+call that omits it.
 
 **Every style or consistency convention must be machine-enforced.** When you fix
 one, do not just fix the instances — in the same change add a check that fails on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,10 +33,14 @@ green — run `npm run coverage` and the xcop suite too.
 ESLint (`eslint-config-google` + `@stylistic`, config in `eslint.config.mjs`,
 run by the `lint` job) enforces: spaced operators, no single-letter names
 (`id-length` >= 2), postfix `x++` only (prefix `++x` is banned), bare module
-names in `require`/`import` (no `node:` prefix), and no redundant return
-variable (`const x = expr; return x` is banned — return the expression). The
-last is a project-local rule in `eslint-local-rules.js`, unit-tested in
-`test/eslint-local-rules.test.js`.
+names in `require`/`import` (no `node:` prefix), no redundant return variable
+(`const x = expr; return x` is banned — return the expression), and no missing
+argument (a call must fill every parameter the callee declares without a
+default, so a report-only `defect(...)` spells its sixth argument `undefined`).
+The last two are project-local rules in `eslint-local-rules.js`, unit-tested in
+`test/eslint-local-rules.test.js`; the arity of the callee is read from its
+declaration in the same file, or by loading the module a relative `require`
+names.
 
 **Every style or consistency convention must be machine-enforced.** When you fix
 one, do not just fix the instances — in the same change add a check that fails on

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -3,12 +3,120 @@
  * SPDX-License-Identifier: MIT
  */
 
+const path = require("path");
+
+// How many arguments a caller must supply: every parameter up to the first one
+// that carries a default or collects the rest.
+const required = function (params) {
+  const optional = params.findIndex(
+    (par) => par.type === "AssignmentPattern" || par.type === "RestElement"
+  );
+  return optional === -1 ? params.length : optional;
+};
+
+// The parameter list of the function a binding holds, when that function is
+// written out in the very file being linted, or null when it is not.
+const written = function (def) {
+  if (def.node.type === "FunctionDeclaration") {
+    return def.node.params;
+  }
+  if (
+    def.node.type === "VariableDeclarator" &&
+    def.node.init &&
+    (def.node.init.type === "FunctionExpression" ||
+      def.node.init.type === "ArrowFunctionExpression")
+  ) {
+    return def.node.init.params;
+  }
+  return null;
+};
+
+// The module a `const ... = require('./somewhere')` binding pulls in, loaded
+// from disk relative to the file being linted. Only a project-local path is
+// followed, so no third-party signature is ever second-guessed, and anything
+// that fails to resolve or to load leaves the call unjudged.
+const loaded = function (def, from) {
+  const init = def.node.type === "VariableDeclarator" ? def.node.init : null;
+  if (
+    !init ||
+    init.type !== "CallExpression" ||
+    init.callee.name !== "require" ||
+    init.arguments.length !== 1 ||
+    init.arguments[0].type !== "Literal" ||
+    typeof init.arguments[0].value !== "string" ||
+    !init.arguments[0].value.startsWith(".")
+  ) {
+    return null;
+  }
+  try {
+    return require(path.resolve(path.dirname(from), init.arguments[0].value));
+  } catch {
+    return null;
+  }
+};
+
+// The name a destructured binding takes out of its module — `defect` out of
+// `const {defect} = require('./checks')` — or null when the binding is the
+// whole module.
+const taken = function (def) {
+  if (
+    def.node.type !== "VariableDeclarator" ||
+    def.node.id.type !== "ObjectPattern"
+  ) {
+    return null;
+  }
+  const property = def.node.id.properties.find(
+    (pro) => pro.type === "Property" && pro.value === def.name
+  );
+  return property && property.key.type === "Identifier" ?
+    property.key.name :
+    null;
+};
+
+// The variable a name resolves to at a scope, respecting shadowing.
+const bound = function (scope, name) {
+  for (let current = scope; current; current = current.upper) {
+    const found = current.variables.find((va) => va.name === name);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+};
+
+// How many arguments the function a variable holds demands, or null when the
+// variable holds something this rule cannot read: a value that is not a
+// function, one that arrives from outside the project, or a member of a
+// binding that is itself only a piece of its module.
+const demanded = function (variable, from, key) {
+  if (!variable || variable.defs.length !== 1) {
+    return null;
+  }
+  const def = variable.defs[0];
+  const params = key === null ? written(def) : null;
+  if (params) {
+    return required(params);
+  }
+  if (key !== null && taken(def) !== null) {
+    return null;
+  }
+  const target = loaded(def, from);
+  if (target === null) {
+    return null;
+  }
+  const name = key === null ? taken(def) : key;
+  const fun = name === null ? target : target[name];
+  return typeof fun === "function" ? fun.length : null;
+};
+
 // A project-local ESLint plugin, kept out of eslint.config.mjs so it can be
-// unit-tested with ESLint's RuleTester (test/eslint-local-rules.test.js). Its
-// one rule flags a variable whose only purpose is to be returned by the very
-// next statement — that binding is redundant and should be inlined. No plugin
-// dependency is needed; a single no-restricted-syntax selector cannot compare a
-// declaration's name with the identifier the following return uses.
+// unit-tested with ESLint's RuleTester (test/eslint-local-rules.test.js). One
+// rule flags a variable whose only purpose is to be returned by the very next
+// statement — that binding is redundant and should be inlined. The other flags
+// a call that leaves out an argument the callee declares. No plugin dependency
+// is needed; a single no-restricted-syntax selector can neither compare a
+// declaration's name with the identifier the following return uses, nor weigh
+// a call's argument count against the parameter list of the callee.
 module.exports = {
   rules: {
     "no-redundant-return-variable": {
@@ -44,6 +152,57 @@ module.exports = {
               prev.declarations[0].id.name === node.argument.name
             ) {
               context.report({ node: prev, messageId: "redundant" });
+            }
+          }
+        };
+      }
+    },
+    "no-missing-arguments": {
+      meta: {
+        type: "problem",
+        docs: {
+          description:
+            "disallow a call that leaves out an argument the callee demands"
+        },
+        messages: {
+          missing:
+            "Pass every argument of '{{name}}': {{expected}} expected, " +
+            "{{given}} given"
+        }
+      },
+      create(context) {
+        return {
+          CallExpression(node) {
+            const callee = node.callee;
+            const named =
+              callee.type === "Identifier" ||
+              (callee.type === "MemberExpression" &&
+                !callee.computed &&
+                callee.object.type === "Identifier" &&
+                callee.property.type === "Identifier");
+            if (
+              !named ||
+              node.arguments.some((arg) => arg.type === "SpreadElement")
+            ) {
+              return;
+            }
+            const holder =
+              callee.type === "Identifier" ? callee : callee.object;
+            const expected = demanded(
+              bound(context.sourceCode.getScope(node), holder.name),
+              context.filename,
+              callee.type === "Identifier" ? null : callee.property.name
+            );
+            if (expected !== null && node.arguments.length < expected) {
+              context.report({
+                node,
+                messageId: "missing",
+                data: {
+                  name: context.sourceCode.getText(callee),
+                  expected,
+                  given: node.arguments.length
+                }
+              });
             }
           }
         };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,6 +41,7 @@ export default defineConfig([
     plugins: { "@stylistic": stylistic, local },
     rules: {
       "local/no-redundant-return-variable": "error",
+      "local/no-missing-arguments": "error",
       "valid-jsdoc": "off",
       "require-jsdoc": "off",
       semi: ["error", "never"],

--- a/src/checks.js
+++ b/src/checks.js
@@ -39,11 +39,11 @@ const suppressed = function(check, suppressions) {
  * @param {string} file - File the node sits in
  * @param {Node} node - The attribute or expression node
  * @param {number} offset - Offset of the defect within the node value
- * @param {?{value: string, replacement: string, suggestion?: boolean}} fix -
+ * @param {?{value: string, replacement: string, suggestion?: boolean}} [fix] -
  *  The fix, or undefined for a report-only defect
  * @return {object} - Defect
  */
-const defect = function(check, meta, file, node, offset, fix) {
+const defect = function(check, meta, file, node, offset, fix = undefined) {
   const pos = node.columnNumber + 1 + offset
   const anchored = fix === undefined ?
     undefined :

--- a/src/using-namespace-axis-linter.js
+++ b/src/using-namespace-axis-linter.js
@@ -64,9 +64,7 @@ const lintByNamespaceAxis = function(corpus, suppressions = []) {
       if (MODERN.includes(xsl.documentElement.getAttribute('version'))) {
         for (const {node, start, expression} of expressionsOf(xsl)) {
           for (const offset of axes(expression)) {
-            defects.push(
-              defect(CHECK, META, file, node, start + offset, undefined),
-            )
+            defects.push(defect(CHECK, META, file, node, start + offset))
           }
         }
       }

--- a/src/using-namespace-axis-linter.js
+++ b/src/using-namespace-axis-linter.js
@@ -64,7 +64,9 @@ const lintByNamespaceAxis = function(corpus, suppressions = []) {
       if (MODERN.includes(xsl.documentElement.getAttribute('version'))) {
         for (const {node, start, expression} of expressionsOf(xsl)) {
           for (const offset of axes(expression)) {
-            defects.push(defect(CHECK, META, file, node, start + offset))
+            defects.push(
+              defect(CHECK, META, file, node, start + offset, undefined),
+            )
           }
         }
       }

--- a/test/eslint-local-rules.test.js
+++ b/test/eslint-local-rules.test.js
@@ -4,11 +4,14 @@
  */
 
 const {RuleTester} = require('eslint')
+const path = require('path')
 const local = require('../eslint-local-rules')
 
 const tester = new RuleTester({
   languageOptions: {ecmaVersion: 2022, sourceType: 'commonjs'},
 })
+
+const caller = path.join(__dirname, 'resources', 'eslint', 'caller.js')
 
 tester.run(
   'no-redundant-return-variable',
@@ -28,6 +31,75 @@ tester.run(
       {
         code: 'function sum() { let total = 1 + 2; return total }',
         errors: [{messageId: 'redundant'}],
+      },
+    ],
+  },
+)
+
+tester.run(
+  'no-missing-arguments',
+  local.rules['no-missing-arguments'],
+  {
+    valid: [
+      'const pair = function(one, two) { return one + two }; pair(1, 2)',
+      'const pair = function(one, two = 2) { return one + two }; pair(1)',
+      'const pair = function(one, ...rest) { return rest }; pair(1)',
+      'const pair = function(one, two) { return two }; pair(...list)',
+      'function pair(one, two) { return two } pair(1, 2)',
+      'const pair = (one, two) => one + two; pair(1, 2)',
+      'const pair = 42; pair(1)',
+      'const use = function(fun) { return fun(1) }; use(Math.abs)',
+      'const use = function(box) { return box.of(1) }; use(Math)',
+      'unknown(1)',
+      `const {join} = require('path'); join('one')`,
+      {
+        code: `const {quartet} = require('./arities'); quartet(1, 2, 3, 4)`,
+        filename: caller,
+      },
+      {
+        code: `const {padded} = require('./arities'); padded(1)`,
+        filename: caller,
+      },
+      {
+        code: `const {heap} = require('./arities'); heap(1)`,
+        filename: caller,
+      },
+      {
+        code: `const {quartet} = require('./nowhere'); quartet(1)`,
+        filename: caller,
+      },
+      {
+        code: `const {quartet} = require('./arities'); const shade = function() { const quartet = function(one) { return one }; return quartet(1) }; shade()`,
+        filename: caller,
+      },
+    ],
+    invalid: [
+      {
+        code: 'const pair = function(one, two) { return two }; pair(1)',
+        errors: [{messageId: 'missing'}],
+      },
+      {
+        code: 'function pair(one, two) { return two } pair(1)',
+        errors: [{messageId: 'missing'}],
+      },
+      {
+        code: 'const pair = (one, two) => one + two; pair()',
+        errors: [{messageId: 'missing'}],
+      },
+      {
+        code: `const {quartet} = require('./arities'); quartet(1, 2)`,
+        filename: caller,
+        errors: [{messageId: 'missing'}],
+      },
+      {
+        code: `const whole = require('./arities'); whole.quartet(1)`,
+        filename: caller,
+        errors: [{messageId: 'missing'}],
+      },
+      {
+        code: `const {padded} = require('./arities'); padded()`,
+        filename: caller,
+        errors: [{messageId: 'missing'}],
       },
     ],
   },

--- a/test/resources/eslint/arities.js
+++ b/test/resources/eslint/arities.js
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const quartet = function(alpha, beta, gamma, delta) {
+  return [alpha, beta, gamma, delta]
+}
+
+const padded = function(alpha, beta = 7) {
+  return alpha + beta
+}
+
+const heap = function(alpha, ...rest) {
+  return [alpha, rest.length]
+}
+
+module.exports = {
+  quartet,
+  padded,
+  heap,
+}


### PR DESCRIPTION
`defect` in `src/checks.js` takes six parameters and gave none of them a
default, yet the namespace-axis linter was calling it with five. Nothing
noticed. The build had no way to weigh a call's argument count against the
parameter list of the callee: ESLint ships no core rule for it, and a
`no-restricted-syntax` selector cannot reach across that gap.

So `eslint-local-rules.js` grows a second rule beside
`no-redundant-return-variable`. It reads the callee's arity from the
declaration in the same file, or, when the name arrives through a relative
`require`, by loading that module and asking the function itself:

```js
const target = loaded(def, from);
const name = key === null ? taken(def) : key;
const fun = name === null ? target : target[name];
return typeof fun === "function" ? fun.length : null;
```

`Function.length` counts only the parameters before the first default or rest,
and that is the contract the rule enforces: a parameter a caller may leave out
has to say so in the signature. `defect` now does, with `fix = undefined`, so
the namespace-axis call stands as written and the whole class of "expected 6,
got 5" disappears at the declaration instead of at every call site. A JSDoc
`[fix]` on its own would not have counted — the rule weighs the runtime
signature, not the comment.

Across the whole tree that was the only violation. Drop the default again and
the lint fails on `src/using-namespace-axis-linter.js:67`, which is the point.

Two limits worth naming for later: an ESM `import` is not followed yet, since
`src` is CJS apart from the entry point, and passing too many arguments still
goes unremarked, because `Function.length` cannot tell you where the parameter
list ends.

Closes #601.