### PR TITLE
bug(#606): read text value templates and shadow attributes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,12 +102,15 @@ list that `--suppress` and config globs match is *derived* from those entries, s
 a linter and its suppression names cannot drift apart.
 
 No code-based linter selects attributes by name on its own. `src/attributes.js`
-hands it every expression the attributes of a stylesheet carry: an XPath or
-pattern attribute *of an XSLT element*, whole, plus each expression an attribute
-value template encloses in braces, offset by where it starts inside the value
-(#579). An attribute a literal result element happens to call `test` or `select`
-holds text destined for the result tree, so it is left alone — reading it as
-XPath let `--fix` rewrite the output.
+hands it every expression a stylesheet carries: an XPath or pattern attribute *of
+an XSLT element*, whole, plus each expression an attribute value template encloses
+in braces, offset by where it starts inside the value (#579). In an XSLT 3.0
+stylesheet it also reads a **text value template** — the braces of a text node
+whose nearest `expand-text`/`xsl:expand-text` is on — and a **shadow attribute**
+(`_select` for `select`), the same expressions the modern idiom hides outside an
+attribute (#606). An attribute a literal result element happens to call `test` or
+`select` holds text destined for the result tree, so it is left alone — reading it
+as XPath let `--fix` rewrite the output.
 
 XPath binds prefix `xsl:` to the XSLT namespace; `xslint:` is reserved in
 `src/xpath.js` for custom functions (none are registered now).
@@ -164,7 +167,8 @@ motive, or ships untested fails the build.
   `message`. A code-based format linter builds its defects through `src/checks.js`
   (`metaOf`, `suppressed`, `defect`) and reads its expressions from
   `src/attributes.js`'s `expressionsOf` (every XPath/pattern attribute of an XSLT
-  element, plus every expression an attribute value template encloses) unless it
+  element, plus every expression an attribute value template, a 3.0 text value
+  template, or a shadow attribute carries) unless it
   has a documented reason to narrow — then it narrows through `selectorOf`, never
   a hand-written `//@name`, which an ESLint `no-restricted-syntax` selector bans.
 
@@ -328,7 +332,7 @@ the harness asserts too.
 | `src/corpus-linter.js` | Loads `checks/corpus/*.yaml`; cross-file rules |
 | `src/*-linter.js` | Code-based `checks/format/*.yaml`, one construct each (axis, namespace, count, name, ...); see the flow diagram |
 | `src/checks.js` | Shared for code-based linters: `metaOf`, `suppressed`, `defect(check, meta, file, node, offset, fix)` |
-| `src/attributes.js` | `expressionsOf(xsl)` — every expression the attributes carry, bare (`ATTRIBUTES` on an XSLT element) or enclosed in an AVT; `selectorOf(name)` for a linter that narrows |
+| `src/attributes.js` | `expressionsOf(xsl)` — every expression a stylesheet carries: a bare/AVT attribute, a 3.0 text value template, or a shadow attribute; `selectorOf(name)` for a linter that narrows |
 | `src/xsl-version.js` | `versionOf(xsl)` — the declared version, from `@version` on an XSLT root or `xsl:version` on a simplified one; shared `MODERN` |
 | `src/comparisons.js` | `comparedToZero` — shared scan for a call compared with `0`/`1` (count, string-length) |
 | `src/expressions.js` | `masked`/`closes` lexer helpers (node-set, double-negation, boolean-call); `enclosed` — the expressions an AVT holds in its braces |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,7 +277,12 @@ the harness asserts too.
   occurrence: the construct **buried** in a larger expression (a predicate, an
   `and`/`or` operand, a nested call), **three or more** occurrences in one
   expression (to catch a first-match bug), and the **negative neighbours** that
-  look similar but must not fire. Positions pin every occurrence.
+  look similar but must not fire. Positions pin every occurrence. A scan over a
+  node *set* must exercise every node *kind* the selector yields — a `//text()`
+  scan needs a CDATA section beside a plain text node, a `//*/@*` scan the
+  literal-result versus XSLT-element split — because 100% branch coverage counts
+  a branch one kind reaches as covered for all: a `nodeType`-blind crash sits
+  green until a pack feeds it the other kind (#606).
 - **Fixtures live in files.** Every test stylesheet is a committed `.xsl` under
   `test/resources/` (never inline in a `.test.js` — the `fixtures` CI job bans
   inline `<?xml`/`<xsl:`); YAML is only for the multi-field packs. Malformed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,9 +168,9 @@ motive, or ships untested fails the build.
   (`metaOf`, `suppressed`, `defect`) and reads its expressions from
   `src/attributes.js`'s `expressionsOf` (every XPath/pattern attribute of an XSLT
   element, plus every expression an attribute value template, a 3.0 text value
-  template, or a shadow attribute carries) unless it
-  has a documented reason to narrow — then it narrows through `selectorOf`, never
-  a hand-written `//@name`, which an ESLint `no-restricted-syntax` selector bans.
+  template, or a shadow attribute carries) unless it has a documented reason to
+  narrow — then it narrows through `selectorOf`, never a hand-written `//@name`,
+  which an ESLint `no-restricted-syntax` selector bans.
 
 Then run `npm test`, `npm run coverage`, and `npx grunt docs`.
 

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -5,6 +5,7 @@
 
 const {nodes} = require('./xpath')
 const {enclosed} = require('./expressions')
+const {XSLT, versionOf} = require('./xsl-version')
 
 /**
  * Attributes that hold an XPath expression or a pattern — every place a
@@ -38,26 +39,84 @@ const selectorOf = function(name) {
 const SELECTOR = ATTRIBUTES.map(selectorOf).join(' | ')
 
 /**
- * Every expression the attributes of a stylesheet carry, in document order. An
- * attribute holding a bare XPath contributes its whole value; any other
- * attribute contributes each expression its braces enclose, an attribute value
- * template being the only way an expression hides there. Each one names the
- * attribute node, the offset it starts at inside that node's value, and its own
- * text, so a defect in it is reported — and fixed — where it truly stands.
+ * Whether text value templates expand around the given text node — the nearest
+ * ancestor to set `expand-text` (an XSLT element) or `xsl:expand-text` (a
+ * literal result element) wins, and expansion is off until one does. In XSLT
+ * 3.0 an on setting turns the `{...}` of a text node into real expressions, the
+ * way a `select` carries one.
+ * @param {Node} text - The text node
+ * @return {boolean} - True when its braces expand
+ */
+const expands = function(text) {
+  let node = text.parentNode
+  while (node.nodeType === 1) {
+    const setting = node.namespaceURI === XSLT ?
+      node.getAttribute('expand-text') :
+      node.getAttributeNS(XSLT, 'expand-text')
+    if (setting) {
+      return setting === 'yes'
+    }
+    node = node.parentNode
+  }
+  return false
+}
+
+/**
+ * Whether the attribute is a shadow attribute standing in for a bare-XPath one
+ * — `_select` for `select` — on an XSLT element, with no braces, so its whole
+ * value is the static expression that becomes the real attribute (XSLT 3.0).
+ * A shadow attribute that does carry braces is a template, left to `enclosed`.
+ * @param {Node} attribute - The attribute node
+ * @return {boolean} - True when its whole value is an expression
+ */
+const shadow = function(attribute) {
+  return attribute.ownerElement.namespaceURI === XSLT &&
+    attribute.nodeName.startsWith('_') &&
+    ATTRIBUTES.includes(attribute.nodeName.slice(1)) &&
+    !attribute.nodeValue.includes('{')
+}
+
+/**
+ * The expressions a node contributes: a whole value when it is a bare-XPath (or
+ * shadow) attribute, otherwise each expression its braces enclose — an
+ * attribute value template, or a text value template in the text node of a 3.0
+ * stylesheet whose `expand-text` is on. Each names its node, the offset it
+ * starts at inside that node's value, and its own text.
+ * @param {Node} node - An attribute or text node
+ * @param {Set.<Node>} bare - Attributes holding a bare XPath
+ * @param {boolean} three - Whether the stylesheet declares version 3.0
+ * @return {Array.<{node: Node, start: number, expression: string}>} - Found
+ */
+const carried = function(node, bare, three) {
+  if (node.nodeType === 3) {
+    return three && expands(node) ? enclosed(node.nodeValue).map((found) => ({
+      node: node, start: found.offset, expression: found.value,
+    })) : []
+  }
+  if (bare.has(node) || (three && shadow(node))) {
+    return [{node: node, start: 0, expression: node.nodeValue}]
+  }
+  return enclosed(node.nodeValue).map((found) => ({
+    node: node, start: found.offset, expression: found.value,
+  }))
+}
+
+/**
+ * Every expression a stylesheet carries, in document order. An attribute
+ * holding a bare XPath contributes its whole value; another attribute, and a
+ * text node under an on `expand-text` in a 3.0 stylesheet, contribute each
+ * expression their braces enclose. Each one names the node, the offset it
+ * starts at inside that node's value, and its own text, so a defect in it is
+ * reported — and fixed — where it truly stands.
  * @param {Document} xsl - XSL document parsed as {@link Document}
  * @return {Array.<{node: Node, start: number, expression: string}>} - The
  *  expressions found
  */
 const expressionsOf = function(xsl) {
   const bare = new Set(nodes(xsl, SELECTOR))
-  return nodes(xsl, '//*/@*').flatMap((attribute) =>
-    bare.has(attribute) ?
-      [{node: attribute, start: 0, expression: attribute.nodeValue}] :
-      enclosed(attribute.nodeValue).map((found) => ({
-        node: attribute,
-        start: found.offset,
-        expression: found.value,
-      })),
+  const three = versionOf(xsl) === '3.0'
+  return nodes(xsl, '//*/@* | //text()').flatMap(
+    (node) => carried(node, bare, three),
   )
 }
 

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -39,6 +39,14 @@ const selectorOf = function(name) {
 const SELECTOR = ATTRIBUTES.map(selectorOf).join(' | ')
 
 /**
+ * The spellings that switch an XSLT boolean attribute on, whitespace trimmed —
+ * `expand-text="true"` and `="1"` turn text value templates on as surely as
+ * `="yes"` does.
+ * @type {Array.<string>}
+ */
+const ON = ['yes', 'true', '1']
+
+/**
  * Whether text value templates expand around the given text node — the nearest
  * ancestor to set `expand-text` (an XSLT element) or `xsl:expand-text` (a
  * literal result element) wins, and expansion is off until one does. In XSLT
@@ -54,7 +62,7 @@ const expands = function(text) {
       node.getAttribute('expand-text') :
       node.getAttributeNS(XSLT, 'expand-text')
     if (setting) {
-      return setting === 'yes'
+      return ON.includes(setting.trim())
     }
     node = node.parentNode
   }
@@ -79,16 +87,18 @@ const shadow = function(attribute) {
 /**
  * The expressions a node contributes: a whole value when it is a bare-XPath (or
  * shadow) attribute, otherwise each expression its braces enclose — an
- * attribute value template, or a text value template in the text node of a 3.0
- * stylesheet whose `expand-text` is on. Each names its node, the offset it
- * starts at inside that node's value, and its own text.
- * @param {Node} node - An attribute or text node
+ * attribute value template, or a text value template in a text node (a CDATA
+ * section is one too) of a 3.0 stylesheet whose `expand-text` is on. Only an
+ * attribute takes the attribute branch, so any other node the selector yields
+ * is read as text rather than dereferenced as one. Each names its node, the
+ * offset it starts at inside that node's value, and its own text.
+ * @param {Node} node - An attribute, text, or CDATA node
  * @param {Set.<Node>} bare - Attributes holding a bare XPath
  * @param {boolean} three - Whether the stylesheet declares version 3.0
  * @return {Array.<{node: Node, start: number, expression: string}>} - Found
  */
 const carried = function(node, bare, three) {
-  if (node.nodeType === 3) {
+  if (node.nodeType !== 2) {
     return three && expands(node) ? enclosed(node.nodeValue).map((found) => ({
       node: node, start: found.offset, expression: found.value,
     })) : []

--- a/src/checks.js
+++ b/src/checks.js
@@ -28,32 +28,45 @@ const suppressed = function(check, suppressions) {
 }
 
 /**
- * A formatting defect at an offset inside an attribute or expression node. The
- * reported column is `node.columnNumber + 1 + offset` — the one the finders
- * compute — and the fix, when given as `{value, replacement, suggestion?}`, is
- * anchored at that column and carries the decoded `offset`, so the fixer can
- * decode-walk from the node's raw start to the match even past an entity that
- * shifts it. Omit `fix` for a report-only defect.
+ * The markup a node's `columnNumber` sits on before its value begins: an
+ * attribute opens on its quote, a CDATA section on its `<![CDATA[` marker, and
+ * every other kind on the value itself.
+ * @type {{[nodeType: number]: number}}
+ */
+const LEAD = {2: 1, 4: '<![CDATA['.length}
+
+/**
+ * A defect at an offset inside an attribute, text, or CDATA node. Its line and
+ * column are the node's own, advanced by the newlines the offset spans
+ * and, on the first line, past the markup the value opens with. The fix, when
+ * given as `{value, replacement, suggestion?}`, is anchored there and carries
+ * the decoded `offset`, so the fixer can decode-walk from the node's raw start
+ * to the match even past an entity that shifts it. Omit `fix` for report-only.
  * @param {string} check - Check name
  * @param {{severity: string, message: string}} meta - The check metadata
  * @param {string} file - File the node sits in
- * @param {Node} node - The attribute or expression node
+ * @param {Node} node - The attribute, text, or CDATA node
  * @param {number} offset - Offset of the defect within the node value
  * @param {?{value: string, replacement: string, suggestion?: boolean}} [fix] -
  *  The fix, or undefined for a report-only defect
  * @return {object} - Defect
  */
 const defect = function(check, meta, file, node, offset, fix = undefined) {
-  const pos = node.columnNumber + (node.nodeType === 3 ? 0 : 1) + offset
+  const before = node.nodeValue.slice(0, offset)
+  const newline = before.lastIndexOf('\n')
+  const line = node.lineNumber + before.split('\n').length - 1
+  const pos = newline < 0 ?
+    node.columnNumber + (LEAD[node.nodeType] || 0) + offset :
+    offset - newline
   const anchored = fix === undefined ?
     undefined :
-    {line: node.lineNumber, col: pos, offset: offset, ...fix}
+    {line: line, col: pos, offset: offset, ...fix}
   return {
     name: check,
     severity: meta.severity,
     message: meta.message,
     file: file,
-    line: node.lineNumber,
+    line: line,
     pos: pos,
     ...(anchored === undefined ? {} : {fix: anchored}),
   }

--- a/src/checks.js
+++ b/src/checks.js
@@ -44,7 +44,7 @@ const suppressed = function(check, suppressions) {
  * @return {object} - Defect
  */
 const defect = function(check, meta, file, node, offset, fix = undefined) {
-  const pos = node.columnNumber + 1 + offset
+  const pos = node.columnNumber + (node.nodeType === 3 ? 0 : 1) + offset
   const anchored = fix === undefined ?
     undefined :
     {line: node.lineNumber, col: pos, offset: offset, ...fix}

--- a/test/attributes.test.js
+++ b/test/attributes.test.js
@@ -23,6 +23,20 @@ const SHEET = xml.parsedFromString(
   ),
 )
 
+/**
+ * A 3.0 stylesheet whose text value templates and shadow attributes carry
+ * expressions alongside the ordinary attributes.
+ * @type {Document}
+ */
+const TEMPLATED = xml.parsedFromString(
+  fs.readFileSync(
+    path.resolve(
+      __dirname, 'resources', 'attributes', 'text-value-templates.xsl',
+    ),
+    'utf-8',
+  ),
+)
+
 describe('attributes', function() {
   it('reads every bare and enclosed expression in document order', function() {
     assert.deepEqual(
@@ -42,6 +56,20 @@ describe('attributes', function() {
     assert.ok(
       expressionsOf(SHEET).every((found) => found.node.nodeName !== 'test'),
       'reads output text on a literal result element as an expression',
+    )
+  })
+  it('reads a text value template and a shadow attribute too', function() {
+    assert.deepEqual(
+      expressionsOf(TEMPLATED).map(
+        (found) => [found.node.nodeName, found.start, found.expression],
+      ),
+      [
+        ['match', 0, 'section'],
+        ['#text', 1, 'count(item) = 0'],
+        ['_select', 0, 'name(.)'],
+        ['select', 0, '@x'],
+      ],
+      'cannot read a text value template or a shadow attribute',
     )
   })
 })

--- a/test/fixer.test.js
+++ b/test/fixer.test.js
@@ -184,6 +184,13 @@ const APPLIED = [
     after: 'count-in-attribute-value-templates.fixed.xsl',
   },
   {
+    name: 'should rewrite a count comparison inside a text value template ' +
+      'with --fix',
+    flag: '--fix',
+    before: 'count-in-text-value-template.xsl',
+    after: 'count-in-text-value-template.fixed.xsl',
+  },
+  {
     name: 'should keep the widest of the fixes that overlap with --fix',
     flag: '--fix',
     before: 'overlapping-fixes.xsl',

--- a/test/resources/attributes/text-value-templates.xsl
+++ b/test/resources/attributes/text-value-templates.xsl
@@ -1,4 +1,8 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" expand-text="yes">
   <xsl:template match="section">
     <p>{count(item) = 0}</p>

--- a/test/resources/attributes/text-value-templates.xsl
+++ b/test/resources/attributes/text-value-templates.xsl
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" expand-text="yes">
+  <xsl:template match="section">
+    <p>{count(item) = 0}</p>
+    <xsl:value-of _select="name(.)"/>
+    <xsl:value-of select="@x"/>
+    <q xsl:expand-text="no">{count(item)}</q>
+    <r>{{literal}}</r>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/count-packs/count-in-text-value-template.yaml
+++ b/test/resources/count-packs/count-in-text-value-template.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: count-compared-to-zero
+found:
+  amount: 1
+  positions: [ [ 4, 9 ] ]
+  fixes: [ "empty(item)" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" expand-text="yes">
+    <xsl:template match="/">
+      <a>{count(item) = 0}</a>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/fix/count-in-text-value-template.fixed.xsl
+++ b/test/resources/fix/count-in-text-value-template.fixed.xsl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" expand-text="yes">
+  <xsl:template match="/">
+    <p>{empty(item)}</p>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/count-in-text-value-template.xsl
+++ b/test/resources/fix/count-in-text-value-template.xsl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" expand-text="yes">
+  <xsl:template match="/">
+    <p>{count(item) = 0}</p>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/using-namespace-axis-packs/namespace-axis-in-cdata.yaml
+++ b/test/resources/using-namespace-axis-packs/namespace-axis-in-cdata.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: using-namespace-axis
+found:
+  amount: 1
+  positions: [ [ 4, 23 ] ]
+  fixes: [ null ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" expand-text="true">
+    <xsl:template match="/">
+      <script><![CDATA[{namespace::c}]]></script>
+      <p xsl:expand-text="no">{namespace::off}</p>
+      <q>{{namespace::esc}}</q>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/using-namespace-axis-packs/namespace-axis-in-shadow-attribute.yaml
+++ b/test/resources/using-namespace-axis-packs/namespace-axis-in-shadow-attribute.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: using-namespace-axis
+found:
+  amount: 1
+  positions: [ [ 4, 28 ] ]
+  fixes: [ null ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+    <xsl:template match="/">
+      <xsl:value-of _select="namespace::*"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/using-namespace-axis-packs/namespace-axis-in-text-value-template.yaml
+++ b/test/resources/using-namespace-axis-packs/namespace-axis-in-text-value-template.yaml
@@ -3,13 +3,16 @@
 ---
 pack: using-namespace-axis
 found:
-  amount: 1
-  positions: [ [ 4, 9 ] ]
-  fixes: [ null ]
+  amount: 4
+  positions: [ [ 4, 9 ], [ 4, 31 ], [ 4, 48 ], [ 6, 8 ] ]
+  fixes: [ null, null, null, null ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" expand-text="yes">
     <xsl:template match="/">
-      <a>{namespace::*}</a>
+      <a>{namespace::x}, {count(namespace::y)}, {namespace::z}</a>
+      <b>
+        {namespace::deep}
+      </b>
     </xsl:template>
   </xsl:stylesheet>

--- a/test/resources/using-namespace-axis-packs/namespace-axis-in-text-value-template.yaml
+++ b/test/resources/using-namespace-axis-packs/namespace-axis-in-text-value-template.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: using-namespace-axis
+found:
+  amount: 1
+  positions: [ [ 4, 9 ] ]
+  fixes: [ null ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" expand-text="yes">
+    <xsl:template match="/">
+      <a>{namespace::*}</a>
+    </xsl:template>
+  </xsl:stylesheet>


### PR DESCRIPTION
`expressionsOf` gathered expressions from `//*/@*` — attributes only. In an
XSLT 3.0 stylesheet that misses the two places the modern idiom puts an XPath
outside an attribute, so every code-based linter was blind to them:

- a **text value template** — `<a>{namespace::*}</a>` where the nearest
  `expand-text`/`xsl:expand-text` is on;
- a **shadow attribute** — `_select="namespace::*"`, whose whole value is the
  static expression that becomes `@select`.

`expressionsOf` now also reads both, in a 3.0 stylesheet: the braces of a text
node whose nearest expansion setting is on (nearest wins, off until one sets it,
`{{` still escapes), and a `_`-prefixed shadow of a bare-XPath attribute (its
whole value when it has no braces, its braces otherwise). Because a text node has
no opening quote, `checks.js` drops the `+1` column adjustment for it, so a defect
— and its `--fix` — lands where it truly stands.

The scan is gated on `versionOf(xsl) === '3.0'` (text value templates and shadow
attributes are 3.0), reusing the helper from #603, so 1.0/2.0 stylesheets are
untouched. New packs prove it is family-wide — `using-namespace-axis` fires in a
text value template and in a shadow attribute, and a `count-compared-to-zero` fix
rewrites `count(item) = 0` to `empty(item)` from inside a text node.

Closes #606. 629 tests, 100% branch coverage, ESLint clean.
