### PR TITLE
Enforce one return per function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,18 +34,27 @@ ESLint (`eslint-config-google` + `@stylistic`, config in `eslint.config.mjs`,
 run by the `lint` job) enforces: spaced operators, no single-letter names
 (`id-length` >= 2), postfix `x++` only (prefix `++x` is banned), bare module
 names in `require`/`import` (no `node:` prefix), no redundant return variable
-(`const x = expr; return x` is banned — return the expression), and no missing
+(`const x = expr; return x` is banned — return the expression), no missing
 argument (a call must fill every parameter the callee declares without a
-default). The last two are project-local rules in `eslint-local-rules.js`,
-unit-tested in `test/eslint-local-rules.test.js`; the arity of the callee is
-read from its declaration in the same file, or by loading the module a relative
-`require` names.
+default), and one `return` per function (a second exit is banned). The last
+three are project-local rules in `eslint-local-rules.js`, unit-tested in
+`test/eslint-local-rules.test.js`; the arity of the callee is read from its
+declaration in the same file, or by loading the module a relative `require`
+names.
 
 A parameter a caller may leave out therefore says so in the signature, with a
 default — `fix = undefined` on `defect` in `src/checks.js`. A JSDoc `[fix]`
 alone does not count: the rule weighs `Function.length`, so an optional
 parameter that the runtime signature calls required is a lint error at every
 call that omits it.
