### PR TITLE
bug(#603): read the effective version on every root shape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,14 +173,20 @@ Then run `npm test`, `npm run coverage`, and `npx grunt docs`.
 ### Mandatory rules
 
 - **Version-dependence.** If a check's detection or fix is valid only for certain
-  XSLT versions, the version test is part of the check. Read the version from
-  `documentElement.getAttribute('version')` against `MODERN = ['2.0', '3.0']`
-  (code), or from `/*/@version` (a declarative rule — any root). Never emit a fix
-  the declared version cannot run; emit the version-appropriate form instead
-  (`count(x) > 0` -> `exists(x)` on 2.0+, `boolean(x)`/`x` on 1.0). A
-  version-sensitive check with no version guard is a bug. Verify a version-based
-  *exclusion* fires on the versions where its premise does not hold — an inert 2.0
-  attribute in a 1.0 sheet is still a defect.
+  XSLT versions, the version test is part of the check. Read the version with
+  `versionOf(xsl)` from `src/xsl-version.js` against its `MODERN` (code) — never
+  `documentElement.getAttribute('version')`, which an ESLint rule bans because it
+  misses a simplified stylesheet's `xsl:version`. A declarative rule reads it
+  structurally — `(/xsl:stylesheet | /xsl:transform)/@version` on an XSLT root,
+  `@xsl:version` on any other root (a literal result element standing in as the
+  stylesheet) — never a bare `/*/@version` (blind to a simplified root) or a
+  presence fallback `(@version | @xsl:version)` (an SVG root's own `version`
+  defeats it); `test/conformance.test.js` fails a selector testing `@version`
+  without `@xsl:version`. Never emit a fix the declared version cannot run; emit
+  the version-appropriate form instead (`count(x) > 0` -> `exists(x)` on 2.0+,
+  `boolean(x)`/`x` on 1.0). A version-sensitive check with no version guard is a
+  bug. Verify a version-based *exclusion* fires on the versions where its premise
+  does not hold — an inert 2.0 attribute in a 1.0 sheet is still a defect.
 - **Root-robustness.** A declarative rule that anchors on the stylesheet root must
   match both spellings: `(/xsl:stylesheet | /xsl:transform)[...]`, never
   `/xsl:stylesheet[...]` — they are exact synonyms in every version. Broaden a
@@ -323,6 +329,7 @@ the harness asserts too.
 | `src/*-linter.js` | Code-based `checks/format/*.yaml`, one construct each (axis, namespace, count, name, ...); see the flow diagram |
 | `src/checks.js` | Shared for code-based linters: `metaOf`, `suppressed`, `defect(check, meta, file, node, offset, fix)` |
 | `src/attributes.js` | `expressionsOf(xsl)` — every expression the attributes carry, bare (`ATTRIBUTES` on an XSLT element) or enclosed in an AVT; `selectorOf(name)` for a linter that narrows |
+| `src/xsl-version.js` | `versionOf(xsl)` — the declared version, from `@version` on an XSLT root or `xsl:version` on a simplified one; shared `MODERN` |
 | `src/comparisons.js` | `comparedToZero` — shared scan for a call compared with `0`/`1` (count, string-length) |
 | `src/expressions.js` | `masked`/`closes` lexer helpers (node-set, double-negation, boolean-call); `enclosed` — the expressions an AVT holds in its braces |
 | `src/tokens.js` | Positioned XPath lexer (`tokenized`, `TOKENS`), preserving whitespace |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -82,6 +82,12 @@ export default defineConfig([
           selector: "Literal[value=/\\/\\/@/]",
           message:
             "Do not select attributes with a bare '//@name' XPath, which reads a literal result element as XPath; go through src/attributes.js (expressionsOf, selectorOf)"
+        },
+        {
+          selector:
+            "CallExpression[callee.property.name='getAttribute'][callee.object.property.name='documentElement'][arguments.0.value='version']",
+          message:
+            "Read the stylesheet version through versionOf in src/xsl-version.js, which handles a simplified stylesheet's xsl:version; do not read documentElement.getAttribute('version') directly"
         }
       ]
     }

