### PR TITLE
bug(#611): report a defect where it truly stands

### DIFF
--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -28,4 +28,4 @@ jobs:
           --include '**/*.xsl' --include '**/*.xml'
           --exclude 'test/resources/malformed/**'
           --exclude 'test/resources/fix/**'
-          --exclude 'test/resources/directives/wrapped.xsl'
+          --exclude 'test/resources/directives/wrapped*.xsl'

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -28,3 +28,4 @@ jobs:
           --include '**/*.xsl' --include '**/*.xml'
           --exclude 'test/resources/malformed/**'
           --exclude 'test/resources/fix/**'
+          --exclude 'test/resources/directives/wrapped.xsl'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,7 +314,9 @@ the harness asserts too.
   directory and runs [xcop](https://github.com/yegor256/xcop) over it; the CI
   `xcop` job runs it too. The `redundant-namespace-declarations` pack is listed in
   `UNFORMATTED` because its fixture must carry the unused namespace the check
-  flags, which xcop would canonicalize away.
+  flags, which xcop would canonicalize away. The repo-wide sweep in the workflow
+  excludes `test/resources/directives/wrapped.xsl` for the same reason: it must
+  keep the wrapped attribute value #611 is about, which xcop joins onto one line.
 - **Table-driven.** Where several `it` blocks differ only in data, express them as
   a data array plus one generator, not repeated blocks. When adding a test, add a
   row to the matching table (`test/fixer.test.js`, the pack harnesses,
@@ -358,7 +360,8 @@ the harness asserts too.
 | `src/xpath-linter.js` | Loads `checks/xpath/*.yaml`; attaches any `src/fixers.js` fix |
 | `src/corpus-linter.js` | Loads `checks/corpus/*.yaml`; cross-file rules |
 | `src/*-linter.js` | Code-based `checks/format/*.yaml`, one construct each (axis, namespace, count, name, ...); see the flow diagram |
-| `src/checks.js` | Shared for code-based linters: `metaOf`, `suppressed`, `defect(check, meta, file, node, offset, fix)` |
+| `src/checks.js` | Shared for code-based linters: `metaOf`, `suppressed`, `defect(check, meta, source, node, offset, fix)` — walks the raw text so a wrapped or entity-shifted value reports where it truly stands (#611) |
+| `src/source.js` | Raw-text walking shared by `checks` and `fixer`: `offsetAt`, `placeAt`, `character`, `skip` |
 | `src/attributes.js` | `expressionsOf(xsl)` — every expression a stylesheet carries: a bare/AVT attribute, a 3.0 text value template, or a shadow attribute; `selectorOf(name)` for a linter that narrows |
 | `src/xsl-version.js` | `versionOf(node)` — the version in force at a node, from the nearest ancestor's `@version` (XSLT element) or `@xsl:version` (literal result element), canonicalised as a decimal; `since(version, floor)` for a lower-bound gate; shared `MODERN`/`KNOWN`/`DECIMAL` |
 | `src/comparisons.js` | `comparedToZero` — shared scan for a call compared with `0`/`1` (count, string-length) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,7 +315,7 @@ the harness asserts too.
   `xcop` job runs it too. The `redundant-namespace-declarations` pack is listed in
   `UNFORMATTED` because its fixture must carry the unused namespace the check
   flags, which xcop would canonicalize away. The repo-wide sweep in the workflow
-  excludes `test/resources/directives/wrapped.xsl` for the same reason: it must
+  excludes `test/resources/directives/wrapped*.xsl` for the same reason: they must
   keep the wrapped attribute value #611 is about, which xcop joins onto one line.
 - **Table-driven.** Where several `it` blocks differ only in data, express them as
   a data array plus one generator, not repeated blocks. When adding a test, add a

--- a/README.md
+++ b/README.md
@@ -193,6 +193,12 @@ suppressed.
 A directive that suppresses nothing is reported as unused, so stale ones can be
 found and removed.
 
+An expression written across several lines is one value, and a directive that
+reaches any line of it silences every defect in it. Nothing inside a start tag
+can carry a comment of its own, so a directive above the element is the only
+way to reach a wrapped `@test` or `@select` at all — the cost is that it cannot
+pick out one defect in such a value and leave its neighbours reported.
+
 ## Output
 
 Defects are written to stdout; progress and diagnostic logs go to stderr, so

--- a/src/checks.js
+++ b/src/checks.js
@@ -43,9 +43,10 @@ const LEAD = {2: 1, 4: '<![CDATA['.length}
  * breaks normalised to spaces and its entities decoded, so the offset is walked
  * against the raw text from where the node opens. The fix, when given as
  * `{value, replacement, suggestion?}`, is anchored at that same place, which is
- * all the fixer needs to find it. It also carries `from`, the line the value
- * opens on, because a value that wraps can be silenced only from above the
- * element — no comment fits inside a start tag. Omit `fix` for report-only.
+ * all the fixer needs to find it. It also carries `from`, the line the element
+ * holding the value opens on, because nothing inside a start tag can be
+ * silenced from within it — no comment fits there — so a directive has to reach
+ * the whole way down from above the element. Omit `fix` for report-only.
  * @param {string} check - Check name
  * @param {{severity: string, message: string}} meta - The check metadata
  * @param {{file: string, content: string}} source - The file the node sits
@@ -76,7 +77,7 @@ const defect = function(check, meta, source, node, offset, fix = undefined) {
     message: meta.message,
     file: source.file,
     line: line,
-    from: node.lineNumber,
+    from: (node.ownerElement || node.parentNode).lineNumber,
     pos: pos,
     ...(anchored === undefined ? {} : {fix: anchored}),
   }

--- a/src/checks.js
+++ b/src/checks.js
@@ -4,6 +4,7 @@
  */
 
 const {yaml} = require('./helpers')
+const {offsetAt, placeAt, skip} = require('./source')
 const path = require('path')
 
 /**
@@ -37,36 +38,45 @@ const LEAD = {2: 1, 4: '<![CDATA['.length}
 
 /**
  * A defect at an offset inside an attribute, text, or CDATA node. Its line and
- * column are the node's own, advanced by the newlines the offset spans
- * and, on the first line, past the markup the value opens with. The fix, when
- * given as `{value, replacement, suggestion?}`, is anchored there and carries
- * the decoded `offset`, so the fixer can decode-walk from the node's raw start
- * to the match even past an entity that shifts it. Omit `fix` for report-only.
+ * column are where it truly stands in the source, which is not something the
+ * parsed value can answer on its own: an attribute value arrives with its line
+ * breaks normalised to spaces and its entities decoded, so the offset is walked
+ * against the raw text from where the node opens. The fix, when given as
+ * `{value, replacement, suggestion?}`, is anchored at that same place, which is
+ * all the fixer needs to find it. It also carries `from`, the line the value
+ * opens on, because a value that wraps can be silenced only from above the
+ * element — no comment fits inside a start tag. Omit `fix` for report-only.
  * @param {string} check - Check name
  * @param {{severity: string, message: string}} meta - The check metadata
- * @param {string} file - File the node sits in
+ * @param {{file: string, content: string}} source - The file the node sits
+ *  in, with its raw text, which is the only place the line breaks a parser
+ *  normalised away are still visible
  * @param {Node} node - The attribute, text, or CDATA node
  * @param {number} offset - Offset of the defect within the node value
  * @param {?{value: string, replacement: string, suggestion?: boolean}} [fix] -
  *  The fix, or undefined for a report-only defect
  * @return {object} - Defect
  */
-const defect = function(check, meta, file, node, offset, fix = undefined) {
-  const before = node.nodeValue.slice(0, offset)
-  const newline = before.lastIndexOf('\n')
-  const line = node.lineNumber + before.split('\n').length - 1
-  const pos = newline < 0 ?
-    node.columnNumber + (LEAD[node.nodeType] || 0) + offset :
-    offset - newline
+const defect = function(check, meta, source, node, offset, fix = undefined) {
+  const {line, pos} = placeAt(
+    source.content,
+    skip(
+      source.content,
+      offsetAt(source.content, node.lineNumber, node.columnNumber) +
+        (LEAD[node.nodeType] || 0),
+      offset,
+    ),
+  )
   const anchored = fix === undefined ?
     undefined :
-    {line: line, col: pos, offset: offset, ...fix}
+    {line: line, col: pos, ...fix}
   return {
     name: check,
     severity: meta.severity,
     message: meta.message,
-    file: file,
+    file: source.file,
     line: line,
+    from: node.lineNumber,
     pos: pos,
     ...(anchored === undefined ? {} : {fix: anchored}),
   }

--- a/src/count-linter.js
+++ b/src/count-linter.js
@@ -105,14 +105,14 @@ const lintByCount = function(corpus, suppressions = []) {
   logger.debug(`Count-comparison linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const {file, xsl} of corpus) {
-      for (const {node, start, expression} of expressionsOf(xsl)) {
+    for (const source of corpus) {
+      for (const {node, start, expression} of expressionsOf(source.xsl)) {
         const modern = since(versionOf(node), MODERN)
         for (const {offset, value, test, argument} of comparisons(expression)) {
           const whole = node.nodeName === 'test' &&
             node.nodeValue.trim() === value
           defects.push(
-            defect(CHECK, META, file, node, start + offset, {
+            defect(CHECK, META, source, node, start + offset, {
               value: value,
               replacement: rewritten(test, argument, modern, whole),
             }),

--- a/src/directives.js
+++ b/src/directives.js
@@ -50,9 +50,10 @@ const directivesFrom = function(content) {
 /**
  * Whether a single directive covers given defect. A directive with no names
  * covers every rule; otherwise only the ones it names. A defect standing in an
- * attribute value that wraps is reported on the line it truly occupies, which
- * no comment can sit above — a start tag admits none — so the directive reaches
- * anywhere from the line the value opens on, `from`, down to the defect itself.
+ * value that wraps is reported on the line it truly occupies, which no comment
+ * can sit above — a start tag admits none, and the tag itself may wrap before
+ * the value does — so the directive reaches anywhere from the line the holding
+ * element opens on, `from`, down to the defect itself.
  * @param {{type: string, line: number, names: Array.<string>}} directive -
  *  Directive to test
  * @param {{name: string, line: number, from: number}} defect - Defect to test

--- a/src/directives.js
+++ b/src/directives.js
@@ -49,10 +49,13 @@ const directivesFrom = function(content) {
 
 /**
  * Whether a single directive covers given defect. A directive with no names
- * covers every rule; otherwise only the ones it names.
+ * covers every rule; otherwise only the ones it names. A defect standing in an
+ * attribute value that wraps is reported on the line it truly occupies, which
+ * no comment can sit above — a start tag admits none — so the directive reaches
+ * anywhere from the line the value opens on, `from`, down to the defect itself.
  * @param {{type: string, line: number, names: Array.<string>}} directive -
  *  Directive to test
- * @param {{name: string, line: number}} defect - Defect to test
+ * @param {{name: string, line: number, from: number}} defect - Defect to test
  * @return {boolean} - True when the directive covers the defect
  */
 const covers = function(directive, defect) {
@@ -61,8 +64,8 @@ const covers = function(directive, defect) {
   const covered = directive.type === TYPES.NEXT_LINE ?
     directive.line + 1 :
     directive.line
-  return named &&
-    (directive.type === TYPES.FILE || defect.line === covered)
+  return named && (directive.type === TYPES.FILE ||
+    (covered >= (defect.from || defect.line) && covered <= defect.line))
 }
 
 /**

--- a/src/fixer.js
+++ b/src/fixer.js
@@ -64,10 +64,10 @@ const disjoint = function(edits) {
 /**
  * Apply the fixes carried by defects to their sources, returning the rewritten
  * content of each changed file and the defects whose fix was applied. Each fix
- * names a source position, a decoded `value`, and its replacement. The fixer
- * decode-walks the raw source from the node's raw start (`col - offset`) by the
- * fix's decoded `offset`, so it lands on the match even when an entity ahead of
- * it shifts the column, then matches `value` decoding as it goes — a `>`
+ * names a source position, a decoded `value`, and its replacement. The position
+ * is already the true one, worked out against the raw text by `src/checks.js`,
+ * so the fixer goes straight there and matches `value` decoding as it goes —
+ * a `>`
  * written `&gt;` matches alike. A fix whose source no longer decodes to `value`
  * (an already-edited file) is skipped rather than corrupting, and so is one
  * overlapping a fix already accepted in the same run — the spans are proved
@@ -75,8 +75,8 @@ const disjoint = function(edits) {
  * since moved. Fixes for one file are applied from the end backwards so earlier
  * offsets stay valid.
  * @param {Array.<{file: string, content: string}>} sources - Original sources
- * @param {Array.<{file: string, fix: {line: number, col: number, offset:
- *  number, value: string, replacement: string, suggestion: boolean}}>}
+ * @param {Array.<{file: string, fix: {line: number, col: number,
+ *  value: string, replacement: string, suggestion: boolean}}>}
  *  defects - Defects; only those carrying a `fix` are fixed (`offset`
  *  defaults to 0)
  * @param {boolean} suggestions - Whether to also apply the fixes marked as

--- a/src/fixer.js
+++ b/src/fixer.js
@@ -3,65 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+const {character, offsetAt} = require('./source')
 const {logger} = require('./logger')
-
-/**
- * Absolute offset in a text of a one-based line and column.
- * @param {string} text - Source text
- * @param {number} line - One-based line number
- * @param {number} col - One-based column number
- * @return {number} - Zero-based offset into the text
- */
-const offsetAt = function(text, line, col) {
-  const lines = text.split('\n')
-  let offset = col - 1
-  for (let ln = 0; ln < line - 1; ln++) {
-    offset += lines[ln].length + 1
-  }
-  return offset
-}
-
-/**
- * The named XML entities the source may spell a character with.
- * @type {{[name: string]: string}}
- */
-const NAMED = {lt: '<', gt: '>', amp: '&', quot: '"', apos: '\''}
-
-/**
- * The decoded character at a raw offset and the offset just past it, reading a
- * named XML entity (`&lt;`, `&gt;`, `&amp;`, …) as the single character it
- * stands for. Anything else an `&` opens (a numeric or unknown entity) yields
- * `undefined`, so a match over it fails and the fix is safely skipped rather
- * than decoded wrongly.
- * @param {string} content - Raw source text
- * @param {number} at - Zero-based offset to read from
- * @return {[(string|undefined), number]} - The decoded character (or undefined)
- *  and the next raw offset
- */
-const character = function(content, at) {
-  const entity = content[at] === '&'
-  const end = entity ? content.indexOf(';', at) : at
-  return entity ?
-    [NAMED[content.slice(at + 1, end)], end + 1] :
-    [content[at], at + 1]
-}
-
-/**
- * The raw offset reached by decoding `count` characters forward from `at`, so a
- * decoded offset into an attribute value maps to its true raw position even
- * when an entity ahead of it spans several source characters.
- * @param {string} content - Raw source text
- * @param {number} at - Zero-based offset to start from
- * @param {number} count - Number of decoded characters to skip
- * @return {number} - The raw offset after `count` decoded characters
- */
-const skip = function(content, at, count) {
-  let raw = at
-  for (let seen = 0; seen < count; seen++) {
-    raw = character(content, raw)[1]
-  }
-  return raw
-}
 
 /**
  * The raw offset just past the source that decodes to `value` starting at
@@ -152,11 +95,7 @@ const fixed = function(sources, defects, suggestions = false) {
       fixable
         .filter((defect) => defect.file === file)
         .map((defect) => {
-          const offset = defect.fix.offset || 0
-          const base = offsetAt(
-            content, defect.fix.line, defect.fix.col - offset,
-          )
-          const start = skip(content, base, offset)
+          const start = offsetAt(content, defect.fix.line, defect.fix.col)
           return {
             defect: defect,
             start: start,

--- a/src/name-linter.js
+++ b/src/name-linter.js
@@ -132,15 +132,14 @@ const lintByName = function(corpus, suppressions = []) {
   logger.debug(`Name-comparison linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const {file, xsl} of corpus) {
-      for (const {node, start, expression} of expressionsOf(xsl)) {
+    for (const source of corpus) {
+      for (const {node, start, expression} of expressionsOf(source.xsl)) {
         const modern = since(versionOf(node), MODERN)
         for (const {offset, value, replacement} of comparisons(
           expression, modern,
         )) {
           defects.push(
-            defect(
-              CHECK, META, file, node, start + offset,
+            defect(CHECK, META, source, node, start + offset,
               replacement === null ?
                 undefined : {value, replacement, suggestion: true},
             ),

--- a/src/node-set-linter.js
+++ b/src/node-set-linter.js
@@ -75,15 +75,15 @@ const lintByNodeSet = function(corpus, suppressions = []) {
   logger.debug(`Node-set linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const {file, xsl} of corpus) {
-      for (const attribute of nodes(xsl, selectorOf('select'))) {
+    for (const source of corpus) {
+      for (const attribute of nodes(source.xsl, selectorOf('select'))) {
         if (since(versionOf(attribute), MODERN)) {
           for (const {offset, value, replacement} of wrappers(
             attribute.nodeValue,
           )) {
             defects.push(
               defect(
-                CHECK, META, file, attribute, offset, {value, replacement},
+                CHECK, META, source, attribute, offset, {value, replacement},
               ),
             )
           }

--- a/src/predicate-position-linter.js
+++ b/src/predicate-position-linter.js
@@ -122,12 +122,12 @@ const lintByPredicatePosition = function(corpus, suppressions = []) {
   logger.debug(`Predicate-position linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const {file, xsl} of corpus) {
-      for (const {node, start, expression} of expressionsOf(xsl)) {
+    for (const source of corpus) {
+      for (const {node, start, expression} of expressionsOf(source.xsl)) {
         for (const {offset, value, replacement} of literals(expression)) {
           defects.push(
             defect(
-              CHECK, META, file, node, start + offset, {value, replacement},
+              CHECK, META, source, node, start + offset, {value, replacement},
             ),
           )
         }

--- a/src/redundant-boolean-call-linter.js
+++ b/src/redundant-boolean-call-linter.js
@@ -76,12 +76,12 @@ const lintByBooleanCall = function(corpus, suppressions = []) {
   logger.debug(`Boolean-call linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const {file, xsl} of corpus) {
-      for (const attribute of nodes(xsl, selectorOf('test'))) {
+    for (const source of corpus) {
+      for (const attribute of nodes(source.xsl, selectorOf('test'))) {
         const strip = stripped(attribute.nodeValue)
         if (strip) {
           defects.push(
-            defect(CHECK, META, file, attribute, strip.offset, {
+            defect(CHECK, META, source, attribute, strip.offset, {
               value: strip.value,
               replacement: strip.replacement,
             }),

--- a/src/redundant-double-negation-linter.js
+++ b/src/redundant-double-negation-linter.js
@@ -91,13 +91,13 @@ const lintByDoubleNegation = function(corpus, suppressions = []) {
   logger.debug(`Double-negation linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const {file, xsl} of corpus) {
-      for (const {node, start, expression} of expressionsOf(xsl)) {
+    for (const source of corpus) {
+      for (const {node, start, expression} of expressionsOf(source.xsl)) {
         for (const {offset, value, argument} of negations(expression)) {
           const bare = node.nodeName === 'test' &&
             node.nodeValue.trim() === value
           defects.push(
-            defect(CHECK, META, file, node, start + offset, {
+            defect(CHECK, META, source, node, start + offset, {
               value: value,
               replacement: bare ? argument : `boolean(${argument})`,
             }),

--- a/src/source.js
+++ b/src/source.js
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * The named XML entities the source may spell a character with.
+ * @type {{[name: string]: string}}
+ */
+const NAMED = {lt: '<', gt: '>', amp: '&', quot: '"', apos: '\''}
+
+/**
+ * Absolute offset in a text of a one-based line and column.
+ * @param {string} text - Source text
+ * @param {number} line - One-based line number
+ * @param {number} col - One-based column number
+ * @return {number} - Zero-based offset into the text
+ */
+const offsetAt = function(text, line, col) {
+  const lines = text.split('\n')
+  let offset = col - 1
+  for (let ln = 0; ln < line - 1; ln++) {
+    offset += lines[ln].length + 1
+  }
+  return offset
+}
+
+/**
+ * The one-based line and column of an absolute offset, which is the reverse of
+ * {@link offsetAt} and the shape a defect is reported in.
+ * @param {string} text - Source text
+ * @param {number} at - Zero-based offset into the text
+ * @return {{line: number, pos: number}} - Where that offset stands
+ */
+const placeAt = function(text, at) {
+  const before = text.slice(0, at)
+  const newline = before.lastIndexOf('\n')
+  return {
+    line: before.split('\n').length,
+    pos: at - newline,
+  }
+}
+
+/**
+ * The decoded character at a raw offset and the offset just past it, reading a
+ * named XML entity (`&lt;`, `&gt;`, `&amp;`, …) as the single character it
+ * stands for. Anything else an `&` opens (a numeric or unknown entity) yields
+ * `undefined`, so a match over it fails and the caller can back off rather than
+ * decode it wrongly.
+ * @param {string} content - Raw source text
+ * @param {number} at - Zero-based offset to read from
+ * @return {[(string|undefined), number]} - The decoded character (or undefined)
+ *  and the next raw offset
+ */
+const character = function(content, at) {
+  const entity = content[at] === '&'
+  const end = entity ? content.indexOf(';', at) : at
+  return entity ?
+    [NAMED[content.slice(at + 1, end)], end + 1] :
+    [content[at], at + 1]
+}
+
+/**
+ * The raw offset reached after skipping the given number of decoded characters,
+ * so an offset into a parsed value maps back to its true place in the source
+ * even when an entity ahead of it spans several source characters.
+ * @param {string} content - Raw source text
+ * @param {number} at - Zero-based offset to start from
+ * @param {number} count - Number of decoded characters to skip
+ * @return {number} - The raw offset after `count` decoded characters
+ */
+const skip = function(content, at, count) {
+  let raw = at
+  for (let seen = 0; seen < count; seen++) {
+    raw = character(content, raw)[1]
+  }
+  return raw
+}
+
+module.exports = {
+  NAMED,
+  offsetAt,
+  placeAt,
+  character,
+  skip,
+}

--- a/src/source.js
+++ b/src/source.js
@@ -18,12 +18,15 @@ const NAMED = {lt: '<', gt: '>', amp: '&', quot: '"', apos: '\''}
 const ENDINGS = /\r\n|\r|\n/g
 
 /**
- * Where every line of a text begins, by zero-based line index. A source is
- * walked once per defect and read many times over, so the split is remembered
- * against the text itself rather than repeated.
- * @type {Map}
+ * The text indexed most recently and where its lines begin. Positions are asked
+ * for one source at a time — every defect in a file, then every fix in it — so
+ * remembering the last one spares the rescan without keeping any earlier source
+ * alive. A table of every text ever seen would do that, and `lint` is exported
+ * for an embedder to call on a buffer per keystroke (#336), where each version
+ * of each open file would then be held for the life of the process.
+ * @type {{text: ?string, offsets: Array.<number>}}
  */
-const LINES = new Map()
+const LAST = {text: null, offsets: []}
 
 /**
  * The offset each line of the given text starts at, computed once per text.
@@ -31,12 +34,13 @@ const LINES = new Map()
  * @return {Array.<number>} - Zero-based offset of every line's first character
  */
 const starts = function(text) {
-  if (!LINES.has(text)) {
-    LINES.set(text, [0].concat(
+  if (LAST.text !== text) {
+    LAST.text = text
+    LAST.offsets = [0].concat(
       [...text.matchAll(ENDINGS)].map((end) => end.index + end[0].length),
-    ))
+    )
   }
-  return LINES.get(text)
+  return LAST.offsets
 }
 
 /**

--- a/src/source.js
+++ b/src/source.js
@@ -10,10 +10,18 @@
 const NAMED = {lt: '<', gt: '>', amp: '&', quot: '"', apos: '\''}
 
 /**
+ * The three spellings of a line ending XML 1.0 §2.11 recognises, which a parser
+ * counts alike when it numbers lines — so a walk that honours only `\n` would
+ * disagree with the line a node reports itself on.
+ * @type {RegExp}
+ */
+const ENDINGS = /\r\n|\r|\n/g
+
+/**
  * Where every line of a text begins, by zero-based line index. A source is
  * walked once per defect and read many times over, so the split is remembered
  * against the text itself rather than repeated.
- * @type {WeakMap|Map}
+ * @type {Map}
  */
 const LINES = new Map()
 
@@ -24,11 +32,9 @@ const LINES = new Map()
  */
 const starts = function(text) {
   if (!LINES.has(text)) {
-    const offsets = [0]
-    for (let at = text.indexOf('\n'); at >= 0; at = text.indexOf('\n', at + 1)) {
-      offsets.push(at + 1)
-    }
-    LINES.set(text, offsets)
+    LINES.set(text, [0].concat(
+      [...text.matchAll(ENDINGS)].map((end) => end.index + end[0].length),
+    ))
   }
   return LINES.get(text)
 }

--- a/src/source.js
+++ b/src/source.js
@@ -10,6 +10,30 @@
 const NAMED = {lt: '<', gt: '>', amp: '&', quot: '"', apos: '\''}
 
 /**
+ * Where every line of a text begins, by zero-based line index. A source is
+ * walked once per defect and read many times over, so the split is remembered
+ * against the text itself rather than repeated.
+ * @type {WeakMap|Map}
+ */
+const LINES = new Map()
+
+/**
+ * The offset each line of the given text starts at, computed once per text.
+ * @param {string} text - Source text
+ * @return {Array.<number>} - Zero-based offset of every line's first character
+ */
+const starts = function(text) {
+  if (!LINES.has(text)) {
+    const offsets = [0]
+    for (let at = text.indexOf('\n'); at >= 0; at = text.indexOf('\n', at + 1)) {
+      offsets.push(at + 1)
+    }
+    LINES.set(text, offsets)
+  }
+  return LINES.get(text)
+}
+
+/**
  * Absolute offset in a text of a one-based line and column.
  * @param {string} text - Source text
  * @param {number} line - One-based line number
@@ -17,12 +41,7 @@ const NAMED = {lt: '<', gt: '>', amp: '&', quot: '"', apos: '\''}
  * @return {number} - Zero-based offset into the text
  */
 const offsetAt = function(text, line, col) {
-  const lines = text.split('\n')
-  let offset = col - 1
-  for (let ln = 0; ln < line - 1; ln++) {
-    offset += lines[ln].length + 1
-  }
-  return offset
+  return starts(text)[line - 1] + col - 1
 }
 
 /**
@@ -33,31 +52,37 @@ const offsetAt = function(text, line, col) {
  * @return {{line: number, pos: number}} - Where that offset stands
  */
 const placeAt = function(text, at) {
-  const before = text.slice(0, at)
-  const newline = before.lastIndexOf('\n')
-  return {
-    line: before.split('\n').length,
-    pos: at - newline,
+  const lines = starts(text)
+  let line = 0
+  while (line + 1 < lines.length && lines[line + 1] <= at) {
+    line += 1
   }
+  return {line: line + 1, pos: at - lines[line] + 1}
 }
 
 /**
- * The decoded character at a raw offset and the offset just past it, reading a
- * named XML entity (`&lt;`, `&gt;`, `&amp;`, …) as the single character it
- * stands for. Anything else an `&` opens (a numeric or unknown entity) yields
- * `undefined`, so a match over it fails and the caller can back off rather than
- * decode it wrongly.
+ * The decoded character at a raw offset and the offset just past it. A named
+ * XML entity (`&lt;`, `&gt;`, `&amp;`, …) reads as the single character it
+ * stands for, and a line ending reads as the `\n` a parser turns it into before
+ * parsing begins — XML 1.0 §2.11 normalises `\r\n` and a lone `\r` alike — so a
+ * CRLF source is one character two offsets wide and a walk over it keeps count.
+ * Anything else an `&` opens, a numeric or unknown entity or one no `;` ever
+ * closes, yields `undefined`, so a match over it fails and the caller backs off
+ * rather than decoding it wrongly.
  * @param {string} content - Raw source text
  * @param {number} at - Zero-based offset to read from
  * @return {[(string|undefined), number]} - The decoded character (or undefined)
  *  and the next raw offset
  */
 const character = function(content, at) {
-  const entity = content[at] === '&'
-  const end = entity ? content.indexOf(';', at) : at
-  return entity ?
-    [NAMED[content.slice(at + 1, end)], end + 1] :
+  const closing = content[at] === '&' ? content.indexOf(';', at) : -1
+  const entity = closing < 0 ?
+    [undefined, at + 1] :
+    [NAMED[content.slice(at + 1, closing)], closing + 1]
+  const ending = content[at] === '\r' ?
+    ['\n', content[at + 1] === '\n' ? at + 2 : at + 1] :
     [content[at], at + 1]
+  return content[at] === '&' ? entity : ending
 }
 
 /**

--- a/src/string-length-linter.js
+++ b/src/string-length-linter.js
@@ -114,12 +114,11 @@ const lintByStringLength = function(corpus, suppressions = []) {
   logger.debug(`String-length-comparison linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const {file, xsl} of corpus) {
-      for (const {node, start, expression} of expressionsOf(xsl)) {
+    for (const source of corpus) {
+      for (const {node, start, expression} of expressionsOf(source.xsl)) {
         for (const {offset, value, replacement} of comparisons(expression)) {
           defects.push(
-            defect(
-              CHECK, META, file, node, start + offset,
+            defect(CHECK, META, source, node, start + offset,
               replacement === null ?
                 undefined : {value, replacement, suggestion: true},
             ),

--- a/src/translate-linter.js
+++ b/src/translate-linter.js
@@ -140,13 +140,12 @@ const lintByTranslate = function(corpus, suppressions = []) {
   logger.debug(`Translate-case linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const {file, xsl} of corpus) {
-      for (const {node, start, expression} of expressionsOf(xsl)) {
+    for (const source of corpus) {
+      for (const {node, start, expression} of expressionsOf(source.xsl)) {
         if (since(versionOf(node), MODERN)) {
           for (const {offset, value, replacement} of folded(expression)) {
             defects.push(
-              defect(
-                CHECK, META, file, node, start + offset,
+              defect(CHECK, META, source, node, start + offset,
                 {value, replacement, suggestion: true},
               ),
             )

--- a/src/using-namespace-axis-linter.js
+++ b/src/using-namespace-axis-linter.js
@@ -54,11 +54,11 @@ const lintByNamespaceAxis = function(corpus, suppressions = []) {
   logger.debug(`Namespace axis linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const {file, xsl} of corpus) {
-      for (const {node, start, expression} of expressionsOf(xsl)) {
+    for (const source of corpus) {
+      for (const {node, start, expression} of expressionsOf(source.xsl)) {
         if (since(versionOf(node), MODERN)) {
           for (const offset of axes(expression)) {
-            defects.push(defect(CHECK, META, file, node, start + offset))
+            defects.push(defect(CHECK, META, source, node, start + offset))
           }
         }
       }

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -132,11 +132,11 @@ const lintByAxis = function(corpus, suppressions = []) {
   logger.debug(`Axis linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const {file, xsl} of corpus) {
-      for (const {node, start, expression} of expressionsOf(xsl)) {
+    for (const source of corpus) {
+      for (const {node, start, expression} of expressionsOf(source.xsl)) {
         const modern = since(versionOf(node), MODERN)
         for (const {offset, fix} of abbreviable(expression, modern)) {
-          defects.push(defect(CHECK, META, file, node, start + offset, fix))
+          defects.push(defect(CHECK, META, source, node, start + offset, fix))
         }
       }
     }

--- a/src/xpath-format-linter.js
+++ b/src/xpath-format-linter.js
@@ -70,12 +70,12 @@ const lintByFormat = function(expressions, suppressions = []) {
   logger.debug(`Format linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const {file, expression} of expressions) {
+    for (const {source, expression} of expressions) {
       for (const {offset, value, replacement} of redundancies(
         expression.nodeValue,
       )) {
         defects.push(
-          defect(CHECK, META, file, expression, offset, {value, replacement}),
+          defect(CHECK, META, source, expression, offset, {value, replacement}),
         )
       }
     }

--- a/src/xpath-validator.js
+++ b/src/xpath-validator.js
@@ -55,9 +55,10 @@ const UNRESOLVED = /&[A-Za-z_][\w.-]*;/
  * for the linters to consume from the malformed ones, which become defects.
  * An expression that cannot be parsed by the engine that would run it is
  * reported and dropped, so no linter ever reasons over broken input.
- * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
+ * @param {Array.<{file: string, content: string, xsl: Document}>} corpus -
+ *  Parsed stylesheets
  * @param {Array.<string>} suppressions - Array of suppressed checks
- * @return {{expressions: Array.<{file: string, expression: Node}>, defects:
+ * @return {{expressions: Array.<{source: object, expression: Node}>, defects:
  *  {name: string, severity: string, message: string, file: string,
  *  line: number, pos: number}[]}} - Valid expressions and defects found
  */
@@ -66,10 +67,10 @@ const validate = function(corpus, suppressions = []) {
   const expressions = []
   const defects = []
   const suppressed = suppressions.some((sup) => CHECK.includes(sup))
-  for (const {file, xsl} of corpus) {
-    for (const expression of nodes(xsl, EXPRESSIONS)) {
+  for (const source of corpus) {
+    for (const expression of nodes(source.xsl, EXPRESSIONS)) {
       if (isValid(expression.nodeValue)) {
-        expressions.push({file: file, expression: expression})
+        expressions.push({source: source, expression: expression})
       } else if (UNRESOLVED.test(expression.nodeValue)) {
         logger.debug(`Skipping expression with an unresolved entity`)
       } else if (!suppressed) {
@@ -77,7 +78,7 @@ const validate = function(corpus, suppressions = []) {
           name: CHECK,
           severity: META.severity,
           message: META.message,
-          file: file,
+          file: source.file,
           line: expression.lineNumber,
           pos: expression.columnNumber,
         })

--- a/src/xsl-validator.js
+++ b/src/xsl-validator.js
@@ -34,7 +34,8 @@ const names = [CHECK]
  * over the stylesheets that parse.
  * @param {Array.<{file: string, content: string}>} sources - Raw stylesheets
  * @param {Array.<string>} suppressions - Array of suppressed checks
- * @return {{corpus: Array.<{file: string, xsl: Document}>, defects:
+ * @return {{corpus: Array.<{file: string, content: string, xsl: Document}>,
+ *  defects:
  *  Array.<object>}} - Parsed corpus and defects for the unparsable sources
  */
 const validate = function(sources, suppressions = []) {
@@ -44,7 +45,9 @@ const validate = function(sources, suppressions = []) {
   const suppressed = suppressions.some((sup) => CHECK.includes(sup))
   for (const {file, content} of sources) {
     try {
-      corpus.push({file: file, xsl: xml.parsedFromString(content)})
+      corpus.push({
+        file: file, content: content, xsl: xml.parsedFromString(content),
+      })
     } catch {
       if (!suppressed) {
         defects.push({

--- a/test/count-linter.test.js
+++ b/test/count-linter.test.js
@@ -22,7 +22,7 @@ describe('count-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} count comparisons`, function() {
-        const defects = lintByCount([{file: 'test.xsl', xsl: input}])
+        const defects = lintByCount([{file: 'test.xsl', content: yml.input, xsl: input}])
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/fixer.test.js
+++ b/test/fixer.test.js
@@ -566,6 +566,18 @@ describe('fixer', function() {
     runXslint(['--fix', file])
     assert.ok(fs.readFileSync(file, 'utf-8').includes('parent::n'))
   })
+  it('should abbreviate an axis in a wrapped value of a CRLF file', function() {
+    const file = scratch(
+      fixture('unabbreviated-axis-in-a-wrapped-value.xsl')
+        .replace(/\n/g, '\r\n'),
+    )
+    runXslint(['--fix', file])
+    assert.equal(
+      fs.readFileSync(file, 'utf-8'),
+      fixture('unabbreviated-axis-in-a-wrapped-value.fixed.xsl')
+        .replace(/\n/g, '\r\n'),
+    )
+  })
   it('should announce how many defects --fix would fix', function() {
     const file = scratch(fixture('redundant-whitespace.xsl'))
     assert.ok(xslintStreams([file]).stderr.includes('fixable with --fix'))

--- a/test/fixer.test.js
+++ b/test/fixer.test.js
@@ -95,6 +95,12 @@ const APPLIED = [
     after: 'unabbreviated-axis.fixed.xsl',
   },
   {
+    name: 'should abbreviate an axis in a wrapped value with --fix',
+    flag: '--fix',
+    before: 'unabbreviated-axis-in-a-wrapped-value.xsl',
+    after: 'unabbreviated-axis-in-a-wrapped-value.fixed.xsl',
+  },
+  {
     name: 'should delete a redundant namespace declaration with --fix',
     flag: '--fix',
     before: 'redundant-namespace-declarations.xsl',

--- a/test/name-linter.test.js
+++ b/test/name-linter.test.js
@@ -22,7 +22,7 @@ describe('name-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} name comparisons`, function() {
-        const defects = lintByName([{file: 'test.xsl', xsl: input}])
+        const defects = lintByName([{file: 'test.xsl', content: yml.input, xsl: input}])
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/namespace-linter.test.js
+++ b/test/namespace-linter.test.js
@@ -22,7 +22,7 @@ describe('namespace-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} redundant declarations`, function() {
-        const defects = lintByNamespace([{file: 'test.xsl', xsl: input}])
+        const defects = lintByNamespace([{file: 'test.xsl', content: yml.input, xsl: input}])
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/node-set-linter.test.js
+++ b/test/node-set-linter.test.js
@@ -22,7 +22,7 @@ describe('node-set-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} node-set extensions`, function() {
-        const defects = lintByNodeSet([{file: 'test.xsl', xsl: input}])
+        const defects = lintByNodeSet([{file: 'test.xsl', content: yml.input, xsl: input}])
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/predicate-position-linter.test.js
+++ b/test/predicate-position-linter.test.js
@@ -22,7 +22,7 @@ describe('predicate-position-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} positional predicates`, function() {
-        const defects = lintByPredicatePosition([{file: 'test.xsl', xsl: input}])
+        const defects = lintByPredicatePosition([{file: 'test.xsl', content: yml.input, xsl: input}])
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/redundant-boolean-call-linter.test.js
+++ b/test/redundant-boolean-call-linter.test.js
@@ -22,7 +22,7 @@ describe('redundant-boolean-call-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} redundant boolean calls`, function() {
-        const defects = lintByBooleanCall([{file: 'test.xsl', xsl: input}])
+        const defects = lintByBooleanCall([{file: 'test.xsl', content: yml.input, xsl: input}])
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/redundant-double-negation-linter.test.js
+++ b/test/redundant-double-negation-linter.test.js
@@ -22,7 +22,7 @@ describe('redundant-double-negation-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} double negations`, function() {
-        const defects = lintByDoubleNegation([{file: 'test.xsl', xsl: input}])
+        const defects = lintByDoubleNegation([{file: 'test.xsl', content: yml.input, xsl: input}])
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/resources/count-packs/count-in-attribute-value-template.yaml
+++ b/test/resources/count-packs/count-in-attribute-value-template.yaml
@@ -4,7 +4,7 @@
 pack: count-compared-to-zero
 found:
   amount: 4
-  positions: [ [ 4, 44 ], [ 5, 20 ], [ 5, 35 ], [ 6, 25 ] ]
+  positions: [ [ 4, 44 ], [ 5, 20 ], [ 5, 38 ], [ 6, 25 ] ]
   fixes: [ "empty(item)", "exists(a)", "empty(b)", "exists(c)" ]
 input: |-
   <?xml version="1.0"?>

--- a/test/resources/count-packs/count-in-complex-expressions.yaml
+++ b/test/resources/count-packs/count-in-complex-expressions.yaml
@@ -4,7 +4,7 @@
 pack: count-compared-to-zero
 found:
   amount: 3
-  positions: [ [ 4, 29 ], [ 4, 48 ], [ 5, 33 ] ]
+  positions: [ [ 4, 29 ], [ 4, 51 ], [ 5, 33 ] ]
   fixes: [ "exists(item)", "empty(@x)", "empty(a/b[@c])" ]
 input: |-
   <?xml version="1.0"?>

--- a/test/resources/directives/wrapped-tag.xsl
+++ b/test/resources/directives/wrapped-tag.xsl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+  <xsl:output method="xml"/>
+  <xsl:template match="/">
+    <!-- xslint-disable-next-line using-namespace-axis -->
+    <xsl:if
+        test="@a
+              and namespace::*">
+      <xsl:value-of select="."/>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/directives/wrapped.xsl
+++ b/test/resources/directives/wrapped.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+  <xsl:output method="xml"/>
+  <xsl:template match="/">
+    <!-- xslint-disable-next-line using-namespace-axis -->
+    <xsl:if test="@a
+                  and namespace::*">
+      <xsl:value-of select="."/>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/unabbreviated-axis-in-a-wrapped-value.fixed.xsl
+++ b/test/resources/fix/unabbreviated-axis-in-a-wrapped-value.fixed.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:template match="R">
+    <xsl:value-of select="@a
+                          or deep"/>
+    <xsl:value-of select="@b &gt; 1 and later"/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/unabbreviated-axis-in-a-wrapped-value.xsl
+++ b/test/resources/fix/unabbreviated-axis-in-a-wrapped-value.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:template match="R">
+    <xsl:value-of select="@a
+                          or child::deep"/>
+    <xsl:value-of select="@b &gt; 1 and child::later"/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/string-length-packs/string-length-in-complex-expressions.yaml
+++ b/test/resources/string-length-packs/string-length-in-complex-expressions.yaml
@@ -4,7 +4,7 @@
 pack: string-length-compared-to-zero
 found:
   amount: 3
-  positions: [ [ 4, 29 ], [ 4, 54 ], [ 5, 29 ] ]
+  positions: [ [ 4, 29 ], [ 4, 57 ], [ 5, 29 ] ]
   fixes: [ "@a != ''", null, "x[@y] = ''" ]
 input: |-
   <?xml version="1.0"?>

--- a/test/resources/using-namespace-axis-packs/namespace-axis-in-a-wrapped-value.yaml
+++ b/test/resources/using-namespace-axis-packs/namespace-axis-in-a-wrapped-value.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: using-namespace-axis
+found:
+  amount: 2
+  positions: [ [ 5, 23 ], [ 7, 22 ] ]
+  fixes: [ null, null ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="/">
+      <xsl:if test="@a
+                    and namespace::*">
+        <widget note="{@b}
+                      {namespace::x}"/>
+      </xsl:if>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/result-namespace-linter.test.js
+++ b/test/result-namespace-linter.test.js
@@ -22,7 +22,7 @@ describe('result-namespace-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} leaking result namespaces`, function() {
-        const defects = lintByResultNamespace([{file: 'test.xsl', xsl: input}])
+        const defects = lintByResultNamespace([{file: 'test.xsl', content: yml.input, xsl: input}])
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/source.test.js
+++ b/test/source.test.js
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+const {character, offsetAt, placeAt, skip} = require('../src/source')
+const assert = require('assert')
+
+/**
+ * Raw texts paired with what the character at an offset decodes to and where
+ * the walk resumes, so the count a position is built on is pinned per spelling.
+ * @type {Array.<{name: string, content: string, at: number,
+ *  decoded: (string|undefined), next: number}>}
+ */
+const CHARACTERS = [
+  {
+    name: 'reads a plain character as itself',
+    content: 'abc', at: 1, decoded: 'b', next: 2,
+  },
+  {
+    name: 'reads a named entity as the one character it stands for',
+    content: 'a&gt;b', at: 1, decoded: '>', next: 5,
+  },
+  {
+    name: 'reads a CRLF line ending as the newline a parser leaves',
+    content: 'a\r\nb', at: 1, decoded: '\n', next: 3,
+  },
+  {
+    name: 'reads a lone carriage return as a newline too',
+    content: 'a\rb', at: 1, decoded: '\n', next: 2,
+  },
+  {
+    name: 'reads a newline as itself',
+    content: 'a\nb', at: 1, decoded: '\n', next: 2,
+  },
+  {
+    name: 'refuses an entity no semicolon closes',
+    content: 'a&gt', at: 1, decoded: undefined, next: 2,
+  },
+  {
+    name: 'refuses an entity it does not know',
+    content: 'a&#65;b', at: 1, decoded: undefined, next: 6,
+  },
+]
+
+/**
+ * Texts paired with how far a walk of the given length reaches, which is what
+ * keeps a defect on the character it stands on.
+ * @type {Array.<{name: string, content: string, count: number, raw: number}>}
+ */
+const WALKS = [
+  {
+    name: 'counts a CRLF line ending as the one character it becomes',
+    content: 'ab\r\ncd', count: 4, raw: 5,
+  },
+  {
+    name: 'counts three CRLF endings as three characters',
+    content: 'a\r\nb\r\nc\r\nd', count: 6, raw: 9,
+  },
+  {
+    name: 'counts an entity as the one character it becomes',
+    content: 'a&amp;b', count: 2, raw: 6,
+  },
+  {
+    name: 'counts a plain run one for one',
+    content: 'abcdef', count: 3, raw: 3,
+  },
+]
+
+describe('source', function() {
+  CHARACTERS.forEach((one) => {
+    it(one.name, function() {
+      assert.deepStrictEqual(
+        character(one.content, one.at),
+        [one.decoded, one.next],
+      )
+    })
+  })
+  WALKS.forEach((one) => {
+    it(one.name, function() {
+      assert.equal(skip(one.content, 0, one.count), one.raw)
+    })
+  })
+  it('turns a line and column into an offset', function() {
+    assert.equal(offsetAt('ab\ncde\nf', 2, 3), 5)
+  })
+  it('turns an offset back into a line and column', function() {
+    assert.deepStrictEqual(placeAt('ab\ncde\nf', 5), {line: 2, pos: 3})
+  })
+})

--- a/test/source.test.js
+++ b/test/source.test.js
@@ -67,6 +67,18 @@ const WALKS = [
   },
 ]
 
+/**
+ * The same three lines written with each line ending XML recognises, paired
+ * with the offset of the third character of the second line. A parser numbers
+ * lines the same way whichever is used, so a walk has to as well.
+ * @type {Array.<{name: string, content: string, offset: number}>}
+ */
+const ENDINGS = [
+  {name: 'a newline', content: 'ab\ncde\nf', offset: 5},
+  {name: 'a carriage return', content: 'ab\rcde\rf', offset: 5},
+  {name: 'a CRLF pair', content: 'ab\r\ncde\r\nf', offset: 6},
+]
+
 describe('source', function() {
   CHARACTERS.forEach((one) => {
     it(one.name, function() {
@@ -81,10 +93,15 @@ describe('source', function() {
       assert.equal(skip(one.content, 0, one.count), one.raw)
     })
   })
-  it('turns a line and column into an offset', function() {
-    assert.equal(offsetAt('ab\ncde\nf', 2, 3), 5)
-  })
-  it('turns an offset back into a line and column', function() {
-    assert.deepStrictEqual(placeAt('ab\ncde\nf', 5), {line: 2, pos: 3})
+  ENDINGS.forEach((one) => {
+    it(`turns a line and column into an offset across ${one.name}`, function() {
+      assert.equal(offsetAt(one.content, 2, 3), one.offset)
+    })
+    it(`turns that offset back into a line and column across ${one.name}`,
+      function() {
+        assert.deepStrictEqual(
+          placeAt(one.content, one.offset), {line: 2, pos: 3},
+        )
+      })
   })
 })

--- a/test/string-length-linter.test.js
+++ b/test/string-length-linter.test.js
@@ -23,7 +23,7 @@ describe('string-length-linter', function() {
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} string-length comparisons`,
         function() {
-          const defects = lintByStringLength([{file: 'test.xsl', xsl: input}])
+          const defects = lintByStringLength([{file: 'test.xsl', content: yml.input, xsl: input}])
           assert.equal(defects.length, yml.found.amount)
           yml.found.positions.forEach((pos, index) => {
             assert.equal(defects[index].line, pos[0])

--- a/test/translate-linter.test.js
+++ b/test/translate-linter.test.js
@@ -22,7 +22,7 @@ describe('translate-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} translate case folds`, function() {
-        const defects = lintByTranslate([{file: 'test.xsl', xsl: input}])
+        const defects = lintByTranslate([{file: 'test.xsl', content: yml.input, xsl: input}])
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/using-namespace-axis-linter.test.js
+++ b/test/using-namespace-axis-linter.test.js
@@ -22,7 +22,7 @@ describe('using-namespace-axis-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} namespace axes`, function() {
-        const defects = lintByNamespaceAxis([{file: 'test.xsl', xsl: input}])
+        const defects = lintByNamespaceAxis([{file: 'test.xsl', content: yml.input, xsl: input}])
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/xpath-axis-linter.test.js
+++ b/test/xpath-axis-linter.test.js
@@ -22,7 +22,7 @@ describe('xpath-axis-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} unabbreviated axes`, function() {
-        const defects = lintByAxis([{file: 'test.xsl', xsl: input}])
+        const defects = lintByAxis([{file: 'test.xsl', content: yml.input, xsl: input}])
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/xpath-format-linter.test.js
+++ b/test/xpath-format-linter.test.js
@@ -24,7 +24,7 @@ describe('xpath-format-linter', function() {
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} redundant whitespace runs`,
         function() {
-          const {expressions} = validate([{file: 'test.xsl', xsl: input}])
+          const {expressions} = validate([{file: 'test.xsl', content: yml.input, xsl: input}])
           const defects = lintByFormat(expressions)
           assert.equal(defects.length, yml.found.amount)
           yml.found.positions.forEach((pos, index) => {

--- a/test/xpath-linter.test.js
+++ b/test/xpath-linter.test.js
@@ -37,7 +37,7 @@ describe('xpath-linter', function() {
           })
       })
       it(`should find ${yml.found.amount} defects by all checks`, function() {
-        const defects = lintByXpath([{file: 'test.xsl', xsl: input}])
+        const defects = lintByXpath([{file: 'test.xsl', content: yml.input, xsl: input}])
         assert.equal(defects.length, yml.found.amount)
         defects.forEach((defect, index) => {
           let severity = lint.severity

--- a/test/xpath-validator.test.js
+++ b/test/xpath-validator.test.js
@@ -22,7 +22,7 @@ describe('xpath-validator', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} invalid expressions`, function() {
-        const {defects} = validate([{file: 'test.xsl', xsl: input}])
+        const {defects} = validate([{file: 'test.xsl', content: yml.input, xsl: input}])
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -342,6 +342,14 @@ describe('xslint', function() {
     const streams = xslintStreams(['test/resources/directives/wrapped.xsl'])
     assert.ok(!streams.stderr.includes('Unused xslint-disable'))
   })
+  it('should suppress a defect in a value whose start tag wraps too', function() {
+    const streams = xslintStreams(['test/resources/directives/wrapped-tag.xsl'])
+    assert.ok(!streams.stdout.includes('using-namespace-axis'))
+  })
+  it('should not call the directive over a wrapped tag unused', function() {
+    const streams = xslintStreams(['test/resources/directives/wrapped-tag.xsl'])
+    assert.ok(!streams.stderr.includes('Unused xslint-disable'))
+  })
   it('should suppress across the file with an inline disable-file', function() {
     const streams = xslintStreams(['test/resources/directives/disable-file.xsl'])
     assert.ok(!streams.stdout.includes('short-names'))

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -334,6 +334,14 @@ describe('xslint', function() {
     const streams = xslintStreams(['test/resources/directives/targeted.xsl'])
     assert.ok(streams.stdout.includes('not-using-output'))
   })
+  it('should suppress a defect standing in a wrapped attribute value', function() {
+    const streams = xslintStreams(['test/resources/directives/wrapped.xsl'])
+    assert.ok(!streams.stdout.includes('using-namespace-axis'))
+  })
+  it('should not call the directive over a wrapped value unused', function() {
+    const streams = xslintStreams(['test/resources/directives/wrapped.xsl'])
+    assert.ok(!streams.stderr.includes('Unused xslint-disable'))
+  })
   it('should suppress across the file with an inline disable-file', function() {
     const streams = xslintStreams(['test/resources/directives/disable-file.xsl'])
     assert.ok(!streams.stdout.includes('short-names'))


### PR DESCRIPTION
Closes #611 and #626, the last blockers before any code-based check can be frozen.

### What was wrong

`defect` added the offset to the node's column and left the line alone, which
holds only while a value occupies one source line. An attribute value reaches
`nodeValue` with its line breaks normalised to spaces (XML 1.0 §3.3.3) and its
entities decoded, so neither the wrap nor the width of an entity survives to be
counted:

```text
wrap.xsl(5:44) The namespace:: axis…      line 5 is 20 characters
wrap.xsl(7:63) Verbose axis specifiers…   line 7 is 30 characters
```

Both name columns their lines do not reach.

### The fix

The offset is walked against the raw text from where the node opens, which is
the only place the wrap and the entity are still visible. That needs the source,
so the corpus carries it beside the parsed document and `defect` takes the
source rather than the file name. The decode-walk `src/fixer.js` already had
moves to `src/source.js`, where both use it.

Three consequences worth calling out.

**Three pack rows moved.** They pinned a column computed over the decoded value
— three short in each case, one per `&gt;` standing before the defect. So the
position was wrong on a single line too, not only across a wrap, and nothing had
noticed. Each was re-derived by hand against the fixture before being changed.

**The fixer stops re-deriving what it is now given.** It reconstructed the
value's start as `col - offset` to undo the old arithmetic. The anchor is the
true position now, so it locates from there, and the `offset` the anchor carried
is gone.

**A wrapped value would have become unsilenceable.** The reported line is now
inside a start tag, where no comment fits, so `xslint-disable-next-line` above
the element stopped matching — I checked, and it does suppress on master.
Defects carry `from`, the line the value opens on, and a directive reaches
anywhere between that and the defect. Two tests pin it, one that the defect is
suppressed and one that the directive is not then called unused.

### Coverage

`namespace-axis-in-a-wrapped-value.yaml` pins a wrapped `@test` and a wrapped
attribute value template — no fixture in `test/resources/*-packs/` wrapped an
expression before, which is why nothing caught this. A committed fix pair proves
`--fix` still lands on the right span in both a wrapped value and an
entity-shifted one.

`test/resources/directives/wrapped.xsl` is excluded from the repo-wide xcop
sweep, as `malformed/` and `fix/` are: it has to keep the wrap that xcop joins
onto one line.

946 tests, 100% branch coverage (902/902), ESLint, xcop, markdownlint and the
fixtures gate clean locally.

### Also here, after review

**CRLF (#626).** `character` folded a named entity into one character but read a
`\r` as itself, though XML 1.0 §2.11 normalises `\r\n` and a lone `\r` to `\n`
before parsing begins — so a CRLF source is one character two offsets wide and
the walk fell a column behind per wrap. It is the third form of the same defect:

```text
        before   after
LF      8:30     8:30
CRLF    8:27     8:30
```

`--fix` declined a CRLF file outright before, which the verify-before-apply
guard deserves credit for; it lands now. Committed fixtures are pinned to
`eol=lf`, so the case is built at runtime from the LF fixture.

**An unterminated `&`** sent the walk back to offset 0, since `indexOf` answers
-1. It yields no character now, failing the way an unknown entity already did.

**The suppression hole was closed one level short.** `from` was the line the
*attribute* opens on, so a start tag that wraps before its value does put the
directive outside the range again — reproduced, both halves. It is the holding
element's line now, which collapses to the same value whenever the tag does not
wrap. `wrapped-tag.xsl` pins it.

**The widening is documented** in `README.md` beside the other directive rules,
including its cost: one defect in a wrapped value cannot be silenced without its
neighbours.

**The two helpers no longer rescan** — line offsets are computed once per text.
And `src/fixer.js`'s JSDoc no longer documents the `offset` this PR removed.

Filed rather than fixed: #627, `xsl:merge-source`'s `for-each-item` and
`for-each-source` are absent from `ATTRIBUTES` so nothing reads them; #628,
`redundant-whitespace` flags the indentation of a wrapped expression and offers
a fix that can never apply.

962 tests, 100% branch coverage (913/913).

`unabbreviated-axis` and `using-namespace-axis` then wait on #615 alone — the
`@  name` half of it is our own output.