### PR TITLE
bug(#564): abbreviate self::node(), version-guard the fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,8 @@ Today this covers ten checks:
 - `redundant-whitespace` — a doubled space is collapsed to one, and a space
   leading or trailing an XPath expression is removed.
 - `unabbreviated-axis` — a verbose axis specifier is shortened: `child::x`
-  becomes `x`, `attribute::x` becomes `@x`, and `parent::node()` becomes `..`.
+  becomes `x`, `attribute::x` becomes `@x`, `parent::node()` becomes `..`, and
+  `self::node()` becomes `.`.
 - `redundant-namespace-declarations` — a namespace prefix declared on the
   stylesheet but never used is deleted.
 - `use-node-set-extension` — the redundant `node-set()` extension is unwrapped

--- a/README.md
+++ b/README.md
@@ -254,7 +254,8 @@ Today this covers ten checks:
   leading or trailing an XPath expression is removed.
 - `unabbreviated-axis` — a verbose axis specifier is shortened: `child::x`
   becomes `x`, `attribute::x` becomes `@x`, `parent::node()` becomes `..`, and
-  `self::node()` becomes `.`.
+  `self::node()` becomes `.`. On a 1.0 stylesheet a predicated step keeps its
+  longhand, since `.` and `..` took no predicate before XPath 2.0.
 - `redundant-namespace-declarations` — a namespace prefix declared on the
   stylesheet but never used is deleted.
 - `use-node-set-extension` — the redundant `node-set()` extension is unwrapped

--- a/src/resources/checks/format/unabbreviated-axis.yaml
+++ b/src/resources/checks/format/unabbreviated-axis.yaml
@@ -3,4 +3,3 @@
 ---
 severity: warning
 message: Verbose axis specifiers child::, attribute::, parent::node(), or self::node() are used. Replace them with the node name alone, @, .., or . respectively.
-mature: true

--- a/src/resources/checks/format/unabbreviated-axis.yaml
+++ b/src/resources/checks/format/unabbreviated-axis.yaml
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: MIT
 ---
 severity: warning
-message: Verbose axis specifiers child::, attribute::, or parent::node() are used. Replace them with the node name alone, @, or .. respectively.
+message: Verbose axis specifiers child::, attribute::, parent::node(), or self::node() are used. Replace them with the node name alone, @, .., or . respectively.
+mature: true

--- a/src/resources/checks/format/using-namespace-axis.yaml
+++ b/src/resources/checks/format/using-namespace-axis.yaml
@@ -3,4 +3,3 @@
 ---
 severity: warning
 message: "The namespace:: axis is deprecated in XSLT 2.0 and later. Use in-scope-prefixes() and namespace-uri-for-prefix() instead."
-mature: true

--- a/src/resources/motives/format/unabbreviated-axis.md
+++ b/src/resources/motives/format/unabbreviated-axis.md
@@ -9,8 +9,8 @@ competing for the reader's attention. Worse, `child::` is noise that says
 nothing — the child axis is the one a bare name already uses, so writing it out
 draws the eye to the one part of the step that carries no information.
 
-The abbreviations are exact synonyms defined by XPath itself, so the shorter
-form selects precisely the same nodes:
+The abbreviations are defined by XPath itself and select precisely the same
+nodes as the longhand:
 
 | Longhand | Short |
 | --- | --- |
@@ -43,6 +43,16 @@ Those four are the whole of the trade. `parent::chapter` and `self::chapter`
 name an element rather than any node at all, so they have no shorter spelling
 and stay as they are, and the remaining axes — `descendant::`, `ancestor::`,
 `following-sibling::` and the rest — were never given one.
+
+The node-sets match, but the grammars do not quite, and on XSLT 1.0 that shows.
+There `.` and `..` are an *abbreviated step*, a production that takes no
+predicate, while the longhand is a full step and a full step accepts them. So
+`self::node()[1]` is legal in a 1.0 stylesheet and `.[1]` is a syntax error in
+it — XPath 2.0 gave the context item its own predicate list and lifted the
+restriction, which is why the same expression compiles under a later `version`.
+Where a predicate follows the step in a 1.0 stylesheet, either leave it spelled
+out or parenthesise the abbreviation, since `(.)[1]` is a filter expression and
+is legal in every version.
 
 `descendant-or-self::node()` is the exception that is not worth taking. Its
 short form is `//`, but the two are easy to confuse in use: a `//` that opens a

--- a/src/resources/motives/format/unabbreviated-axis.md
+++ b/src/resources/motives/format/unabbreviated-axis.md
@@ -1,8 +1,23 @@
 # Can use abbreviated axis specifier
 
-XSLT supports short forms for common axis specifiers: `child::` can be
-omitted entirely, `attribute::` is abbreviated as `@`, and `parent::node()`
-is written as `..`.
+The steps an XPath uses most often have short forms, and those short forms are
+what every XSLT reader scans for. Spelling them out buries the shape of the
+path under axis ceremony: `child::chapter/child::section/attribute::id` selects
+exactly what `chapter/section/@id` selects, in nearly three times the width,
+and the difference only grows inside a predicate, where the path is already
+competing for the reader's attention. Worse, `child::` is noise that says
+nothing — the child axis is the one a bare name already uses, so writing it out
+draws the eye to the one part of the step that carries no information.
+
+The abbreviations are exact synonyms defined by XPath itself, so the shorter
+form selects precisely the same nodes:
+
+| Longhand | Short |
+| --- | --- |
+| `child::name` | `name` |
+| `attribute::name` | `@name` |
+| `parent::node()` | `..` |
+| `self::node()` | `.` |
 
 Incorrect:
 
@@ -10,6 +25,8 @@ Incorrect:
 <xsl:value-of select="child::title"/>
 <xsl:value-of select="attribute::name"/>
 <xsl:apply-templates select="parent::node()"/>
+<xsl:copy-of select="self::node()"/>
+<xsl:value-of select="child::book/child::author/attribute::id"/>
 ```
 
 Correct:
@@ -18,4 +35,18 @@ Correct:
 <xsl:value-of select="title"/>
 <xsl:value-of select="@name"/>
 <xsl:apply-templates select=".."/>
+<xsl:copy-of select="."/>
+<xsl:value-of select="book/author/@id"/>
 ```
+
+Those four are the whole of the trade. `parent::chapter` and `self::chapter`
+name an element rather than any node at all, so they have no shorter spelling
+and stay as they are, and the remaining axes — `descendant::`, `ancestor::`,
+`following-sibling::` and the rest — were never given one.
+
+`descendant-or-self::node()` is the exception that is not worth taking. Its
+short form is `//`, but the two are easy to confuse in use: a `//` that opens a
+`select` walks the whole document from the root on every evaluation, which is
+rarely what the longhand step meant. Where the abbreviation is wanted there,
+anchor it — `.//author` searches the current subtree, `//author` searches the
+entire document.

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -168,6 +168,14 @@ const opensComment = function(xpath, at) {
 }
 
 /**
+ * Characters a name is spelled with. An axis name only ever opens a step, so
+ * one of these just before it means the match landed inside a longer name —
+ * the `child::` that ends `grandchild::` — and no axis starts there.
+ * @type {RegExp}
+ */
+const NAMED = /[\w.:-]/
+
+/**
  * The axis opening at the given offset, or null when none does. XPath allows
  * whitespace between the axis name and its `::`, so `child ::` names the same
  * axis as `child::`; the name and the colons are matched across that gap and
@@ -187,7 +195,7 @@ const opensAxis = function(xpath, at) {
   }
   const name = `${xpath.slice(at, end)}::`
   if (end === at || xpath[colons] !== ':' || xpath[colons + 1] !== ':' ||
-    !AXES[name]) {
+    !AXES[name] || (at > 0 && NAMED.test(xpath[at - 1]))) {
     return null
   }
   return {name: name, length: colons + 2 - at}

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -168,9 +168,7 @@ const opensComment = function(xpath, at) {
 }
 
 /**
- * Characters a name is spelled with. An axis name only ever opens a step, so
- * one of these just before it means the match landed inside a longer name —
- * the `child::` that ends `grandchild::` — and no axis starts there.
+ * Characters a name is spelled with.
  * @type {RegExp}
  */
 const NAMED = /[\w.:-]/
@@ -195,10 +193,25 @@ const opensAxis = function(xpath, at) {
   }
   const name = `${xpath.slice(at, end)}::`
   if (end === at || xpath[colons] !== ':' || xpath[colons + 1] !== ':' ||
-    !AXES[name] || (at > 0 && NAMED.test(xpath[at - 1]))) {
+    !AXES[name]) {
     return null
   }
   return {name: name, length: colons + 2 - at}
+}
+
+/**
+ * The axis opening a step part-way through a run of other characters, or null
+ * when none does. Reached with a name character just behind it, an axis name
+ * is the tail of a longer name — the `child::` that ends `grandchild::` — and
+ * starts nothing, so the run swallows it. Where the run has already ended the
+ * question does not arise, and `tokenized` asks `opensAxis` directly: after an
+ * operator, `count(a)-child::b` opens a genuine step.
+ * @param {string} xpath - Xpath expression
+ * @param {number} at - Offset to test
+ * @return {?{name: string, length: number}} - The axis name and matched length
+ */
+const opensStep = function(xpath, at) {
+  return at > 0 && NAMED.test(xpath[at - 1]) ? null : opensAxis(xpath, at)
 }
 
 /**
@@ -363,7 +376,7 @@ const afterOther = function(xpath, start) {
     !opensComment(xpath, at) &&
     !opensUserFunction(xpath, at) &&
     !opensNumber(xpath, at) &&
-    !opensAxis(xpath, at)
+    !opensStep(xpath, at)
   ) {
     at += 1
   }

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -6,6 +6,7 @@
 const {tokenized, TOKENS} = require('./tokens')
 const {metaOf, suppressed, defect} = require('./checks')
 const {expressionsOf} = require('./attributes')
+const {MODERN, versionOf} = require('./xsl-version')
 const {logger} = require('./logger')
 
 /**
@@ -50,60 +51,68 @@ const STEP = {
 }
 
 /**
- * How many tokens a `node()` test can span once the whitespace XPath allows
- * between its pieces is counted in: the name, the two parentheses, and a run
- * of whitespace before each.
+ * How many tokens a `node()` test and the bracket that may follow it span,
+ * once the whitespace XPath allows between the pieces is counted in.
  * @type {number}
  */
