### PR TITLE
bug(#615): shorten an axis cleanly, and not at all inside a pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,14 @@ a linter and its suppression names cannot drift apart.
 No code-based linter selects attributes by name on its own. `src/attributes.js`
 hands it every expression a stylesheet carries: an XPath or pattern attribute *of
 an XSLT element*, whole, plus each expression an attribute value template encloses
-in braces, offset by where it starts inside the value (#579). In an XSLT 3.0
+in braces, offset by where it starts inside the value (#579). Each one says
+whether it is a `pattern`, because the two are different languages and a rewrite
+legal in one can be a syntax error in the other — `.` stands alone in an
+expression but is a whole pattern rather than a step inside one, so `y|.` does
+not parse and a bare `match="."` outranks the `self::node()` it replaced. A
+fixer touching a step withholds inside a pattern; where the shorter form does
+not exist there at all, the check does not report it either, the way it stays
+quiet on a `parent::n` (#583). In an XSLT 3.0
 stylesheet it also reads a **text value template** — the braces of a text node
 whose nearest `expand-text`/`xsl:expand-text` is on — and a **shadow attribute**
 (`_select` for `select`), the same expressions the modern idiom hides outside an
@@ -177,7 +184,8 @@ motive, or ships untested fails the build.
   (`metaOf`, `suppressed`, `defect`) and reads its expressions from
   `src/attributes.js`'s `expressionsOf` (every XPath/pattern attribute of an XSLT
   element, plus every expression an attribute value template, a 3.0 text value
-  template, or a shadow attribute carries) unless it has a documented reason to
+  template, or a shadow attribute carries, each flagged `pattern` or not) unless
+  it has a documented reason to
   narrow — then it narrows through `selectorOf`, never a hand-written `//@name`,
   which an ESLint `no-restricted-syntax` selector bans.
 
@@ -362,7 +370,7 @@ the harness asserts too.
 | `src/*-linter.js` | Code-based `checks/format/*.yaml`, one construct each (axis, namespace, count, name, ...); see the flow diagram |
 | `src/checks.js` | Shared for code-based linters: `metaOf`, `suppressed`, `defect(check, meta, source, node, offset, fix)` — walks the raw text so a wrapped or entity-shifted value reports where it truly stands (#611) |
 | `src/source.js` | Raw-text walking shared by `checks` and `fixer`: `offsetAt`, `placeAt`, `character`, `skip` |
-| `src/attributes.js` | `expressionsOf(xsl)` — every expression a stylesheet carries: a bare/AVT attribute, a 3.0 text value template, or a shadow attribute; `selectorOf(name)` for a linter that narrows |
+| `src/attributes.js` | `expressionsOf(xsl)` — every expression a stylesheet carries: a bare/AVT attribute, a 3.0 text value template, or a shadow attribute, each saying whether it is a `pattern`; `PATTERNS` names the five attributes that hold one; `selectorOf(name)` for a linter that narrows |
 | `src/xsl-version.js` | `versionOf(node)` — the version in force at a node, from the nearest ancestor's `@version` (XSLT element) or `@xsl:version` (literal result element), canonicalised as a decimal; `since(version, floor)` for a lower-bound gate; shared `MODERN`/`KNOWN`/`DECIMAL` |
 | `src/comparisons.js` | `comparedToZero` — shared scan for a call compared with `0`/`1` (count, string-length) |
 | `src/expressions.js` | `masked`/`closes` lexer helpers (node-set, double-negation, boolean-call); `enclosed` — the expressions an AVT holds in its braces |

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -20,7 +20,19 @@ const ATTRIBUTES = [
   'select', 'test', 'use', 'value', 'group-by', 'group-adjacent', 'key',
   'initial-value', 'xpath', 'context-item', 'with-params', 'namespace-context',
   'match', 'count', 'from', 'group-starting-with', 'group-ending-with',
-  'for-each-item', 'for-each-source',
+  'for-each-item', 'for-each-source', 'use-when',
+]
+
+/**
+ * The attributes among those that hold a *pattern* rather than an expression.
+ * The two are not one language: a pattern has its own grammar, narrower where
+ * an expression is free — `.` may stand alone there but not inside a union or
+ * a parenthesis — and it decides which template wins rather than what a step
+ * selects. A linter rewriting one has to know which of the two it is holding.
+ * @type {Array.<string>}
+ */
+const PATTERNS = [
+  'match', 'count', 'from', 'group-starting-with', 'group-ending-with',
 ]
 
 /**
@@ -103,9 +115,12 @@ const carried = function(node, bare, three) {
     (bare.has(node) || (three && shadow(node)))
   const braced = node.nodeType === 2 || (three && expands(node))
   return whole ?
-    [{node: node, start: 0, expression: node.nodeValue}] :
+    [{
+      node: node, start: 0, expression: node.nodeValue,
+      pattern: PATTERNS.includes(node.nodeName.replace(/^_/, '')),
+    }] :
     braced ? enclosed(node.nodeValue).map((found) => ({
-      node: node, start: found.offset, expression: found.value,
+      node: node, start: found.offset, expression: found.value, pattern: false,
     })) : []
 }
 
@@ -118,7 +133,7 @@ const carried = function(node, bare, three) {
  * reported — and fixed — where it truly stands.
  * @param {Document} xsl - XSL document parsed as {@link Document}
  * @return {Array.<{node: Node, start: number, expression: string}>} - The
- *  expressions found
+ *  expressions found, each saying whether it is a pattern
  */
 const expressionsOf = function(xsl) {
   const bare = new Set(nodes(xsl, SELECTOR))

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -11,13 +11,16 @@ const {XSLT, since, versionOf} = require('./xsl-version')
  * Attributes that hold an XPath expression or a pattern — every place a
  * construct like an axis, a predicate, or a `count(...)` call can appear.
  * Patterns (`match` and the grouping attributes) are included, so a construct
- * in a template match is caught too, not only in the expression stream.
+ * in a template match is caught too, not only in the expression stream. So are
+ * the two an `xsl:merge-source` holds beside its `select`, which carry an
+ * expression the same way it does (#627).
  * @type {Array.<string>}
  */
 const ATTRIBUTES = [
   'select', 'test', 'use', 'value', 'group-by', 'group-adjacent', 'key',
   'initial-value', 'xpath', 'context-item', 'with-params', 'namespace-context',
   'match', 'count', 'from', 'group-starting-with', 'group-ending-with',
+  'for-each-item', 'for-each-source',
 ]
 
 /**

--- a/src/resources/checks/format/unabbreviated-axis.yaml
+++ b/src/resources/checks/format/unabbreviated-axis.yaml
@@ -3,3 +3,4 @@
 ---
 severity: warning
 message: Verbose axis specifiers child::, attribute::, parent::node(), or self::node() are used. Replace them with the node name alone, @, .., or . respectively.
+mature: true

--- a/src/resources/checks/format/using-namespace-axis.yaml
+++ b/src/resources/checks/format/using-namespace-axis.yaml
@@ -3,3 +3,4 @@
 ---
 severity: warning
 message: "The namespace:: axis is deprecated in XSLT 2.0 and later. Use in-scope-prefixes() and namespace-uri-for-prefix() instead."
+mature: true

--- a/src/resources/motives/format/unabbreviated-axis.md
+++ b/src/resources/motives/format/unabbreviated-axis.md
@@ -60,11 +60,12 @@ is legal in every version.
 In a pattern only the first two rows hold, and not by coincidence. Before 3.0 a
 pattern step admits the child and attribute axes and no others — a 1.0 processor
 rejects `match="self::r"` outright — which is exactly the pair whose
-abbreviations are safe there. XSLT 3.0 widened the step to the forward axes —
+abbreviations are safe there. XSLT 3.0 widened the step to the downward axes —
 `descendant`, `self`, `descendant-or-self`, `namespace` — so `match="self::r"`
 compiles on a 3.0 processor; the pair is still the pair, because those two drop
-a step without touching how the rule is weighed. The reverse axes stayed out,
-which is why `parent::` never became a pattern step in any version.
+a step without touching how the rule is weighed. Every axis that reaches
+elsewhere stayed out, `following::` as much as `parent::`, which is why
+`parent::` never became a pattern step in any version.
 
 Neither abbreviated step survives the trip. For `..` there is nothing to weigh:
 `match="parent::node()"` is not a legal pattern in any version, so neither is

--- a/src/resources/motives/format/unabbreviated-axis.md
+++ b/src/resources/motives/format/unabbreviated-axis.md
@@ -60,22 +60,25 @@ is legal in every version.
 In a pattern only the first two rows hold, and not by coincidence. Before 3.0 a
 pattern step admits the child and attribute axes and no others — a 1.0 processor
 rejects `match="self::r"` outright — which is exactly the pair whose
-abbreviations are safe there. XSLT 3.0 widened the step to `descendant`, `self`
-and the rest, so `match="self::r"` compiles on a 3.0 processor; the pair is
-still the pair, because those two drop a step without touching how the rule is
-weighed.
+abbreviations are safe there. XSLT 3.0 widened the step to the forward axes —
+`descendant`, `self`, `descendant-or-self`, `namespace` — so `match="self::r"`
+compiles on a 3.0 processor; the pair is still the pair, because those two drop
+a step without touching how the rule is weighed. The reverse axes stayed out,
+which is why `parent::` never became a pattern step in any version.
 
-The abbreviated steps never survive the trip, for a different reason in each
-era. Before 3.0 the longhand is not a legal pattern to begin with — the self
-axis is not among the two — so the question of shortening it never arises. From
-3.0 it is legal, and then the short form is not a synonym: `.` is a pattern in
-its own right rather than a step inside one, so it cannot stand in a union or
-behind a parenthesis, `match="y|self::node()"` being legal where `match="y|."`
-is not; and standing alone it is outranked by the longhand it replaced, `.`
-carrying a default priority of -1 where `self::node()` carries -0.5, so the
-rewrite quietly hands the node to a template that used to lose. Leave a longhand
-step as it is in a `match`, a `count`, a `from`, or an `xsl:for-each-group`
-boundary.
+Neither abbreviated step survives the trip. For `..` there is nothing to weigh:
+`match="parent::node()"` is not a legal pattern in any version, so neither is
+`match=".."`, and the question of shortening one into the other never arises.
+
+`.` is the one with two eras. Before 3.0 the longhand is not a legal pattern
+either, the self axis not being among the two. From 3.0 it is, and then the
+short form is no synonym for it: `.` is a pattern in its own right, not a step
+inside one, so it cannot stand in a union or behind a parenthesis,
+`match="y|self::node()"` being legal where `match="y|."` is not; and standing
+alone it is outranked by the longhand it replaced, `.` carrying a default
+priority of -1 where `self::node()` carries -0.5, so the rewrite quietly hands
+the node to a template that used to lose. Leave a longhand step as it is in a
+`match`, a `count`, a `from`, or an `xsl:for-each-group` boundary.
 
 `descendant-or-self::node()` is the exception that is not worth taking. Its
 short form is `//`, but the two are easy to confuse in use: a `//` that opens a

--- a/src/resources/motives/format/unabbreviated-axis.md
+++ b/src/resources/motives/format/unabbreviated-axis.md
@@ -58,22 +58,24 @@ out or parenthesise the abbreviation, since `(.)[1]` is a filter expression and
 is legal in every version.
 
 In a pattern only the first two rows hold, and not by coincidence. Before 3.0 a
-pattern step admits the child and attribute axes and nothing else — `match="c"`,
-`match="child::c"` and `match="@a"` are the whole of it, and a 1.0 processor
+pattern step admits the child and attribute axes and no others — a 1.0 processor
 rejects `match="self::r"` outright — which is exactly the pair whose
 abbreviations are safe there. XSLT 3.0 widened the step to `descendant`, `self`
 and the rest, so `match="self::r"` compiles on a 3.0 processor; the pair is
 still the pair, because those two drop a step without touching how the rule is
 weighed.
 
-The abbreviated steps never survive the trip. Before 3.0 there is nothing to
-shorten to: a pattern has no `.` step, so `match="self::node()"` does not
-compile at all. From 3.0 `match="."` does compile, and is not a synonym — it is
-a pattern in its own right rather than a step inside one, so it cannot stand in
-a union or behind a parenthesis, `match="y|self::node()"` being legal where
-`match="y|."` is not; and standing alone it outranks the longhand it replaced,
-quietly handing the node to a template that used to lose. Leave a longhand step
-as it is in a `match`, a `count`, a `from`, or an `xsl:for-each-group` boundary.
+The abbreviated steps never survive the trip, for a different reason in each
+era. Before 3.0 the longhand is not a legal pattern to begin with — the self
+axis is not among the two — so the question of shortening it never arises. From
+3.0 it is legal, and then the short form is not a synonym: `.` is a pattern in
+its own right rather than a step inside one, so it cannot stand in a union or
+behind a parenthesis, `match="y|self::node()"` being legal where `match="y|."`
+is not; and standing alone it is outranked by the longhand it replaced, `.`
+carrying a default priority of -1 where `self::node()` carries -0.5, so the
+rewrite quietly hands the node to a template that used to lose. Leave a longhand
+step as it is in a `match`, a `count`, a `from`, or an `xsl:for-each-group`
+boundary.
 
 `descendant-or-self::node()` is the exception that is not worth taking. Its
 short form is `//`, but the two are easy to confuse in use: a `//` that opens a

--- a/src/resources/motives/format/unabbreviated-axis.md
+++ b/src/resources/motives/format/unabbreviated-axis.md
@@ -10,7 +10,10 @@ nothing — the child axis is the one a bare name already uses, so writing it ou
 draws the eye to the one part of the step that carries no information.
 
 The abbreviations are defined by XPath itself and select precisely the same
-nodes as the longhand:
+nodes as the longhand — in an expression. A `match` is not an expression but a
+pattern, a narrower grammar with its own rules about where `.` may stand and its
+own way of deciding which template wins, so the table below is about `select`
+and `test`, and a pattern is discussed at the end:
 
 | Longhand | Short |
 | --- | --- |
@@ -53,6 +56,15 @@ restriction, which is why the same expression compiles under a later `version`.
 Where a predicate follows the step in a 1.0 stylesheet, either leave it spelled
 out or parenthesise the abbreviation, since `(.)[1]` is a filter expression and
 is legal in every version.
+
+In a pattern only the first two rows hold. A pattern takes the child and
+attribute axes, so `match="child::chapter"` is `match="chapter"` and nothing
+changes. The abbreviated steps are another matter: `.` is a pattern in its own
+right rather than a step inside one, so it cannot stand in a union or behind a
+parenthesis — `match="y|self::node()"` is legal and `match="y|."` will not
+compile — and where it does parse it is weighed differently against a competing
+template. Leave a longhand step alone in a `match`, a `count`, a `from`, or an
+`xsl:for-each-group` boundary.
 
 `descendant-or-self::node()` is the exception that is not worth taking. Its
 short form is `//`, but the two are easy to confuse in use: a `//` that opens a

--- a/src/resources/motives/format/unabbreviated-axis.md
+++ b/src/resources/motives/format/unabbreviated-axis.md
@@ -57,9 +57,10 @@ Where a predicate follows the step in a 1.0 stylesheet, either leave it spelled
 out or parenthesise the abbreviation, since `(.)[1]` is a filter expression and
 is legal in every version.
 
-In a pattern only the first two rows hold. A pattern takes the child and
-attribute axes, so `match="child::chapter"` is `match="chapter"` and nothing
-changes. The abbreviated steps are another matter: `.` is a pattern in its own
+In a pattern only the first two rows hold. A pattern is free with axes —
+`match="self::r"` and `match="descendant::c"` are both legal — and the child and
+attribute axes are among them, so `match="child::chapter"` is `match="chapter"`
+and nothing changes. The abbreviated steps are another matter: `.` is a pattern in its own
 right rather than a step inside one, so it cannot stand in a union or behind a
 parenthesis — `match="y|self::node()"` is legal and `match="y|."` will not
 compile — and where it does parse it is weighed differently against a competing

--- a/src/resources/motives/format/unabbreviated-axis.md
+++ b/src/resources/motives/format/unabbreviated-axis.md
@@ -57,15 +57,23 @@ Where a predicate follows the step in a 1.0 stylesheet, either leave it spelled
 out or parenthesise the abbreviation, since `(.)[1]` is a filter expression and
 is legal in every version.
 
-In a pattern only the first two rows hold. A pattern is free with axes —
-`match="self::r"` and `match="descendant::c"` are both legal — and the child and
-attribute axes are among them, so `match="child::chapter"` is `match="chapter"`
-and nothing changes. The abbreviated steps are another matter: `.` is a pattern in its own
-right rather than a step inside one, so it cannot stand in a union or behind a
-parenthesis — `match="y|self::node()"` is legal and `match="y|."` will not
-compile — and where it does parse it is weighed differently against a competing
-template. Leave a longhand step alone in a `match`, a `count`, a `from`, or an
-`xsl:for-each-group` boundary.
+In a pattern only the first two rows hold, and not by coincidence. Before 3.0 a
+pattern step admits the child and attribute axes and nothing else — `match="c"`,
+`match="child::c"` and `match="@a"` are the whole of it, and a 1.0 processor
+rejects `match="self::r"` outright — which is exactly the pair whose
+abbreviations are safe there. XSLT 3.0 widened the step to `descendant`, `self`
+and the rest, so `match="self::r"` compiles on a 3.0 processor; the pair is
+still the pair, because those two drop a step without touching how the rule is
+weighed.
+
+The abbreviated steps never survive the trip. Before 3.0 there is nothing to
+shorten to: a pattern has no `.` step, so `match="self::node()"` does not
+compile at all. From 3.0 `match="."` does compile, and is not a synonym — it is
+a pattern in its own right rather than a step inside one, so it cannot stand in
+a union or behind a parenthesis, `match="y|self::node()"` being legal where
+`match="y|."` is not; and standing alone it outranks the longhand it replaced,
+quietly handing the node to a template that used to lose. Leave a longhand step
+as it is in a `match`, a `count`, a `from`, or an `xsl:for-each-group` boundary.
 
 `descendant-or-self::node()` is the exception that is not worth taking. Its
 short form is `//`, but the two are easy to confuse in use: a `//` that opens a

--- a/src/source.js
+++ b/src/source.js
@@ -99,9 +99,12 @@ const character = function(content, at) {
  * The raw offset reached after skipping the given number of decoded characters,
  * so an offset into a parsed value maps back to its true place in the source
  * even when an entity ahead of it spans several source characters. Where the
- * span holds no `&` and no `\r` nothing can be wider than one character, and
- * the answer is the count itself — which is the ordinary case, and worth not
- * walking a character at a time to reach.
+ * span holds no `&` and no `\r` nothing in it can be wider than one character,
+ * and the answer is the count itself — the ordinary case, and worth not walking
+ * a character at a time to reach. Testing only that span is enough: every
+ * character before the first wide one is read one for one, so the first `&` or
+ * `\r` a walk could reach always sits below `at + count`, inside the span
+ * tested. A count below zero takes the walk, which answers `at`.
  * @param {string} content - Raw source text
  * @param {number} at - Zero-based offset to start from
  * @param {number} count - Number of decoded characters to skip
@@ -110,7 +113,7 @@ const character = function(content, at) {
 const skip = function(content, at, count) {
   const ahead = content.slice(at, at + count)
   let raw = at + count
-  if (ahead.includes('&') || ahead.includes('\r')) {
+  if (count < 0 || ahead.includes('&') || ahead.includes('\r')) {
     raw = at
     for (let seen = 0; seen < count; seen++) {
       raw = character(content, raw)[1]

--- a/src/source.js
+++ b/src/source.js
@@ -98,16 +98,23 @@ const character = function(content, at) {
 /**
  * The raw offset reached after skipping the given number of decoded characters,
  * so an offset into a parsed value maps back to its true place in the source
- * even when an entity ahead of it spans several source characters.
+ * even when an entity ahead of it spans several source characters. Where the
+ * span holds no `&` and no `\r` nothing can be wider than one character, and
+ * the answer is the count itself — which is the ordinary case, and worth not
+ * walking a character at a time to reach.
  * @param {string} content - Raw source text
  * @param {number} at - Zero-based offset to start from
  * @param {number} count - Number of decoded characters to skip
  * @return {number} - The raw offset after `count` decoded characters
  */
 const skip = function(content, at, count) {
-  let raw = at
-  for (let seen = 0; seen < count; seen++) {
-    raw = character(content, raw)[1]
+  const ahead = content.slice(at, at + count)
+  let raw = at + count
+  if (ahead.includes('&') || ahead.includes('\r')) {
+    raw = at
+    for (let seen = 0; seen < count; seen++) {
+      raw = character(content, raw)[1]
+    }
   }
   return raw
 }

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -29,8 +29,10 @@ const names = [CHECK]
 
 /**
  * The abbreviation each axis specifier collapses to on its own, whatever node
- * test follows it. The verbatim text comes from the token, so a spaced
- * `child ::` is stripped in full rather than leaving its whitespace behind.
+ * test follows it. What gets replaced is measured by `spans`, not taken from
+ * the token: the token carries the gap in front of the colons and `spans`
+ * reaches the one behind them, so a spaced `child ::  a` is stripped in full
+ * from either side.
  * @type {{[type: string]: {replacement: string}}}
  */
 const SHORT = {
@@ -63,7 +65,10 @@ const SPAN = 4
  * whitespace behind its colons. XPath allows a gap there, and it belongs to the
  * axis rather than to the node test, so shortening `attribute::  name` has to
  * take the gap with it — leaving `@  name` would be a fix that reads worse than
- * what it replaced.
+ * what it replaced. A gap the source wrote as a line break cannot be told apart
+ * here — the parser turned it into a space before the lexer saw it — so such a
+ * fix reaches the source as a run of spaces, fails to match, and is declined
+ * rather than misapplied. That is #629's to settle, not this function's.
  * @param {Array.<{type: string, value: string, start: number}>} tokens - Tokens
  * @param {number} index - Index of the axis token
  * @return {number} - Offset just past the axis and the gap behind it
@@ -113,9 +118,11 @@ const afterNode = function(tokens, index) {
  * comments are never seen because the lexer keeps those whole.
  * @param {string} expression - Xpath expression or pattern
  * @param {boolean} modern - Whether the stylesheet declares XSLT 2.0 or later
+ * @param {boolean} pattern - Whether the expression is a pattern, where the
+ *  step abbreviations are not the synonyms they are in an expression
  * @return {Array.<{offset: number, fix: ?object}>} - Axes and their fixes
  */
-const abbreviable = function(expression, modern) {
+const abbreviable = function(expression, modern, pattern) {
   const tokens = tokenized(expression)
   const found = []
   tokens.forEach((token, index) => {
@@ -131,7 +138,7 @@ const abbreviable = function(expression, modern) {
     } else if (step !== null) {
       found.push({
         offset: token.start,
-        fix: step.predicated && !modern ? undefined : {
+        fix: pattern || (step.predicated && !modern) ? undefined : {
           value: expression.slice(token.start, step.end),
           replacement: STEP[token.type].replacement,
         },
@@ -154,9 +161,11 @@ const lintByAxis = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const source of corpus) {
-      for (const {node, start, expression} of expressionsOf(source.xsl)) {
-        const modern = since(versionOf(node), MODERN)
-        for (const {offset, fix} of abbreviable(expression, modern)) {
+      for (const held of expressionsOf(source.xsl)) {
+        const {node, start, expression} = held
+        for (const {offset, fix} of abbreviable(
+          expression, since(versionOf(node), MODERN), held.pattern,
+        )) {
           defects.push(defect(CHECK, META, source, node, start + offset, fix))
         }
       }

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -59,6 +59,24 @@ const STEP = {
 const SPAN = 4
 
 /**
+ * Offset just past the axis at the given token index, counting in any
+ * whitespace behind its colons. XPath allows a gap there, and it belongs to the
+ * axis rather than to the node test, so shortening `attribute::  name` has to
+ * take the gap with it — leaving `@  name` would be a fix that reads worse than
+ * what it replaced.
+ * @param {Array.<{type: string, value: string, start: number}>} tokens - Tokens
+ * @param {number} index - Index of the axis token
+ * @return {number} - Offset just past the axis and the gap behind it
+ */
+const spans = function(tokens, index) {
+  const gap = tokens[index + 1]
+  const axis = tokens[index]
+  return gap !== undefined && gap.type === TOKENS.WHITESPACE ?
+    gap.start + gap.value.length :
+    axis.start + axis.value.length
+}
+
+/**
  * The `node()` test that follows the axis token at the given index, or null
  * when the axis carries another node test. The whitespace XPath allows between
  * the pieces is insignificant, so `node ( )` names the same test as `node()`.
@@ -105,7 +123,10 @@ const abbreviable = function(expression, modern) {
     if (SHORT[token.type]) {
       found.push({
         offset: token.start,
-        fix: {value: token.value, replacement: SHORT[token.type].replacement},
+        fix: {
+          value: expression.slice(token.start, spans(tokens, index)),
+          replacement: SHORT[token.type].replacement,
+        },
       })
     } else if (step !== null) {
       found.push({

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -115,11 +115,12 @@ const afterNode = function(tokens, index) {
  * gave the context item a predicate list, `.` and `..` were an AbbreviatedStep,
  * which takes no predicate, so `self::node()[1]` is only reported on a 1.0
  * sheet: `.[1]` is a syntax error there. A longhand step in a pattern goes
- * unreported for two reasons that meet: before 3.0 a pattern has no `.` step to
- * offer, so there is nothing shorter to name, and from 3.0 `match="."` does
- * compile but is not a synonym — a pattern in its own right rather than a step
- * inside one, illegal in a union and outranking the longhand where it stands
- * alone. Either way the check has no shorter form to recommend. Axes inside
+ * unreported for a different reason in each era: before 3.0 the longhand is not
+ * a legal pattern at all, the self axis not being one a pattern step admits,
+ * and from 3.0 it is legal but `match="."` is no synonym — a pattern in its
+ * own right rather than a step inside one, illegal in a union, and outranked by
+ * the longhand where it stands alone. Either way there is no shorter form to
+ * recommend. Axes inside
  * string literals or comments are never seen because the lexer keeps those
  * whole.
  * @param {string} expression - Xpath expression or pattern

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -115,14 +115,14 @@ const afterNode = function(tokens, index) {
  * gave the context item a predicate list, `.` and `..` were an AbbreviatedStep,
  * which takes no predicate, so `self::node()[1]` is only reported on a 1.0
  * sheet: `.[1]` is a syntax error there. A longhand step in a pattern goes
- * unreported for a different reason in each era: before 3.0 the longhand is not
- * a legal pattern at all, the self axis not being one a pattern step admits,
- * and from 3.0 it is legal but `match="."` is no synonym — a pattern in its
- * own right rather than a step inside one, illegal in a union, and outranked by
- * the longhand where it stands alone. Either way there is no shorter form to
- * recommend. Axes inside
- * string literals or comments are never seen because the lexer keeps those
- * whole.
+ * unreported because no pattern offers a shorter one. `parent::node()` is not a
+ * legal pattern in any version, the parent axis being reverse where a pattern
+ * step takes forward axes only, so `..` never enters the question. The self
+ * axis is illegal before 3.0 for the same kind of reason and legal after it,
+ * where `match="."` is still no synonym — a pattern in its own right, not a
+ * step inside one, illegal in a union, and outranked by the longhand where it
+ * stands alone. Axes inside string literals or comments are never seen because
+ * the lexer keeps those whole.
  * @param {string} expression - Xpath expression or pattern
  * @param {boolean} modern - Whether the stylesheet declares XSLT 2.0 or later
  * @param {boolean} pattern - Whether the expression is a pattern, which has no

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -114,12 +114,15 @@ const afterNode = function(tokens, index) {
  * aside, whose `//` trades a named step for a whole-tree walk. Before XPath 2.0
  * gave the context item a predicate list, `.` and `..` were an AbbreviatedStep,
  * which takes no predicate, so `self::node()[1]` is only reported on a 1.0
- * sheet: `.[1]` is a syntax error there. Axes inside string literals or
+ * sheet: `.[1]` is a syntax error there. A pattern has no abbreviated step to
+ * offer at all — `.` is a pattern in its own right rather than a step inside
+ * one — so a longhand step there goes unreported, the way `parent::n` does:
+ * both are steps with nothing shorter to become. Axes inside string literals or
  * comments are never seen because the lexer keeps those whole.
  * @param {string} expression - Xpath expression or pattern
  * @param {boolean} modern - Whether the stylesheet declares XSLT 2.0 or later
- * @param {boolean} pattern - Whether the expression is a pattern, where the
- *  step abbreviations are not the synonyms they are in an expression
+ * @param {boolean} pattern - Whether the expression is a pattern, which has no
+ *  abbreviated step to offer, so a longhand one there is not a defect at all
  * @return {Array.<{offset: number, fix: ?object}>} - Axes and their fixes
  */
 const abbreviable = function(expression, modern, pattern) {
@@ -135,10 +138,10 @@ const abbreviable = function(expression, modern, pattern) {
           replacement: SHORT[token.type].replacement,
         },
       })
-    } else if (step !== null) {
+    } else if (step !== null && !pattern) {
       found.push({
         offset: token.start,
-        fix: pattern || (step.predicated && !modern) ? undefined : {
+        fix: step.predicated && !modern ? undefined : {
           value: expression.slice(token.start, step.end),
           replacement: STEP[token.type].replacement,
         },

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -114,10 +114,12 @@ const afterNode = function(tokens, index) {
  * aside, whose `//` trades a named step for a whole-tree walk. Before XPath 2.0
  * gave the context item a predicate list, `.` and `..` were an AbbreviatedStep,
  * which takes no predicate, so `self::node()[1]` is only reported on a 1.0
- * sheet: `.[1]` is a syntax error there. A pattern has no abbreviated step to
- * offer at all — `.` is a pattern in its own right rather than a step inside
- * one — so a longhand step there goes unreported, the way `parent::n` does:
- * both are steps with nothing shorter to become. Axes inside string literals or
+ * sheet: `.[1]` is a syntax error there. A longhand step in a pattern goes
+ * unreported for two reasons that meet: before 3.0 a pattern has no `.` step to
+ * offer, so there is nothing shorter to name, and from 3.0 `match="."` does
+ * compile but is not a synonym — a pattern in its own right rather than a step
+ * inside one, illegal in a union and outranking the longhand where it stands
+ * alone. Either way the check has no shorter form to recommend. Axes inside string literals or
  * comments are never seen because the lexer keeps those whole.
  * @param {string} expression - Xpath expression or pattern
  * @param {boolean} modern - Whether the stylesheet declares XSLT 2.0 or later

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -119,8 +119,9 @@ const afterNode = function(tokens, index) {
  * offer, so there is nothing shorter to name, and from 3.0 `match="."` does
  * compile but is not a synonym — a pattern in its own right rather than a step
  * inside one, illegal in a union and outranking the longhand where it stands
- * alone. Either way the check has no shorter form to recommend. Axes inside string literals or
- * comments are never seen because the lexer keeps those whole.
+ * alone. Either way the check has no shorter form to recommend. Axes inside
+ * string literals or comments are never seen because the lexer keeps those
+ * whole.
  * @param {string} expression - Xpath expression or pattern
  * @param {boolean} modern - Whether the stylesheet declares XSLT 2.0 or later
  * @param {boolean} pattern - Whether the expression is a pattern, which has no

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -116,8 +116,8 @@ const afterNode = function(tokens, index) {
  * which takes no predicate, so `self::node()[1]` is only reported on a 1.0
  * sheet: `.[1]` is a syntax error there. A longhand step in a pattern goes
  * unreported because no pattern offers a shorter one. `parent::node()` is not a
- * legal pattern in any version, the parent axis being reverse where a pattern
- * step takes forward axes only, so `..` never enters the question. The self
+ * legal pattern in any version, the parent axis not being among the downward
+ * ones a pattern step takes, so `..` never enters the question. The self
  * axis is illegal before 3.0 for the same kind of reason and legal after it,
  * where `match="."` is still no synonym — a pattern in its own right, not a
  * step inside one, illegal in a union, and outranked by the longhand where it

--- a/test/conformance.test.js
+++ b/test/conformance.test.js
@@ -239,6 +239,17 @@ describe('conformance', function() {
         )
       }
     }
+    const every = new Set(KINDS.flatMap((kind) => names(kind)))
+    for (const dir of fs.readdirSync(RESOURCES)
+      .filter((one) => one.endsWith('-packs'))) {
+      for (const pack of allFilesFrom(path.join(RESOURCES, dir))
+        .filter((file) => file.endsWith('.yaml'))) {
+        assert.ok(
+          every.has(yaml.parsedFromFile(pack).pack),
+          `pack ${dir}/${path.basename(pack)} names no check`,
+        )
+      }
+    }
     for (const [kind, dir] of Object.entries(PACKED)) {
       const checks = new Set(names(kind))
       for (const pack of allFilesFrom(path.join(RESOURCES, dir))

--- a/test/resources/axis-packs/abbreviated-axis.yaml
+++ b/test/resources/axis-packs/abbreviated-axis.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: abbreviated-axis
+pack: unabbreviated-axis
 found:
   amount: 0
   positions: [ ]

--- a/test/resources/axis-packs/abbreviated-step-inside-a-pattern.yaml
+++ b/test/resources/axis-packs/abbreviated-step-inside-a-pattern.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 0
+  positions: [ ]
+  fixes: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+    <xsl:template match="self::node()"/>
+    <xsl:template match="y|self::node()"/>
+    <xsl:template match="(self::node())"/>
+    <xsl:template match="y|self::node()[1]"/>
+    <xsl:template match="parent::node()"/>
+    <xsl:template _match="y|self::node()"/>
+    <xsl:template match="/">
+      <xsl:number count="self::node()" from="parent::node()"/>
+      <xsl:for-each-group select="x" group-starting-with="self::node()">
+        <xsl:sequence select="."/>
+      </xsl:for-each-group>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/axis-packs/axis-in-a-merge-source.yaml
+++ b/test/resources/axis-packs/axis-in-a-merge-source.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 5
+  positions: [ [ 5, 40 ], [ 5, 60 ], [ 6, 32 ], [ 8, 42 ], [ 8, 62 ] ]
+  fixes: [ "", "", "", "", "" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+    <xsl:template match="/">
+      <xsl:merge>
+        <xsl:merge-source for-each-item="child::doc" select="child::record">
+          <xsl:merge-key select="child::key"/>
+        </xsl:merge-source>
+        <xsl:merge-source for-each-source="child::src" select="child::other">
+          <xsl:merge-key select="@id"/>
+        </xsl:merge-source>
+      </xsl:merge>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/axis-packs/axis-with-a-gap-behind-the-colons.yaml
+++ b/test/resources/axis-packs/axis-with-a-gap-behind-the-colons.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 4
+  positions: [ [ 4, 27 ], [ 5, 27 ], [ 6, 27 ], [ 7, 27 ] ]
+  fixes: [ "@", "", "", ".." ]
+  values: [ "attribute::  ", "child::\t", "child ::  ", "parent ::  node ( )" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="/">
+      <xsl:value-of select="attribute::  name"/>
+      <xsl:value-of select="child::&#9;title"/>
+      <xsl:value-of select="child ::  buried"/>
+      <xsl:value-of select="parent ::  node ( )"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/fix/unabbreviated-axis-in-a-wrapped-value.fixed.xsl
+++ b/test/resources/fix/unabbreviated-axis-in-a-wrapped-value.fixed.xsl
@@ -8,5 +8,7 @@
     <xsl:value-of select="@a
                           or deep"/>
     <xsl:value-of select="@b &gt; 1 and later"/>
+    <xsl:value-of select="child::
+                          alpha"/>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/resources/fix/unabbreviated-axis-in-a-wrapped-value.xsl
+++ b/test/resources/fix/unabbreviated-axis-in-a-wrapped-value.xsl
@@ -8,5 +8,7 @@
     <xsl:value-of select="@a
                           or child::deep"/>
     <xsl:value-of select="@b &gt; 1 and child::later"/>
+    <xsl:value-of select="child::
+                          alpha"/>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/resources/fix/unabbreviated-axis.fixed.xsl
+++ b/test/resources/fix/unabbreviated-axis.fixed.xsl
@@ -12,5 +12,7 @@
     <xsl:value-of select=".."/>
     <xsl:value-of select="parent::n"/>
     <xsl:value-of select="self::text()"/>
+    <xsl:value-of select="@spaced"/>
+    <xsl:value-of select="gapped"/>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/resources/fix/unabbreviated-axis.xsl
+++ b/test/resources/fix/unabbreviated-axis.xsl
@@ -12,5 +12,7 @@
     <xsl:value-of select="parent :: node ( )"/>
     <xsl:value-of select="parent::n"/>
     <xsl:value-of select="self::text()"/>
+    <xsl:value-of select="attribute::  spaced"/>
+    <xsl:value-of select="child::  gapped"/>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/resources/namespace-packs/used-namespaces.yaml
+++ b/test/resources/namespace-packs/used-namespaces.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: used-namespaces
+pack: redundant-namespace-declarations
 found:
   amount: 0
   positions: [ ]

--- a/test/resources/node-set-packs/does-not-use-node-set-extension.yaml
+++ b/test/resources/node-set-packs/does-not-use-node-set-extension.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: does-not-use-node-set-extension
+pack: use-node-set-extension
 found:
   amount: 0
   positions: [ ]

--- a/test/resources/node-set-packs/node-set-edge-cases.yaml
+++ b/test/resources/node-set-packs/node-set-edge-cases.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: does-not-use-node-set-extension
+pack: use-node-set-extension
 found:
   amount: 0
   positions: [ ]

--- a/test/resources/xpath-format-packs/clean-expressions.yaml
+++ b/test/resources/xpath-format-packs/clean-expressions.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: clean-expressions
+pack: redundant-whitespace
 found:
   amount: 0
   positions: [ ]

--- a/test/resources/xpath-format-packs/skips-invalid-expression.yaml
+++ b/test/resources/xpath-format-packs/skips-invalid-expression.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: skips-invalid-expression
+pack: redundant-whitespace
 found:
   amount: 0
   positions: [ ]

--- a/test/resources/xpath-validator-packs/invalid-extra-attributes.yaml
+++ b/test/resources/xpath-validator-packs/invalid-extra-attributes.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: invalid-extra-attributes
+pack: invalid-xpath-expression
 found:
   amount: 7
   positions: [ [ 3, 43 ], [ 5, 23 ], [ 7, 26 ], [ 9, 44 ], [ 9, 86 ], [ 9, 62 ], [ 9, 25 ] ]

--- a/test/resources/xpath-validator-packs/invalid-select-expression.yaml
+++ b/test/resources/xpath-validator-packs/invalid-select-expression.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: invalid-select-expression
+pack: invalid-xpath-expression
 found:
   amount: 1
   positions: [ [ 4, 26 ] ]

--- a/test/resources/xpath-validator-packs/invalid-test-expression.yaml
+++ b/test/resources/xpath-validator-packs/invalid-test-expression.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: invalid-test-expression
+pack: invalid-xpath-expression
 found:
   amount: 1
   positions: [ [ 4, 18 ] ]

--- a/test/resources/xpath-validator-packs/valid-expressions.yaml
+++ b/test/resources/xpath-validator-packs/valid-expressions.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: valid-expressions
+pack: invalid-xpath-expression
 found:
   amount: 0
   positions: [ ]

--- a/test/resources/xpath-validator-packs/valid-extra-attributes.yaml
+++ b/test/resources/xpath-validator-packs/valid-extra-attributes.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: valid-extra-attributes
+pack: invalid-xpath-expression
 found:
   amount: 0
   positions: [ ]

--- a/test/resources/xpath-validator-packs/valid-namespace-axis.yaml
+++ b/test/resources/xpath-validator-packs/valid-namespace-axis.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: valid-namespace-axis
+pack: invalid-xpath-expression
 found:
   amount: 0
   positions: [ ]

--- a/test/resources/xpath-validator-packs/valid-numeric-coercion.yaml
+++ b/test/resources/xpath-validator-packs/valid-numeric-coercion.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: valid-numeric-coercion
+pack: invalid-xpath-expression
 found:
   amount: 0
   positions: [ ]

--- a/test/resources/xpath-validator-packs/valid-unresolved-entity.yaml
+++ b/test/resources/xpath-validator-packs/valid-unresolved-entity.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-pack: valid-unresolved-entity
+pack: invalid-xpath-expression
 found:
   amount: 0
   positions: [ ]

--- a/test/source.test.js
+++ b/test/source.test.js
@@ -65,6 +65,14 @@ const WALKS = [
     name: 'counts a plain run one for one',
     content: 'abcdef', count: 3, raw: 3,
   },
+  {
+    name: 'reaches an entity that sits at the very end of the span',
+    content: 'ab&amp;', count: 3, raw: 7,
+  },
+  {
+    name: 'goes nowhere for a count below zero',
+    content: 'abcdef', count: -2, raw: 0,
+  },
 ]
 
 /**

--- a/test/using-namespace-axis-linter.test.js
+++ b/test/using-namespace-axis-linter.test.js
@@ -35,6 +35,13 @@ describe('using-namespace-axis-linter', function() {
             expected,
           )
         })
+        const values = yml.found.values || []
+        values.forEach((expected, index) => {
+          assert.equal(
+            defects[index].fix ? defects[index].fix.value : null,
+            expected,
+          )
+        })
       })
     })
   })

--- a/test/xpath-axis-linter.test.js
+++ b/test/xpath-axis-linter.test.js
@@ -35,6 +35,13 @@ describe('xpath-axis-linter', function() {
             expected,
           )
         })
+        const values = yml.found.values || []
+        values.forEach((expected, index) => {
+          assert.equal(
+            defects[index].fix ? defects[index].fix.value : null,
+            expected,
+          )
+        })
       })
     })
   })


### PR DESCRIPTION
Closes #627 and the half of #615 that is ours, fixes the #583-class defect the
review turned up, and takes both axis checks to `mature: true`.

The branch grew past its title. In order of weight:

### The #583-class defect: an abbreviated step inside a pattern

`--fix` was rewriting `match` attributes in the safe tier, and a pattern is not
an expression. XSLT 3.0 §5.5.2 makes `.` a `PredicatePattern` — an alternative to
the whole union grammar rather than a term inside it — so three shapes stopped
compiling, and a fourth changed which template wins:

```text
match="y|self::node()"     ->  match="y|."     will not compile
match="(self::node())"     ->  match="(.)"     will not compile
match="y|self::node()[1]"  ->  match="y|.[1]"  will not compile
match="self::node()"       ->  match="."       demoted: -0.5 becomes -1
```

Before 3.0 it is simpler still: the self axis is not a pattern axis at all, so
the longhand was never legal there.

`src/attributes.js` now says which of the names it reads hold a pattern — nothing
could ask it before, which is why no fixer could withhold on that basis — and the
check leaves a longhand step in one alone entirely. Not just the fix: the message
told the reader to write `.` where the motive tells them not to, and for
`match="y|self::node()"` that edit does not compile. The check already answers
this shape, staying quiet on `parent::n` because nothing shorter exists; a
pattern is the same case.

`child::` and `attribute::` keep their fixes there, both being axes a pattern
step admits in every version — and, tested by declaration order on two
processors, both leaving the weighing untouched.

### #615, the gap the colons left behind

| | before | now |
| --- | --- | --- |
| `attribute::  name` | `@  name` | `@name` |
| `child::  title` | `  title` | `title` |

The gap belongs to the axis, so the fix takes it. Master's output was a fresh
defect: `@  name` draws `invalid-xpath-expression` and `  title` draws
`redundant-whitespace`. The other half of #615 — `isValid` refusing `child ::x`
outright — is fontoxpath's and stays open there.

### #627, two attributes nothing read

```text
<xsl:merge-source for-each-item="child::doc" select="child::record">
                                 ^ silent                ^ reported
```

Both read now, and `use-when` with them. The element looking half-covered rather
than uncovered is what kept it quiet.

### Positioning, from the review of #611

`skip` walked the raw text one character at a time for every defect. Nothing in a
span can be wider than one character unless the span holds an `&` or a `\r`, so
where it holds neither the answer is the count itself: 62.9 ms to 6.6 ms over
80,000 calls, with the walk unchanged for the spans that need it and both paths
pinned in `test/source.test.js`.

### Coverage

Two packs pin what no pack could before: `abbreviated-step-inside-a-pattern.yaml`
holds all eight withheld shapes at `amount: 0` and fails on either mistake —
restoring the fix or restoring the report — and a `values:` list beside `fixes:`
pins the span a fix replaces, which is the part of a fix nothing asserted.
Reverting either change now fails the suite; neither did before.

Three packs named a check that does not exist, so the gate counting a format
check's coverage never saw them. Pack names are checked against the real checks
across every directory now, which found nine more of the same.

### `mature: true`

Both checks. 37 expressions past them with no mismatch, on top of 22 packs for
`unabbreviated-axis` and 16 for `using-namespace-axis`: both roots, a simplified
stylesheet, non-`xsl` prefixes, every version and every legal spelling of one, a
raised and a lowered subtree, an `xsl:result-document`, a wrapped value, patterns,
and every node kind — attribute, AVT, text value template, shadow attribute,
CDATA.

The commit subjects on this branch read `bug(#583)` for the pattern work. #583
itself is `starts-with-double-slash` in `src/fixers.js`, still open and untouched
here — the reference is to its class, not to that instance, and merging does not
close it (`closingIssuesReferences` is `#627` alone). The title now reads #615,
which the branch is named for and genuinely advances. No issue is filed for the
instance, since it is fixed in this branch rather than outstanding.

Filed rather than folded in: #631, a pattern axis illegal before 3.0 goes
unreported, which is cheap now that `pattern` and `versionOf` are both available
at the node; #632, `using-namespace-axis` naming two functions that cannot stand
as a pattern step.

974 tests, 100% branch coverage (920/920), ESLint, xcop, markdownlint and the
fixtures gate clean locally.