--- a/src/count-linter.js
+++ b/src/count-linter.js
@@ -6,6 +6,7 @@
 const {comparedToZero} = require('./comparisons')
 const {metaOf, suppressed, defect} = require('./checks')
 const {expressionsOf} = require('./attributes')
+const {MODERN, versionOf} = require('./xsl-version')
 const {logger} = require('./logger')
 
 /**
@@ -25,13 +26,6 @@ const META = metaOf(CHECK)
  * @type {Array.<string>}
  */
 const names = [CHECK]
-
-/**
- * Stylesheet versions where `exists()`/`empty()` exist, so the rewrite is
- * available. The smell is worth reporting on any version, but the fix is not.
- * @type {Array.<string>}
- */
-const MODERN = ['2.0', '3.0']
 
 /**
  * The existence function a comparison collapses to, or null when it is a
@@ -124,9 +118,7 @@ const lintByCount = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const {file, xsl} of corpus) {
-      const modern = MODERN.includes(
-        xsl.documentElement.getAttribute('version'),
-      )
+      const modern = MODERN.includes(versionOf(xsl))
       for (const {node, start, expression} of expressionsOf(xsl)) {
         for (const {offset, value, test, argument} of comparisons(expression)) {
           const whole = node.nodeName === 'test' &&

--- a/src/name-linter.js
+++ b/src/name-linter.js
@@ -6,6 +6,7 @@
 const {masked, closes} = require('./expressions')
 const {metaOf, suppressed, defect} = require('./checks')
 const {expressionsOf} = require('./attributes')
+const {MODERN, versionOf} = require('./xsl-version')
 const {logger} = require('./logger')
 
 /**
@@ -25,13 +26,6 @@ const META = metaOf(CHECK)
  * @type {Array.<string>}
  */
 const names = [CHECK]
-
-/**
- * Stylesheet versions where the `*:name` wildcard used to fix a `local-name()`
- * comparison is available.
- * @type {Array.<string>}
- */
-const MODERN = ['2.0', '3.0']
 
 /**
  * A `name(` or `local-name(` call opener, unprefixed so a custom one is left
@@ -140,9 +134,7 @@ const lintByName = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const {file, xsl} of corpus) {
-      const modern = MODERN.includes(
-        xsl.documentElement.getAttribute('version'),
-      )
+      const modern = MODERN.includes(versionOf(xsl))
       for (const {node, start, expression} of expressionsOf(xsl)) {
         for (const {offset, value, replacement} of comparisons(
           expression, modern,

--- a/src/node-set-linter.js
+++ b/src/node-set-linter.js
@@ -7,6 +7,7 @@ const {nodes} = require('./xpath')
 const {masked, closes} = require('./expressions')
 const {metaOf, suppressed, defect} = require('./checks')
 const {selectorOf} = require('./attributes')
+const {MODERN, versionOf} = require('./xsl-version')
 const {logger} = require('./logger')
 
 /**
@@ -26,12 +27,6 @@ const META = metaOf(CHECK)
  * @type {Array.<string>}
  */
 const names = [CHECK]