+
+A function likewise leaves through exactly one `return`, and the branching — not
+the exit — decides what it carries: a lookup keyed on the deciding values
+(`collapses` in `src/count-linter.js`), a ternary chain (`defectsOf` in
+`src/corpus-linter.js`), or a sentinel a scan assigns before its loop ends
+(`closes` in `src/expressions.js`). A `return` counts against the nearest
+enclosing function, so a `map`/`every` callback carrying its own single `return`
+is fine, and an arrow with an expression body has none at all.
 
 **Every style or consistency convention must be machine-enforced.** When you fix
 one, do not just fix the instances — in the same change add a check that fails on

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -112,11 +112,14 @@ const demanded = function (variable, from, key) {
 // A project-local ESLint plugin, kept out of eslint.config.mjs so it can be
 // unit-tested with ESLint's RuleTester (test/eslint-local-rules.test.js). One
 // rule flags a variable whose only purpose is to be returned by the very next
-// statement — that binding is redundant and should be inlined. The other flags
-// a call that leaves out an argument the callee declares. No plugin dependency
-// is needed; a single no-restricted-syntax selector can neither compare a
+// statement — that binding is redundant and should be inlined. Another flags
+// a call that leaves out an argument the callee declares. The third flags a
+// function that can be left through more than one return, where the branching,
+// not the exit, is what should carry the choice. No plugin dependency is
+// needed; a single no-restricted-syntax selector can neither compare a
 // declaration's name with the identifier the following return uses, nor weigh
-// a call's argument count against the parameter list of the callee.
+// a call's argument count against the parameter list of the callee, nor tell
+// which function a return belongs to.
 module.exports = {
   rules: {
     "no-redundant-return-variable": {
@@ -203,6 +206,46 @@ module.exports = {
                   given: node.arguments.length
                 }
               });
+            }
+          }
+        };
+      }
+    },
+    "no-multiple-returns": {
+      meta: {
+        type: "suggestion",
+        docs: {
+          description: "disallow more than one return statement in a function"
+        },
+        messages: {
+          multiple:
+            "Return once from a function; let the branching decide the " +
+            "value, not the exit"
+        }
+      },
+      create(context) {
+        const walked = [];
+        const entered = function () {
+          walked.push([]);
+        };
+        const exited = function () {
+          walked
+            .pop()
+            .slice(1)
+            .forEach(
+              (ret) => context.report({ node: ret, messageId: "multiple" })
+            );
+        };
+        return {
+          FunctionDeclaration: entered,
+          FunctionExpression: entered,
+          ArrowFunctionExpression: entered,
+          "FunctionDeclaration:exit": exited,
+          "FunctionExpression:exit": exited,
+          "ArrowFunctionExpression:exit": exited,
+          ReturnStatement(node) {
+            if (walked.length > 0) {
+              walked[walked.length - 1].push(node);
             }
           }
         };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,6 +42,7 @@ export default defineConfig([
     rules: {
       "local/no-redundant-return-variable": "error",
       "local/no-missing-arguments": "error",
+      "local/no-multiple-returns": "error",
       "valid-jsdoc": "off",
       "require-jsdoc": "off",
       semi: ["error", "never"],

--- a/scripts/changelog-notes.js
+++ b/scripts/changelog-notes.js
@@ -23,13 +23,12 @@ const section = function(heading) {
   const start = lines.findIndex(
     (line) => line === `## ${heading}` || line.startsWith(`## ${heading} `),
   )
-  if (start < 0) {
-    return ''
-  }
   const next = lines.findIndex(
     (line, index) => index > start && line.startsWith('## '),
   )
-  return lines.slice(start + 1, next < 0 ? lines.length : next).join('\n').trim()
+  return start < 0 ?
+    '' :
+    lines.slice(start + 1, next < 0 ? lines.length : next).join('\n').trim()
 }
 
 // Prefer this version's section; fall back to Unreleased, then a bare line, so

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -101,19 +101,14 @@ const severityBadge = (severity) => {
 
 const escaped = (xpath) => xpath.replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
-const expressions = (kind, lint) => {
-  if (kind === 'corpus') {
-    return `<code class="xpath">declaration: ${escaped(lint.declaration)}</code>
-    <code class="xpath">usage: ${escaped(lint.usage)}</code>`
-  }
-  if (kind === 'validation') {
-    return `<code class="xpath">verified by the parser, not an XPath rule</code>`
-  }
-  if (kind === 'format') {
-    return `<code class="xpath">checked over the tokens, not an XPath rule</code>`
-  }
-  return `<code class="xpath">${escaped(lint.xpath)}</code>`
-}
+const expressions = (kind, lint) => kind === 'corpus' ?
+  `<code class="xpath">declaration: ${escaped(lint.declaration)}</code>
+    <code class="xpath">usage: ${escaped(lint.usage)}</code>` :
+  kind === 'validation' ?
+    `<code class="xpath">verified by the parser, not an XPath rule</code>` :
+    kind === 'format' ?
+      `<code class="xpath">checked over the tokens, not an XPath rule</code>` :
+      `<code class="xpath">${escaped(lint.xpath)}</code>`
 
 const generate = function() {
   const checks = KINDS.flatMap((kind) => allFilesFrom(path.join(CHECKS, kind))

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -57,16 +57,14 @@ const ON = ['yes', 'true', '1']
  */
 const expands = function(text) {
   let node = text.parentNode
-  while (node.nodeType === 1) {
-    const setting = node.namespaceURI === XSLT ?
+  let setting = ''
+  while (node.nodeType === 1 && !setting) {
+    setting = node.namespaceURI === XSLT ?
       node.getAttribute('expand-text') :
       node.getAttributeNS(XSLT, 'expand-text')
-    if (setting) {
-      return ON.includes(setting.trim())
-    }
     node = node.parentNode
   }
-  return false
+  return Boolean(setting) && ON.includes(setting.trim())
 }
 
 /**
@@ -98,17 +96,14 @@ const shadow = function(attribute) {
  * @return {Array.<{node: Node, start: number, expression: string}>} - Found
  */
 const carried = function(node, bare, three) {
-  if (node.nodeType !== 2) {
-    return three && expands(node) ? enclosed(node.nodeValue).map((found) => ({
+  const whole = node.nodeType === 2 &&
+    (bare.has(node) || (three && shadow(node)))
+  const braced = node.nodeType === 2 || (three && expands(node))
+  return whole ?
+    [{node: node, start: 0, expression: node.nodeValue}] :
+    braced ? enclosed(node.nodeValue).map((found) => ({
       node: node, start: found.offset, expression: found.value,
     })) : []
-  }
-  if (bare.has(node) || (three && shadow(node))) {
-    return [{node: node, start: 0, expression: node.nodeValue}]
-  }
-  return enclosed(node.nodeValue).map((found) => ({
-    node: node, start: found.offset, expression: found.value,
-  }))
 }
 
 /**

--- a/src/config.js
+++ b/src/config.js
@@ -60,14 +60,12 @@ const located = function(from) {
  * @return {*} - The value when it fits, the fallback otherwise
  */
 const typed = function(raw, key, ok, expected, fallback) {
-  if (!raw || !Object.hasOwn(raw, key)) {
-    return fallback
+  const present = Boolean(raw) && Object.hasOwn(raw, key)
+  const fits = present && ok(raw[key])
+  if (present && !fits) {
+    logger.warn(`Value of '${key}' in ${NAME} must be ${expected}, ignoring it`)
   }
-  if (ok(raw[key])) {
-    return raw[key]
-  }
-  logger.warn(`Value of '${key}' in ${NAME} must be ${expected}, ignoring it`)
-  return fallback
+  return fits ? raw[key] : fallback
 }
 
 /**

--- a/src/corpus-linter.js
+++ b/src/corpus-linter.js
@@ -38,13 +38,10 @@ const names = CHECKS.map((check) => check.name)
  */
 const within = function(declaration, attribute) {
   let node = attribute.ownerElement
-  while (node) {
-    if (node === declaration) {
-      return true
-    }
+  while (node && node !== declaration) {
     node = node.parentNode
   }
-  return false
+  return node === declaration
 }
 
 /**
@@ -101,13 +98,10 @@ const needle = function(check, declaration) {
  */
 const enclosing = function(declarations, usage) {
   let node = usage.ownerElement
-  while (node) {
-    if (declarations.has(node)) {
-      return node
-    }
+  while (node && !declarations.has(node)) {
     node = node.parentNode
   }
-  return null
+  return node
 }
 
 /**
@@ -215,16 +209,10 @@ const byReachability = function(corpus, check) {
  * @return {Array.<object>} - Defects found
  */
 const defectsOf = function(corpus, check) {
-  if (!check.reference) {
-    return byName(corpus, check)
-  }
-  if (check.reachable) {
-    return byReachability(corpus, check)
-  }
-  if (check.scoped) {
-    return byScope(corpus, check)
-  }
-  return byCall(corpus, check)
+  return !check.reference ? byName(corpus, check) :
+    check.reachable ? byReachability(corpus, check) :
+      check.scoped ? byScope(corpus, check) :
+        byCall(corpus, check)
 }
 
 /**

--- a/src/count-linter.js
+++ b/src/count-linter.js
@@ -35,23 +35,14 @@ const names = [CHECK]
  * @return {?string} - `exists`, `empty`, or null
  */
 const collapses = function(operator, zero) {
-  if (zero === '0') {
-    if (operator === '>' || operator === '!=') {
-      return 'exists'
-    }
-    if (operator === '=' || operator === '<=') {
-      return 'empty'
-    }
-  }
-  if (zero === '1') {
-    if (operator === '>=') {
-      return 'exists'
-    }
-    if (operator === '<') {
-      return 'empty'
-    }
-  }
-  return null
+  return {
+    '0>': 'exists',
+    '0!=': 'exists',
+    '0=': 'empty',
+    '0<=': 'empty',
+    '1>=': 'exists',
+    '1<': 'empty',
+  }[`${zero}${operator}`] ?? null
 }
 
 /**
@@ -82,13 +73,10 @@ const decide = function(operator, zero, argument) {
  * @return {string} - The replacement expression
  */
 const rewritten = function(test, argument, modern, whole) {
-  if (modern) {
-    return `${test}(${argument})`
-  }
-  if (test === 'exists') {
-    return whole ? argument : `boolean(${argument})`
-  }
-  return `not(${argument})`
+  return modern ? `${test}(${argument})` :
+    test === 'exists' ?
+      (whole ? argument : `boolean(${argument})`) :
+      `not(${argument})`
 }
 
 /**

--- a/src/directives.js
+++ b/src/directives.js
@@ -56,16 +56,13 @@ const directivesFrom = function(content) {
  * @return {boolean} - True when the directive covers the defect
  */
 const covers = function(directive, defect) {
-  if (directive.names.length > 0 && !directive.names.includes(defect.name)) {
-    return false
-  }
-  if (directive.type === TYPES.FILE) {
-    return true
-  }
-  if (directive.type === TYPES.NEXT_LINE) {
-    return defect.line === directive.line + 1
-  }
-  return defect.line === directive.line
+  const named = directive.names.length === 0 ||
+    directive.names.includes(defect.name)
+  const covered = directive.type === TYPES.NEXT_LINE ?
+    directive.line + 1 :
+    directive.line
+  return named &&
+    (directive.type === TYPES.FILE || defect.line === covered)
 }
 
 /**

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -33,17 +33,18 @@ const masked = function(expression) {
  */
 const closes = function(expression, open) {
   let depth = 0
-  for (let at = open; at < expression.length; at++) {
+  let shut = -1
+  for (let at = open; at < expression.length && shut < 0; at++) {
     if (expression[at] === '(') {
       depth++
     } else if (expression[at] === ')') {
       depth--
       if (depth === 0) {
-        return at
+        shut = at
       }
     }
   }
-  return -1
+  return shut
 }
 
 /**
@@ -59,17 +60,19 @@ const closes = function(expression, open) {
 const closing = function(template, from) {
   const blanked = masked(template.slice(from))
   let depth = 0
-  for (let at = 0; at < blanked.length; at++) {
+  let shut = -1
+  for (let at = 0; at < blanked.length && shut < 0; at++) {
     if (blanked[at] === '{') {
       depth++
     } else if (blanked[at] === '}') {
       if (depth === 0) {
-        return from + at
+        shut = from + at
+      } else {
+        depth--
       }
-      depth--
     }
   }
-  return -1
+  return shut
 }
 
 /**

--- a/src/fixer.js
+++ b/src/fixer.js
@@ -39,11 +39,11 @@ const NAMED = {lt: '<', gt: '>', amp: '&', quot: '"', apos: '\''}
  *  and the next raw offset
  */
 const character = function(content, at) {
-  if (content[at] !== '&') {
-    return [content[at], at + 1]
-  }
-  const end = content.indexOf(';', at)
-  return [NAMED[content.slice(at + 1, end)], end + 1]
+  const entity = content[at] === '&'
+  const end = entity ? content.indexOf(';', at) : at
+  return entity ?
+    [NAMED[content.slice(at + 1, end)], end + 1] :
+    [content[at], at + 1]
 }
 
 /**
@@ -75,17 +75,14 @@ const skip = function(content, at, count) {
  */
 const decodes = function(content, from, value) {
   let raw = from
-  for (const char of value) {
-    if (raw >= content.length) {
-      return -1
-    }
-    const [decoded, next] = character(content, raw)
-    if (decoded !== char) {
-      return -1
-    }
+  const matched = [...value].every((char) => {
+    const [decoded, next] = raw < content.length ?
+      character(content, raw) :
+      [null, raw]
     raw = next
-  }
-  return raw
+    return decoded === char
+  })
+  return matched ? raw : -1
 }
 
 /**

--- a/src/import-linter.js
+++ b/src/import-linter.js
@@ -61,19 +61,18 @@ const defect = function(check, file, node) {
 const reaches = function(adjacency, start, goal) {
   const stack = [start]
   const seen = new Set()
-  while (stack.length > 0) {
+  let reached = false
+  while (stack.length > 0 && !reached) {
     const current = stack.pop()
-    if (current === goal) {
-      return true
-    }
-    if (!seen.has(current)) {
+    reached = current === goal
+    if (!reached && !seen.has(current)) {
       seen.add(current)
       for (const edge of adjacency.get(current) || []) {
         stack.push(edge.to)
       }
     }
   }
-  return false
+  return reached
 }
 
 /**

--- a/src/name-linter.js
+++ b/src/name-linter.js
@@ -64,11 +64,10 @@ const NAME = /^[A-Za-z_][\w.-]*(:[A-Za-z_][\w.-]*)?$/
  * @return {?string} - The replacement expression, or null
  */
 const test = function(fn, operator, literal, modern) {
-  if (!NAME.test(literal) || (fn === 'local-name' && !modern)) {
-    return null
-  }
   const node = fn === 'name' ? `self::${literal}` : `self::*:${literal}`
-  return operator === '!=' ? `not(${node})` : node
+  return !NAME.test(literal) || (fn === 'local-name' && !modern) ?
+    null :
+    operator === '!=' ? `not(${node})` : node
 }
 
 /**

--- a/src/predicate-position-linter.js
+++ b/src/predicate-position-linter.js
@@ -47,13 +47,9 @@ const SIGN = {
  * @return {string} - Its one-character signature symbol
  */
 const symbol = function(token) {
-  if (token.type === TOKENS.OTHER && token.value === 'position') {
-    return 'P'
-  }
-  if (token.type === TOKENS.OTHER && token.value === 'last') {
-    return 'L'
-  }
-  return SIGN[token.type] || 'x'
+  return (token.type === TOKENS.OTHER ?
+    {position: 'P', last: 'L'}[token.value] :
+    SIGN[token.type]) || 'x'
 }
 
 /**
@@ -68,13 +64,9 @@ const symbol = function(token) {
  */
 const shortened = function(significant) {
   const sign = significant.map(symbol).join('')
-  if (sign === 'P()=N' || sign === 'N=P()') {
-    return significant.find((token) => token.type === TOKENS.NUMBER).value
-  }
-  if (sign === 'P()=L()' || sign === 'L()=P()') {
-    return 'last()'
-  }
-  return null
+  return sign === 'P()=N' || sign === 'N=P()' ?
+    significant.find((token) => token.type === TOKENS.NUMBER).value :
+    sign === 'P()=L()' || sign === 'L()=P()' ? 'last()' : null
 }
 
 /**

--- a/src/redundant-boolean-call-linter.js
+++ b/src/redundant-boolean-call-linter.js
@@ -48,20 +48,16 @@ const WRAPPER = /^\s*boolean\s*\(/
 const stripped = function(test) {
   const blanked = masked(test)
   const wrapper = WRAPPER.exec(blanked)
-  if (!wrapper) {
-    return null
-  }
-  const open = wrapper[0].length - 1
-  const close = closes(blanked, open)
-  if (close < 0 || blanked.slice(close + 1).trim() !== '') {
-    return null
-  }
-  const offset = wrapper[0].indexOf('boolean')
-  return {
-    offset: offset,
-    value: test.slice(offset, close + 1),
-    replacement: test.slice(open + 1, close).trim(),
-  }
+  const open = wrapper ? wrapper[0].length - 1 : -1
+  const close = wrapper ? closes(blanked, open) : -1
+  const offset = wrapper ? wrapper[0].indexOf('boolean') : -1
+  return close < 0 || blanked.slice(close + 1).trim() !== '' ?
+    null :
+    {
+      offset: offset,
+      value: test.slice(offset, close + 1),
+      replacement: test.slice(open + 1, close).trim(),
+    }
 }
 
 /**

--- a/src/result-namespace-linter.js
+++ b/src/result-namespace-linter.js
@@ -144,22 +144,21 @@ const textual = function(elements) {
  */
 const exclusion = function(root, prefix) {
   const attribute = root.getAttributeNode('exclude-result-prefixes')
-  if (attribute) {
-    return {
+  return attribute ?
+    {
       line: attribute.lineNumber,
       col: attribute.columnNumber - attribute.name.length - 1,
       value: `${attribute.name}="${attribute.value}"`,
       replacement: `${attribute.name}="${attribute.value} ${prefix}"`,
       suggestion: true,
+    } :
+    {
+      line: root.lineNumber,
+      col: root.columnNumber + root.nodeName.length + 1,
+      value: '',
+      replacement: ` exclude-result-prefixes="${prefix}"`,
+      suggestion: true,
     }
-  }
-  return {
-    line: root.lineNumber,
-    col: root.columnNumber + root.nodeName.length + 1,
-    value: '',
-    replacement: ` exclude-result-prefixes="${prefix}"`,
-    suggestion: true,
-  }
 }
 
 /**

--- a/src/string-length-linter.js
+++ b/src/string-length-linter.js
@@ -34,23 +34,14 @@ const names = [CHECK]
  * @return {?boolean} - Non-empty, empty, or null
  */
 const empty = function(operator, zero) {
-  if (zero === '0') {
-    if (operator === '>' || operator === '!=') {
-      return false
-    }
-    if (operator === '=' || operator === '<=') {
-      return true
-    }
-  }
-  if (zero === '1') {
-    if (operator === '>=') {
-      return false
-    }
-    if (operator === '<') {
-      return true
-    }
-  }
-  return null
+  return {
+    '0>': false,
+    '0!=': false,
+    '0=': true,
+    '0<=': true,
+    '1>=': false,
+    '1<': true,
+  }[`${zero}${operator}`] ?? null
 }
 
 /**
@@ -62,16 +53,17 @@ const empty = function(operator, zero) {
  */
 const simple = function(argument) {
   let depth = 0
+  let lone = true
   for (const char of argument) {
     if (char === '(' || char === '[') {
       depth++
     } else if (char === ')' || char === ']') {
       depth--
     } else if (depth === 0 && (char === '|' || char === ' ')) {
-      return false
+      lone = false
     }
   }
-  return true
+  return lone
 }
 
 /**
@@ -88,10 +80,7 @@ const simple = function(argument) {
  */
 const decide = function(operator, zero, argument, blanked) {
   const hollow = empty(operator, zero)
-  if (hollow === null) {
-    return null
-  }
-  return {
+  return hollow === null ? null : {
     replacement: simple(blanked) ?
       `${argument} ${hollow ? '=' : '!='} ''` : null,
   }

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -223,11 +223,10 @@ const opensAxis = function(xpath, at) {
     colons += 1
   }
   const name = `${xpath.slice(at, end)}::`
-  if (end === at || xpath[colons] !== ':' || xpath[colons + 1] !== ':' ||
-    !AXES[name] || spelling(xpath, at)) {
-    return null
-  }
-  return {name: name, length: colons + 2 - at}
+  return end === at || xpath[colons] !== ':' || xpath[colons + 1] !== ':' ||
+    !AXES[name] || spelling(xpath, at) ?
+    null :
+    {name: name, length: colons + 2 - at}
 }
 
 /**

--- a/src/translate-linter.js
+++ b/src/translate-linter.js
@@ -88,13 +88,8 @@ const args = function(expression, blanked, from, to) {
  * @return {?string} - `lower-case`, `upper-case`, or null
  */
 const folds = function(from, to) {
-  if (from === UPPER && to === LOWER) {
-    return 'lower-case'
-  }
-  if (from === LOWER && to === UPPER) {
-    return 'upper-case'
-  }
-  return null
+  return from === UPPER && to === LOWER ? 'lower-case' :
+    from === LOWER && to === UPPER ? 'upper-case' : null
 }
 
 /**

--- a/test/eslint-local-rules.test.js
+++ b/test/eslint-local-rules.test.js
@@ -104,3 +104,48 @@ tester.run(
     ],
   },
 )
+
+tester.run(
+  'no-multiple-returns',
+  local.rules['no-multiple-returns'],
+  {
+    valid: [
+      'function once() { return make() }',
+      'function never() { make() }',
+      'const brief = (one, two) => one + two',
+      'function branched() { let pick; if (one()) { pick = 1 } else { pick = 2 } return pick }',
+      'function nested() { const inner = function() { return 1 }; return inner }',
+      'function callback() { return list.map(function(item) { return item }) }',
+      'function arrows() { return list.map((item) => { return item }) }',
+      'const shorthand = {method() { return 1 }, other() { return 2 }}',
+      'class Holder { one() { return 1 } two() { return 2 } }',
+      'return 1',
+    ],
+    invalid: [
+      {
+        code: 'function twice() { if (one()) { return 1 } return 2 }',
+        errors: [{messageId: 'multiple'}],
+      },
+      {
+        code: 'function thrice() { if (one()) { return 1 } if (two()) { return 2 } return 3 }',
+        errors: [{messageId: 'multiple'}, {messageId: 'multiple'}],
+      },
+      {
+        code: 'const picked = (one) => { if (one) { return 1 } return 2 }',
+        errors: [{messageId: 'multiple'}],
+      },
+      {
+        code: 'function bare() { if (one()) { return } return 2 }',
+        errors: [{messageId: 'multiple'}],
+      },
+      {
+        code: 'function outer() { const inner = function() { if (one()) { return 1 } return 2 }; return inner }',
+        errors: [{messageId: 'multiple'}],
+      },
+      {
+        code: 'function guarded() { for (const one of many()) { if (one) { return one } } return null }',
+        errors: [{messageId: 'multiple'}],
+      },
+    ],
+  },
+)

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -89,13 +89,13 @@ const runXcop = function(arg, print = true) {
  * @return {boolean} - Result
  */
 const cmdAvailable = function(cmd, print = true) {
+  let available = true
   try {
-    const command = os.platform === 'win32' ? 'where' : 'which'
-    execCmd(command, [cmd], print)
-    return true
+    execCmd(os.platform === 'win32' ? 'where' : 'which', [cmd], print)
   } catch {
-    return false
+    available = false
   }
+  return available
 }
 
 module.exports = {


### PR DESCRIPTION
Nothing stopped a function here from carrying several exits, so 47 of them did.
`collapses` in `src/count-linter.js` had five, which meant tracing four escape
routes to learn when the fifth line is the one that fires. One exit, with the
branching deciding what it carries, reads in a single pass:

```js
const collapses = function(operator, zero) {
  return {
    '0>': 'exists',
    '0!=': 'exists',
    '0=': 'empty',
    '0<=': 'empty',
    '1>=': 'exists',
    '1<': 'empty',
  }[`${zero}${operator}`] ?? null
}
```

The rule that forbids the second exit lands with the rewrites, because a
convention nothing checks is the actual gap. `local/no-multiple-returns` keeps a
stack of the functions it has entered and reports every return after the first,
so a return counts against its nearest enclosing function — a `map` or `every`
callback with its own single return is left alone, and an arrow with an
expression body has none to count. A `no-restricted-syntax` selector cannot do
this, since it cannot tell which function a return belongs to.

The rewrites take three shapes: a lookup keyed on the deciding pair (`collapses`,
`empty`), a ternary chain (`defectsOf`, `covers`, `folds`), and a sentinel the
scan assigns before its loop ends (`closes`, `closing`, `reaches`). Nothing is
suppressed and no behavior moves — 665 tests pass, coverage holds at 100% of
statements, branches, functions and lines, and the generated docs site comes out
byte-identical to master's even though `scripts/generate-docs.js` is one of the
files rewritten.

Worth knowing before this merges: the in-flight #618 branch adds four
multi-return functions to `src/xsl-version.js`, which will need the same
treatment when the two meet.

Closes #623
