### PR TITLE
bug(#595): freeze using-namespace-axis as mature

### DIFF
--- a/src/resources/checks/format/using-namespace-axis.yaml
+++ b/src/resources/checks/format/using-namespace-axis.yaml
@@ -3,3 +3,4 @@
 ---
 severity: warning
 message: "The namespace:: axis is deprecated in XSLT 2.0 and later. Use in-scope-prefixes() and namespace-uri-for-prefix() instead."
+mature: true


### PR DESCRIPTION
The first check to carry `mature: true`.

Everything the bar asks for is in the tree and verified, dimension by dimension:

- **No false positive, no false negative** — fires on 2.0/3.0 and not 1.0; on
  `xsl:stylesheet`, `xsl:transform`, a non-`xsl` prefix, and a simplified
  stylesheet (the SVG `version`-vs-`xsl:version` trap included); on the axis
  buried, three-plus in one expression, and whitespaced; inside an attribute
  value template, a text value template, a shadow attribute, and a CDATA
  section; and never on `in-scope-prefixes()`, `namespace-uri-for-prefix()`, a
  `namespace::` in a string literal, or a `namespace-node()` node test.
- **Motive** teaches the construct with an `Incorrect:`/`Correct:` pair of valid
  XSLT and says nothing of the tool.
- **Report-only by nature** — the axis-to-functions rewrite has no single local
  form, so no fixer is wired; all ten packs assert `fixes: [null]`.
- **Version-dependence** handled through `versionOf`; **selector** is lexer-based
  and optimal; it **overlaps** no other check.

The ten packs pin each of those cases. Conformance's mature-freeze gate passes,
the suite is green at 100% branch coverage.

Closes #595.