-
-/**
- * Stylesheet versions where the node-set() extension is redundant.
- * @type {Array.<string>}
- */
-const MODERN = ['2.0', '3.0']
 
 /**
  * Pattern of a `prefix:node-set(` call opener.
@@ -81,7 +76,7 @@ const lintByNodeSet = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const {file, xsl} of corpus) {
-      if (MODERN.includes(xsl.documentElement.getAttribute('version'))) {
+      if (MODERN.includes(versionOf(xsl))) {
         for (const attribute of nodes(xsl, selectorOf('select'))) {
           for (const {offset, value, replacement} of wrappers(
             attribute.nodeValue,

--- a/src/resources/checks/xpath/empty-variable.yaml
+++ b/src/resources/checks/xpath/empty-variable.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //xsl:variable[not(@select) and not(node()) and not(@as and (/*/@version = '2.0' or /*/@version = '3.0'))]
+xpath: "//xsl:variable[not(@select) and not(node()) and not(@as and (if (/xsl:stylesheet | /xsl:transform) then /*/@version else /*/@xsl:version) = ('2.0', '3.0'))]"
 severity: warning
 message: An empty xsl:variable binds the empty string for no reason. Give it a @select or some content, or remove it.

--- a/src/resources/checks/xpath/function-use-in-xslt-1.yaml
+++ b/src/resources/checks/xpath/function-use-in-xslt-1.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: "/*[not(@version = '2.0' or @version = '3.0')]//xsl:function"
+xpath: "/*[not((if (self::xsl:stylesheet or self::xsl:transform) then @version else @xsl:version) = ('2.0', '3.0'))]//xsl:function"
 severity: error
 message: "'xsl:function' requires XSLT 2.0 or later, but this stylesheet is not version 2.0 or 3.0. Use a named template, or set the version to 2.0."

--- a/src/resources/checks/xpath/modern-construct-in-xslt-1.yaml
+++ b/src/resources/checks/xpath/modern-construct-in-xslt-1.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: "(/xsl:stylesheet | /xsl:transform)[@version = '1.0']//(xsl:for-each-group | xsl:sequence | xsl:analyze-string | xsl:next-match | xsl:perform-sort | xsl:namespace | xsl:character-map | xsl:result-document | xsl:import-schema | xsl:*[@as])"
+xpath: "/*[(if (self::xsl:stylesheet or self::xsl:transform) then @version else @xsl:version) = '1.0']//(xsl:for-each-group | xsl:sequence | xsl:analyze-string | xsl:next-match | xsl:perform-sort | xsl:namespace | xsl:character-map | xsl:result-document | xsl:import-schema | xsl:*[@as])"
 severity: error
 message: "This XSLT 2.0 construct is used in a stylesheet declared version 1.0, which a conformant 1.0 processor rejects. Use a 1.0 equivalent, or set the version to 2.0."

--- a/src/resources/motives/xpath/modern-construct-in-xslt-1.md
+++ b/src/resources/motives/xpath/modern-construct-in-xslt-1.md
@@ -10,8 +10,8 @@ This check flags a curated set of 2.0-only XSLT **instructions** —
 `xsl:for-each-group`, `xsl:sequence`, `xsl:analyze-string`, `xsl:next-match`,
 `xsl:perform-sort`, `xsl:namespace`, `xsl:character-map`, `xsl:result-document`,
 `xsl:import-schema` — and the 2.0 **`as` sequence-type attribute** on any XSLT
-element, whenever the stylesheet root (`xsl:stylesheet` or `xsl:transform`)
-declares `version="1.0"`. Only elements in the XSLT namespace are examined for
+element, whenever the stylesheet declares version 1.0. Only elements in the XSLT
+namespace are examined for
 `@as`, so a literal result element that legitimately carries an `as` attribute —
 `<link rel="preload" as="script"/>` in HTML output — is never mistaken for the
 sequence-type attribute.

--- a/src/translate-linter.js
+++ b/src/translate-linter.js
@@ -6,6 +6,7 @@
 const {masked, closes} = require('./expressions')
 const {metaOf, suppressed, defect} = require('./checks')
 const {expressionsOf} = require('./attributes')
+const {MODERN, versionOf} = require('./xsl-version')
 const {logger} = require('./logger')
 
 /**
@@ -25,13 +26,6 @@ const META = metaOf(CHECK)
  * @type {Array.<string>}
  */
 const names = [CHECK]
-
-/**
- * Stylesheet versions where lower-case()/upper-case() exist, so a translate()
- * over the alphabet is an anachronism rather than the only option.
- * @type {Array.<string>}
- */
-const MODERN = ['2.0', '3.0']
 
 /**
  * A `translate(` call opener, unprefixed so a custom one is left alone.
@@ -152,7 +146,7 @@ const lintByTranslate = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const {file, xsl} of corpus) {
-      if (MODERN.includes(xsl.documentElement.getAttribute('version'))) {
+      if (MODERN.includes(versionOf(xsl))) {
         for (const {node, start, expression} of expressionsOf(xsl)) {
           for (const {offset, value, replacement} of folded(expression)) {
             defects.push(

--- a/src/using-namespace-axis-linter.js
+++ b/src/using-namespace-axis-linter.js
@@ -6,6 +6,7 @@
 const {tokenized, TOKENS} = require('./tokens')
 const {metaOf, suppressed, defect} = require('./checks')
 const {expressionsOf} = require('./attributes')
+const {MODERN, versionOf} = require('./xsl-version')
 const {logger} = require('./logger')
 
 /**
@@ -25,13 +26,6 @@ const META = metaOf(CHECK)
  * @type {Array.<string>}
  */
 const names = [CHECK]