-const SPAN = 6
+const SPAN = 4
 
 /**
- * Offset just past the `node()` test that follows the axis token at the given
- * index, or null when the axis carries another node test. The whitespace XPath
- * allows between the pieces is insignificant, so `node ( )` names the same
- * test as `node()`.
+ * The `node()` test that follows the axis token at the given index, or null
+ * when the axis carries another node test. The whitespace XPath allows between
+ * the pieces is insignificant, so `node ( )` names the same test as `node()`.
+ * A predicate on the step is reported alongside, because the abbreviations are
+ * not free to take one everywhere.
  * @param {Array.<{type: string, value: string, start: number}>} tokens - Tokens
  * @param {number} index - Index of the axis token
- * @return {?number} - Offset just past the closing parenthesis
+ * @return {?{end: number, predicated: boolean}} - Where it ends, and its shape
  */
 const afterNode = function(tokens, index) {
-  const rest = tokens.slice(index + 1, index + 1 + SPAN).filter(
+  const rest = tokens.slice(index + 1, index + 1 + SPAN * 2).filter(
     (token) => token.type !== TOKENS.WHITESPACE,
   )
   const shaped = rest.length >= 3 &&
     rest[0].type === TOKENS.OTHER && rest[0].value === 'node' &&
     rest[1].type === TOKENS.LPAREN && rest[2].type === TOKENS.RPAREN
-  return shaped ? rest[2].start + 1 : null
+  return shaped ? {
+    end: rest[2].start + 1,
+    predicated: rest.length > 3 && rest[3].type === TOKENS.LBRACKET,
+  } : null
 }
 
 /**
  * Abbreviable axis specifiers in an expression. Each carries the offset where
- * it starts, its verbatim text, and the shorter form it becomes: `child::`
- * drops away, `attribute::` becomes `@`, `parent::node()` becomes `..`, and
- * `self::node()` becomes `.`. Those four are the whole of it — a `parent::` or
- * `self::` before any other node test has no shorter form, and neither has any
- * remaining axis, `descendant-or-self::node()` aside, whose `//` trades a
- * named step for a whole-tree walk. Axes inside string literals or comments
- * are never seen because the lexer keeps those whole.
+ * it starts and the fix that shortens it, or no fix where the shorter form
+ * cannot stand in that place: `child::` drops away, `attribute::` becomes `@`,
+ * `parent::node()` becomes `..`, and `self::node()` becomes `.`. Those four are
+ * the whole of it — a `parent::` or `self::` before any other node test has no
+ * shorter form, and neither has any remaining axis, `descendant-or-self`
+ * aside, whose `//` trades a named step for a whole-tree walk. Before XPath 2.0
+ * gave the context item a predicate list, `.` and `..` were an AbbreviatedStep,
+ * which takes no predicate, so `self::node()[1]` is only reported on a 1.0
+ * sheet: `.[1]` is a syntax error there. Axes inside string literals or
+ * comments are never seen because the lexer keeps those whole.
  * @param {string} expression - Xpath expression or pattern
- * @return {Array.<{offset: number, value: string, replacement: string}>} - Axes
+ * @param {boolean} modern - Whether the stylesheet declares XSLT 2.0 or later
+ * @return {Array.<{offset: number, fix: ?object}>} - Axes and their fixes
  */
-const abbreviable = function(expression) {
+const abbreviable = function(expression, modern) {
   const tokens = tokenized(expression)
   const found = []
   tokens.forEach((token, index) => {
-    const end = STEP[token.type] ? afterNode(tokens, index) : null
+    const step = STEP[token.type] ? afterNode(tokens, index) : null
     if (SHORT[token.type]) {
       found.push({
         offset: token.start,
-        value: token.value,
-        replacement: SHORT[token.type].replacement,
+        fix: {value: token.value, replacement: SHORT[token.type].replacement},
       })
-    } else if (end !== null) {
+    } else if (step !== null) {
       found.push({
         offset: token.start,
-        value: expression.slice(token.start, end),
-        replacement: STEP[token.type].replacement,
+        fix: step.predicated && !modern ? undefined : {
+          value: expression.slice(token.start, step.end),
+          replacement: STEP[token.type].replacement,
+        },
       })
     }
   })
@@ -123,13 +132,10 @@ const lintByAxis = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const {file, xsl} of corpus) {
+      const modern = MODERN.includes(versionOf(xsl))
       for (const {node, start, expression} of expressionsOf(xsl)) {
-        for (const {offset, value, replacement} of abbreviable(expression)) {
-          defects.push(
-            defect(
-              CHECK, META, file, node, start + offset, {value, replacement},
-            ),
-          )
+        for (const {offset, fix} of abbreviable(expression, modern)) {
+          defects.push(defect(CHECK, META, file, node, start + offset, fix))
         }
       }
     }

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -27,9 +27,9 @@ const META = metaOf(CHECK)
 const names = [CHECK]
 
 /**
- * The abbreviation each single-token axis specifier collapses to. The verbatim
- * text comes from the token, so a spaced `child ::` is stripped in full rather
- * than leaving its whitespace behind.
+ * The abbreviation each axis specifier collapses to on its own, whatever node
+ * test follows it. The verbatim text comes from the token, so a spaced
+ * `child ::` is stripped in full rather than leaving its whitespace behind.
  * @type {{[type: string]: {replacement: string}}}
  */
 const SHORT = {
@@ -38,31 +38,75 @@ const SHORT = {
 }
 
 /**
+ * The abbreviation each axis collapses to when — and only when — its node test
+ * is `node()`, in which case the whole step goes. The same axis before any
+ * other node test names a kind of node rather than every one, so it keeps its
+ * longhand.
+ * @type {{[type: string]: {replacement: string}}}
+ */
+const STEP = {
+  [TOKENS.PARENT]: {replacement: '..'},
+  [TOKENS.SELF]: {replacement: '.'},
+}
+
+/**
+ * How many tokens a `node()` test can span once the whitespace XPath allows
+ * between its pieces is counted in: the name, the two parentheses, and a run
+ * of whitespace before each.
+ * @type {number}
+ */
+const SPAN = 6
+
+/**
+ * Offset just past the `node()` test that follows the axis token at the given
+ * index, or null when the axis carries another node test. The whitespace XPath
+ * allows between the pieces is insignificant, so `node ( )` names the same
+ * test as `node()`.
+ * @param {Array.<{type: string, value: string, start: number}>} tokens - Tokens
+ * @param {number} index - Index of the axis token
+ * @return {?number} - Offset just past the closing parenthesis
+ */
+const afterNode = function(tokens, index) {
+  const rest = tokens.slice(index + 1, index + 1 + SPAN).filter(
+    (token) => token.type !== TOKENS.WHITESPACE,
+  )
+  const shaped = rest.length >= 3 &&
+    rest[0].type === TOKENS.OTHER && rest[0].value === 'node' &&
+    rest[1].type === TOKENS.LPAREN && rest[2].type === TOKENS.RPAREN
+  return shaped ? rest[2].start + 1 : null
+}
+
+/**
  * Abbreviable axis specifiers in an expression. Each carries the offset where
  * it starts, its verbatim text, and the shorter form it becomes: `child::`
- * drops away, `attribute::` becomes `@`, and `parent::node()` becomes `..`. A
- * `parent::` with any other node test has no abbreviation and is left alone.
- * Axes inside string literals or comments are never seen because the lexer
- * keeps those whole.
+ * drops away, `attribute::` becomes `@`, `parent::node()` becomes `..`, and
+ * `self::node()` becomes `.`. Those four are the whole of it — a `parent::` or
+ * `self::` before any other node test has no shorter form, and neither has any
+ * remaining axis, `descendant-or-self::node()` aside, whose `//` trades a
+ * named step for a whole-tree walk. Axes inside string literals or comments
+ * are never seen because the lexer keeps those whole.
  * @param {string} expression - Xpath expression or pattern
  * @return {Array.<{offset: number, value: string, replacement: string}>} - Axes
  */
 const abbreviable = function(expression) {
+  const tokens = tokenized(expression)
   const found = []
-  for (const token of tokenized(expression)) {
+  tokens.forEach((token, index) => {
+    const end = STEP[token.type] ? afterNode(tokens, index) : null
     if (SHORT[token.type]) {
       found.push({
         offset: token.start,
         value: token.value,
         replacement: SHORT[token.type].replacement,
       })
-    } else if (
-      token.type === TOKENS.PARENT &&
-      expression.slice(token.start, token.start + 14) === 'parent::node()'
-    ) {
-      found.push({offset: token.start, value: 'parent::node()', replacement: '..'})
+    } else if (end !== null) {
+      found.push({
+        offset: token.start,
+        value: expression.slice(token.start, end),
+        replacement: STEP[token.type].replacement,
+      })
     }
-  }
+  })
   return found
 }
 

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -51,8 +51,9 @@ const STEP = {
 }
 
 /**
- * How many tokens a `node()` test and the bracket that may follow it span,
- * once the whitespace XPath allows between the pieces is counted in.
+ * How many significant tokens a `node()` test and the bracket that may follow
+ * it come to: the name, the two parentheses, and the bracket. A run of
+ * whitespace may precede each, so twice that bounds the slice they sit in.
  * @type {number}
  */
 const SPAN = 4

--- a/test/fixer.test.js
+++ b/test/fixer.test.js
@@ -337,6 +337,11 @@ const UNCHANGED = [
     sheet: 'count-in-xslt-1-0.xsl',
   },
   {
+    name: 'cannot abbreviate a predicated step in a 1.0 stylesheet with --fix',
+    flag: '--fix',
+    sheet: 'unabbreviated-axis-in-xslt-1.xsl',
+  },
+  {
     name: 'cannot rewrite an entity-encoded comparison with --fix-dry-run',
     flag: '--fix-dry-run',
     sheet: 'count-entity-comparison.xsl',

--- a/test/resources/axis-packs/axis-after-an-operator.yaml
+++ b/test/resources/axis-packs/axis-after-an-operator.yaml
@@ -3,15 +3,15 @@
 ---
 pack: unabbreviated-axis
 found:
-  amount: 0
-  positions: [ ]
-  fixes: [ ]
+  amount: 3
+  positions: [ [ 4, 36 ], [ 5, 29 ], [ 6, 38 ] ]
+  fixes: [ "", "", "" ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
     <xsl:template match="/">
-      <xsl:value-of select="my:child::x"/>
-      <xsl:value-of select="stepparent::node()"/>
-      <xsl:value-of select="myself::node()"/>
+      <xsl:value-of select="count(a)-child::b"/>
+      <xsl:value-of select="1-child::b"/>
+      <xsl:value-of select="count(a) - child::b"/>
     </xsl:template>
   </xsl:stylesheet>

--- a/test/resources/axis-packs/axis-in-cdata.yaml
+++ b/test/resources/axis-packs/axis-in-cdata.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 1
+  positions: [ [ 4, 23 ] ]
+  fixes: [ "" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" expand-text="true">
+    <xsl:template match="/">
+      <script><![CDATA[{child::c}]]></script>
+      <p xsl:expand-text="no">{child::off}</p>
+      <q>{{child::esc}}</q>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/axis-packs/axis-in-shadow-attribute.yaml
+++ b/test/resources/axis-packs/axis-in-shadow-attribute.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 1
+  positions: [ [ 4, 28 ] ]
+  fixes: [ "@" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+    <xsl:template match="/">
+      <xsl:value-of _select="attribute::x"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/axis-packs/axis-in-simplified-stylesheet.yaml
+++ b/test/resources/axis-packs/axis-in-simplified-stylesheet.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 2
+  positions: [ [ 3, 31 ], [ 4, 27 ] ]
+  fixes: [ "@", "" ]
+input: |-
+  <?xml version="1.0"?>
+  <html xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xsl:version="1.0">
+    <p select="child::x" note="{attribute::z}">
+      <xsl:value-of select="child::title"/>
+    </p>
+  </html>

--- a/test/resources/axis-packs/axis-in-text-value-template.yaml
+++ b/test/resources/axis-packs/axis-in-text-value-template.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 4
+  positions: [ [ 4, 9 ], [ 4, 27 ], [ 4, 44 ], [ 6, 8 ] ]
+  fixes: [ "", "@", ".", ".." ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" expand-text="yes">
+    <xsl:template match="/">
+      <a>{child::x}, {count(attribute::y)}, {self::node()}</a>
+      <b>
+        {parent::node()}
+      </b>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/axis-packs/axis-name-inside-a-name.yaml
+++ b/test/resources/axis-packs/axis-name-inside-a-name.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 0
+  positions: [ ]
+  fixes: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="/">
+      <xsl:value-of select="grandchild::x"/>
+      <xsl:value-of select="a-child::b"/>
+      <xsl:value-of select="my:child::x"/>
+      <xsl:value-of select="stepparent::node()"/>
+      <xsl:value-of select="myself::node()"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/axis-packs/axis-non-xsl-prefix.yaml
+++ b/test/resources/axis-packs/axis-non-xsl-prefix.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 2
+  positions: [ [ 3, 22 ], [ 4, 25 ] ]
+  fixes: [ "", "@" ]
+input: |-
+  <?xml version="1.0"?>
+  <t:transform xmlns:t="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <t:template match="child::a">
+      <t:value-of select="attribute::b"/>
+    </t:template>
+  </t:transform>

--- a/test/resources/axis-packs/axis-without-short-form.yaml
+++ b/test/resources/axis-packs/axis-without-short-form.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 0
+  positions: [ ]
+  fixes: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="/">
+      <xsl:value-of select="a/descendant-or-self::node()/b"/>
+      <xsl:value-of select="descendant::x"/>
+      <xsl:value-of select="ancestor-or-self::node()"/>
+      <xsl:value-of select="following-sibling::y"/>
+      <xsl:value-of select="a (: child::x :)"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/axis-packs/predicated-step-in-xslt-1.yaml
+++ b/test/resources/axis-packs/predicated-step-in-xslt-1.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 4
+  positions: [ [ 4, 26 ], [ 5, 26 ], [ 6, 26 ], [ 7, 26 ] ]
+  fixes: [ null, null, ".", "" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:template match="/">
+      <xsl:copy-of select="self::node()[1]"/>
+      <xsl:copy-of select="parent::node()[1]"/>
+      <xsl:copy-of select="self::node()"/>
+      <xsl:copy-of select="child::a[1]"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/axis-packs/predicated-step-in-xslt-2.yaml
+++ b/test/resources/axis-packs/predicated-step-in-xslt-2.yaml
@@ -3,15 +3,14 @@
 ---
 pack: unabbreviated-axis
 found:
-  amount: 0
-  positions: [ ]
-  fixes: [ ]
+  amount: 2
+  positions: [ [ 4, 26 ], [ 5, 26 ] ]
+  fixes: [ ".", ".." ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
     <xsl:template match="/">
-      <xsl:value-of select="my:child::x"/>
-      <xsl:value-of select="stepparent::node()"/>
-      <xsl:value-of select="myself::node()"/>
+      <xsl:copy-of select="self::node()[1]"/>
+      <xsl:copy-of select="parent::node()[1]"/>
     </xsl:template>
   </xsl:stylesheet>

--- a/test/resources/axis-packs/self-node-axis.yaml
+++ b/test/resources/axis-packs/self-node-axis.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 4
+  positions: [ [ 4, 27 ], [ 5, 21 ], [ 5, 41 ], [ 5, 57 ] ]
+  fixes: [ ".", ".", ".", "." ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="/">
+      <xsl:value-of select="self::node()"/>
+      <xsl:if test="a[self::node()] | b[c/self::node()] | self::node()">
+        <xsl:value-of select="self::a"/>
+        <xsl:value-of select="self::*"/>
+        <xsl:value-of select="self::text()"/>
+        <xsl:value-of select="'self::node()'"/>
+      </xsl:if>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/axis-packs/whitespaced-node-test.yaml
+++ b/test/resources/axis-packs/whitespaced-node-test.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 3
+  positions: [ [ 4, 27 ], [ 5, 27 ], [ 6, 27 ] ]
+  fixes: [ "..", "..", "." ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="/">
+      <xsl:value-of select="parent::node ()"/>
+      <xsl:value-of select="parent :: node()"/>
+      <xsl:value-of select="self :: node ( )"/>
+      <xsl:value-of select="parent::node"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/fix/unabbreviated-axis-in-xslt-1.xsl
+++ b/test/resources/fix/unabbreviated-axis-in-xslt-1.xsl
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:template match="R">
+    <xsl:copy-of select="self::node()[1]"/>
+    <xsl:copy-of select="parent::node()[1]"/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/unabbreviated-axis.fixed.xsl
+++ b/test/resources/fix/unabbreviated-axis.fixed.xsl
@@ -8,6 +8,9 @@
     <xsl:value-of select="title"/>
     <xsl:value-of select="@name"/>
     <xsl:apply-templates select=".."/>
+    <xsl:value-of select="."/>
+    <xsl:value-of select=".."/>
     <xsl:value-of select="parent::n"/>
+    <xsl:value-of select="self::text()"/>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/resources/fix/unabbreviated-axis.xsl
+++ b/test/resources/fix/unabbreviated-axis.xsl
@@ -8,6 +8,9 @@
     <xsl:value-of select="child::title"/>
     <xsl:value-of select="attribute::name"/>
     <xsl:apply-templates select="parent::node()"/>
+    <xsl:value-of select="self::node()"/>
+    <xsl:value-of select="parent :: node ( )"/>
     <xsl:value-of select="parent::n"/>
+    <xsl:value-of select="self::text()"/>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/resources/using-namespace-axis-packs/namespace-axis-inside-a-name.yaml
+++ b/test/resources/using-namespace-axis-packs/namespace-axis-inside-a-name.yaml
@@ -1,17 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: unabbreviated-axis
+pack: using-namespace-axis
 found:
-  amount: 0
-  positions: [ ]
-  fixes: [ ]
+  amount: 1
+  positions: [ [ 5, 36 ] ]
+  fixes: [ null ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
     <xsl:template match="/">
-      <xsl:value-of select="my:child::x"/>
-      <xsl:value-of select="stepparent::node()"/>
-      <xsl:value-of select="myself::node()"/>
+      <xsl:value-of select="my:namespace::x"/>
+      <xsl:value-of select="count(a)-namespace::b"/>
     </xsl:template>
   </xsl:stylesheet>

--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -82,6 +82,10 @@ const SCANS = [
       ['child:abc', TOKENS.CHILD],
       ['descendant-or-self', TOKENS.DESCENDANT_OR_SELF],
       ['child : :abc', TOKENS.CHILD],
+      ['grandchild::abc', TOKENS.CHILD],
+      ['a-child::abc', TOKENS.CHILD],
+      ['ns:child::abc', TOKENS.CHILD],
+      ['myself::abc', TOKENS.SELF],
     ],
   },
 ]

--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -76,16 +76,25 @@ const SCANS = [
     ],
   },
   {
+    name: 'finds an axis that opens a step after an operator',
+    count: 1,
+    pairs: [
+      ['count(a)-child::b', TOKENS.CHILD],
+      ['1-child::b', TOKENS.CHILD],
+      ['count(a) - child::b', TOKENS.CHILD],
+      ['a|self::b', TOKENS.SELF],
+    ],
+  },
+  {
     name: 'finds no axes',
     count: 0,
     pairs: [
       ['child:abc', TOKENS.CHILD],
       ['descendant-or-self', TOKENS.DESCENDANT_OR_SELF],
       ['child : :abc', TOKENS.CHILD],
-      ['grandchild::abc', TOKENS.CHILD],
-      ['a-child::abc', TOKENS.CHILD],
       ['ns:child::abc', TOKENS.CHILD],
       ['myself::abc', TOKENS.SELF],
+      ['stepparent::abc', TOKENS.PARENT],
     ],
   },
 ]


### PR DESCRIPTION
Closes #564. Does **not** claim `mature: true` — see the last section.

### What was missing

XPath defines four axis abbreviations. The check handled three, and one of those
brittlely:

| Longhand | Short | Before |
| --- | --- | --- |
| `child::name` | `name` | handled |
| `attribute::name` | `@name` | handled |
| `parent::node()` | `..` | matched by a fixed 14-character slice |
| `self::node()` | `.` | missed entirely |

The slice meant the whitespace tolerance PR #599 put into the lexer never
reached the linter: `parent :: node()` tokenized correctly and then failed the
literal comparison. Both halves of #564 are closed — `afterNode` reads the node
test off the token stream, so `parent::node ()`, `parent :: node()` and
`self :: node ( )` all abbreviate.

### The abbreviation is version-dependent

`.` and `..` are an `AbbreviatedStep` in XPath 1.0, and an `AbbreviatedStep`
takes no predicate:

```text
[4]  Step ::= AxisSpecifier NodeTest Predicate* | AbbreviatedStep
[12] AbbreviatedStep ::= '.' | '..'
```

So `self::node()[1]` is legal on 1.0 and `.[1]` is a syntax error there, and
plain `--fix` was turning a working stylesheet into one xsltproc will not
compile. fontoxpath is 3.1 and accepts `.[1]`, so the validator could not catch
what the fixer had written. The linter now reads `versionOf` and withholds the
fix — report only — when a predicate follows the step on a pre-2.0 sheet:

| | 1.0 | 2.0 |
| --- | --- | --- |
| `self::node()[1]` | reported, not fixed | `.[1]` |
| `parent::node()[1]` | reported, not fixed | `..[1]` |
| `self::node()` | `.` | `.` |
| `child::a[1]` | `a[1]` | `a[1]` |
| `(self::node())[1]` | `(.)[1]` | `(.)[1]` |

The last two rows are the ones worth checking: `@a[1]` and `a[1]` are full steps
and take predicates on 1.0, and a parenthesised `(.)[1]` is a filter expression,
legal in every version. Only the bare abbreviated step is restricted. A sheet
with no readable version is treated as old and keeps its longhand.

### A false positive with a destructive fix

`opensAxis` matched at any offset, so the `child::` at the tail of a longer name
read as an axis and `--fix` rewrote `ns:child::x`. The guard for that is
`opensStep`, and it is called only from `afterOther`: mid-run a match can land
inside a name, but at a token boundary the preceding character belongs to the
previous token, and guarding there loses real steps — `count(a)-child::b` and
`1-child::b` both compile and neither draws `invalid-xpath-expression`.

### Deliberately out of scope

`descendant-or-self::node()` also abbreviates, to `//`. Not adopted: a leading
`//` in a `select` rescans the whole document, which is what
`select-starts-with-double-slash` exists to flag, so recommending it here would
have two checks contradict each other. The motive teaches the trade and points
at `.//`; a pack pins that `a/descendant-or-self::node()/b` stays quiet.

### Coverage

Twelve new packs, taking the check from 4 to 16. They exercise the construct
buried in a predicate, three times in one expression, and beside the lookalikes
that must not fire — `self::a`, `self::*`, `self::text()`, `parent::node` with no
parentheses, an axis in a string literal and in an XPath comment. Per the
node-kind rule from #610 they also cover a non-`xsl` prefix on an `xsl:transform`
root, a simplified 1.0 stylesheet whose literal result element carries a `select`
bound for the result tree (left alone) beside an AVT that is read, a 3.0 text
value template, a shadow attribute, and a CDATA section. `unabbreviated-axis-in-xslt-1.xsl`
joins `UNCHANGED` under `--fix`, so a fix that creeps back onto 1.0 fails the build.

`using-namespace-axis` shares the lexer, so its one behavior delta here —
`my:namespace::x`, a false positive removed — is recorded in
`namespace-axis-inside-a-name.yaml`. That pack also pins
`count(a)-namespace::b`, which the first push had regressed. Its `mature: true`
comes off in this PR as well: `ornamespace::x` and `exceptnamespace::x` are live
false positives on master, so the attestation was already untrue, and #617 is now
the gate for both checks.

### Why the flag is not set

Writing the pack for `grandchild::x` showed the guard cannot reach it, and the
reason is not the axis code at all:

```text
border  -> ["b", "or", "der"]      grandchild -> ["gr", "and", "child"]
agent   -> ["a", "ge", "nt"]       exception  -> ["except", "ion"]
```

`afterOther` breaks a run at any word operator, so the axis ends up at a genuine
token boundary. Filed as #617. `--fix` still rewrites `grandchild::x` to
`grandx` — malformed input, already reported as `invalid-xpath-expression`, but
the file is edited all the same, so "no false positive" is not true yet. #617 is
the gate, and it names the one dimension #613's audit of `using-namespace-axis`
did not cover.

Also filed: #615, the validator calling a legal whitespaced axis malformed. It
does not reach this check, which is a document linter and reads the corpus
rather than the validator's filtered expressions.

883 tests, 100% branch coverage (920/920), ESLint, xcop, markdownlint and the
fixtures gate all clean locally.