-
-/**
- * Versions where the namespace:: axis is deprecated. In XSLT 1.0 it is the
- * standard way to inspect namespace nodes, so it is not flagged there.
- * @type {Array.<string>}
- */
-const MODERN = ['2.0', '3.0']
 
 /**
  * Offsets of every namespace:: axis in an expression. The lexer keeps string
@@ -61,7 +55,7 @@ const lintByNamespaceAxis = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const {file, xsl} of corpus) {
-      if (MODERN.includes(xsl.documentElement.getAttribute('version'))) {
+      if (MODERN.includes(versionOf(xsl))) {
         for (const {node, start, expression} of expressionsOf(xsl)) {
           for (const offset of axes(expression)) {
             defects.push(defect(CHECK, META, file, node, start + offset))

--- a/src/xsl-version.js
+++ b/src/xsl-version.js
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * The XSLT namespace, which distinguishes a stylesheet root from a literal
+ * result element standing in as one.
+ * @type {string}
+ */
+const XSLT = 'http://www.w3.org/1999/XSL/Transform'
+
+/**
+ * Versions where an XSLT 2.0-or-later construct is available.
+ * @type {Array.<string>}
+ */
+const MODERN = ['2.0', '3.0']
+
+/**
+ * The version a stylesheet declares, read from wherever its root shape keeps
+ * it: an unprefixed `version` on an `xsl:stylesheet`/`xsl:transform`, or the
+ * XSLT-namespaced `version` on the literal result element of a simplified
+ * stylesheet. The two are told apart by the root's namespace, not by which
+ * attribute happens to be present, so a result vocabulary carrying its own
+ * `version` — an SVG root does — never misleads it.
+ * @param {Document} xsl - Parsed stylesheet
+ * @return {string} - The declared version, or empty when none is declared
+ */
+const versionOf = function(xsl) {
+  const root = xsl.documentElement
+  return (root.namespaceURI === XSLT ?
+    root.getAttribute('version') : root.getAttributeNS(XSLT, 'version')) || ''
+}
+
+module.exports = {
+  XSLT,
+  MODERN,
+  versionOf,
+}

--- a/test/conformance.test.js
+++ b/test/conformance.test.js
@@ -198,6 +198,25 @@ describe('conformance', function() {
       }
     }
   })
+  it('reads @xsl:version too wherever a selector tests @version', function() {
+    const versioned = /@version\s*!?=/
+    for (const [kind, keys] of Object.entries(SELECTORS)) {
+      for (const name of names(kind)) {
+        const check = yaml.parsedFromFile(
+          path.join(CHECKS, kind, `${name}.yaml`),
+        )
+        for (const key of keys) {
+          if (check[key] && versioned.test(check[key])) {
+            assert.ok(
+              check[key].includes('@xsl:version'),
+              `${kind}/${name} tests @version but not @xsl:version, ` +
+                'so it misreads a simplified stylesheet',
+            )
+          }
+        }
+      }
+    }
+  })
   it('maps every motive and pack back to a real check', function() {
     for (const kind of KINDS) {
       const checks = new Set(names(kind))

--- a/test/resources/using-namespace-axis-packs/namespace-axis-in-simplified-stylesheet.yaml
+++ b/test/resources/using-namespace-axis-packs/namespace-axis-in-simplified-stylesheet.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: using-namespace-axis
+found:
+  amount: 1
+  positions: [ [ 3, 25 ] ]
+  fixes: [ null ]
+input: |-
+  <?xml version="1.0"?>
+  <html xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xsl:version="2.0">
+    <xsl:value-of select="namespace::*"/>
+  </html>

--- a/test/resources/xpath-packs/empty-variable-in-simplified-stylesheet.yaml
+++ b/test/resources/xpath-packs/empty-variable-in-simplified-stylesheet.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: empty-variable
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <html xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xsl:version="2.0">
+    <xsl:variable name="zz" as="xs:string"/>
+  </html>

--- a/test/resources/xpath-packs/modern-construct-in-simplified-1-0.yaml
+++ b/test/resources/xpath-packs/modern-construct-in-simplified-1-0.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: modern-construct-in-xslt-1
+found:
+  amount: 1
+  positions: [ [ 3, 3 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <html xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xsl:version="1.0">
+    <xsl:sequence select="1"/>
+  </html>

--- a/test/resources/xsl-version/roots.yaml
+++ b/test/resources/xsl-version/roots.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+- name: reads the version of an xsl:stylesheet root
+  input: |-
+    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"/>
+  version: "2.0"
+- name: reads the version of a transform root under a non-xsl prefix
+  input: |-
+    <t:transform xmlns:t="http://www.w3.org/1999/XSL/Transform" version="2.0"/>
+  version: "2.0"
+- name: reads version 1.0 of an xsl:stylesheet root
+  input: |-
+    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"/>
+  version: "1.0"
+- name: reads the xsl:version of a simplified html root
+  input: |-
+    <html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xsl:version="2.0"/>
+  version: "2.0"
+- name: ignores the result vocabulary version on a simplified svg root
+  input: |-
+    <svg xmlns="http://www.w3.org/2000/svg"
+      xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.1" xsl:version="2.0"/>
+  version: "2.0"
+- name: is empty when the root declares no version
+  input: |-
+    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"/>
+  version: ""

--- a/test/xsl-version.test.js
+++ b/test/xsl-version.test.js
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {versionOf} = require('../src/xsl-version')
+const {xml, yaml} = require('../src/helpers')
+const path = require('path')
+const assert = require('assert')
+
+/**
+ * Root shapes paired with the version each declares.
+ * @type {Array.<{name: string, input: string, version: string}>}
+ */
+const ROOTS = yaml.parsedFromFile(
+  path.resolve(__dirname, 'resources', 'xsl-version', 'roots.yaml'),
+)
+
+describe('xsl-version', function() {
+  ROOTS.forEach((root) => {
+    it(root.name, function() {
+      assert.equal(versionOf(xml.parsedFromString(root.input)), root.version)
+    })
+  })
+})


### PR DESCRIPTION
Every version-sensitive check read the stylesheet version straight off
`documentElement.getAttribute('version')`, which is `null` on a simplified
stylesheet — a literal result element carrying `xsl:version` (XSLT 1.0 §2.3,
2.0 §3.7). So a valid 2.0 simplified stylesheet was silently skipped by the code
linters (#603) and misjudged by the declarative ones (#608).

A new `versionOf(xsl)` in `src/xsl-version.js` reads the version **structurally**
— `@version` on an `xsl:stylesheet`/`xsl:transform` root, the XSLT-namespaced
`version` on any other root — discriminated by the root's namespace, not by
which attribute is present, so a result vocabulary carrying its own `version`
(an SVG root does) never misleads it:

```js
const versionOf = function(xsl) {
  const root = xsl.documentElement
  return (root.namespaceURI === XSLT ?
    root.getAttribute('version') : root.getAttributeNS(XSLT, 'version')) || ''
}
```

The five code linters route through it, and an ESLint rule bans the chained
`documentElement.getAttribute('version')` so linter six cannot reintroduce the
read. The three declarative guards (`empty-variable`, `modern-construct-in-xslt-1`,
`function-use-in-xslt-1`) pick the version top-down with

```text
if (self::xsl:stylesheet or self::xsl:transform) then @version else @xsl:version
```

and a `conformance.test.js` gate fails any selector that tests `@version` without
`@xsl:version`. New fixtures lock the behavior end-to-end: `using-namespace-axis`
now fires on a simplified sheet, `empty-variable` no longer false-positives, and
`modern-construct` now catches a simplified 1.0 sheet; a `versionOf` unit test
covers every root shape, including the SVG trap.

Closes #603. Addresses #608 (the two live bugs, `function-use` consistency, the
CLAUDE.md rule, and the gate). `missing-version-in-stylesheet`'s simplified case
is deliberately left: a root without `xsl:version` is not identifiable as a
simplified stylesheet.

625 tests, 100% branch coverage, ESLint clean.
