### PR TITLE
bug(#633): derive a stylesheet's expressions once, cheaply, and by walking

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes} = require('./xpath')
 const {enclosed} = require('./expressions')
 const {XSLT, since, versionOf} = require('./xsl-version')
+const {walked} = require('./tree')
 
 /**
  * Attributes that hold an XPath expression or a pattern — every place a
@@ -154,10 +154,12 @@ const carried = function(node, bare, three) {
  */
 const expressionsOf = function(xsl) {
   if (!DERIVED.has(xsl)) {
-    const bare = new Set(
-      nodes(xsl, '//xsl:*/@*').filter((one) => NAMED.has(one.nodeName)),
-    )
-    DERIVED.set(xsl, Object.freeze(nodes(xsl, '//*/@* | //text()').flatMap(
+    const held = walked(xsl)
+    const bare = new Set(held.filter(
+      (one) => one.nodeType === 2 && NAMED.has(one.nodeName) &&
+        one.ownerElement.namespaceURI === XSLT,
+    ))
+    DERIVED.set(xsl, Object.freeze(held.flatMap(
       (node) => carried(node, bare, since(versionOf(node), '3.0')),
     )))
   }

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -48,10 +48,25 @@ const selectorOf = function(name) {
 }
 
 /**
- * XPath selecting every attribute that holds a bare XPath, across the document.
- * @type {string}
+ * The names that hold a bare XPath, for testing one attribute at a time. Asking
+ * XPath for all of them at once — a union of nineteen descendant scans, one per
+ * name — costs more than a single scan of every XSLT attribute filtered by name
+ * here, and costs it quadratically: 4.4 s against 0.3 s on a 2000-line
+ * stylesheet (#633).
+ * @type {Set.<string>}
  */
-const SELECTOR = ATTRIBUTES.map(selectorOf).join(' | ')
+const NAMED = new Set(ATTRIBUTES)
+
+/**
+ * The expression list already derived for a document. Eight code-based linters
+ * ask for the same one in a single run, and deriving it walks every attribute
+ * and text node of the stylesheet, so it is derived once and remembered against
+ * the document itself — which a `WeakMap` releases when the corpus does, rather
+ * than holding every stylesheet ever linted (#633). The list is frozen, since
+ * eight callers now share one array.
+ * @type {WeakMap}
+ */
+const DERIVED = new WeakMap()
 
 /**
  * The spellings that switch an XSLT boolean attribute on, whitespace trimmed —
@@ -136,10 +151,15 @@ const carried = function(node, bare, three) {
  *  expressions found, each saying whether it is a pattern
  */
 const expressionsOf = function(xsl) {
-  const bare = new Set(nodes(xsl, SELECTOR))
-  return nodes(xsl, '//*/@* | //text()').flatMap(
-    (node) => carried(node, bare, since(versionOf(node), '3.0')),
-  )
+  if (!DERIVED.has(xsl)) {
+    const bare = new Set(
+      nodes(xsl, '//xsl:*/@*').filter((one) => NAMED.has(one.nodeName)),
+    )
+    DERIVED.set(xsl, Object.freeze(nodes(xsl, '//*/@* | //text()').flatMap(
+      (node) => carried(node, bare, since(versionOf(node), '3.0')),
+    )))
+  }
+  return DERIVED.get(xsl)
 }
 
 module.exports = {

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -62,8 +62,10 @@ const NAMED = new Set(ATTRIBUTES)
  * ask for the same one in a single run, and deriving it walks every attribute
  * and text node of the stylesheet, so it is derived once and remembered against
  * the document itself — which a `WeakMap` releases when the corpus does, rather
- * than holding every stylesheet ever linted (#633). The list is frozen, since
- * eight callers now share one array.
+ * than holding every stylesheet ever linted (#633). Eight callers share one
+ * array, so the array is frozen against having its entries swapped and each
+ * entry is frozen where `carried` builds it — freezing the array alone leaves
+ * `held.expression = ...` free to poison the other seven.
  * @type {WeakMap}
  */
 const DERIVED = new WeakMap()
@@ -130,11 +132,11 @@ const carried = function(node, bare, three) {
     (bare.has(node) || (three && shadow(node)))
   const braced = node.nodeType === 2 || (three && expands(node))
   return whole ?
-    [{
+    [Object.freeze({
       node: node, start: 0, expression: node.nodeValue,
       pattern: PATTERNS.includes(node.nodeName.replace(/^_/, '')),
-    }] :
-    braced ? enclosed(node.nodeValue).map((found) => ({
+    })] :
+    braced ? enclosed(node.nodeValue).map((found) => Object.freeze({
       node: node, start: found.offset, expression: found.value, pattern: false,
     })) : []
 }

--- a/src/tree.js
+++ b/src/tree.js
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Node kinds a walk collects: an attribute, a text node, and the CDATA section
+ * that is a text node written another way.
+ * @type {Array.<number>}
+ */
+const CARRIED = [2, 3, 4]
+
+/**
+ * Namespace declarations, which XPath does not count among an element's
+ * attributes however the DOM lists them — they are namespace nodes, reached by
+ * an axis of their own.
+ * @type {RegExp}
+ */
+const DECLARED = /^xmlns(:|$)/
+
+/**
+ * The walk already taken over a document. Every stage that needs the attributes
+ * or the text of a stylesheet wants the same sequence, so it is walked once and
+ * remembered against the document — released with it, a `WeakMap` holding no
+ * stylesheet the corpus has finished with.
+ * @type {WeakMap}
+ */
+const WALKED = new WeakMap()
+
+/**
+ * Every attribute, text node and CDATA section of a document, in document
+ * order: each element's attributes in the order they were written, then its
+ * children in theirs. Two details keep the sequence the one a descendant scan
+ * answers, so that swapping the two changes no report: a namespace declaration
+ * is left out, XPath counting those as nodes of another kind, and an element's
+ * attributes come out sorted by name, which is the order fontoxpath yields them
+ * in — XPath leaves it to the implementation, and matching the old one is what
+ * makes this change invisible rather than a re-ordering of every report.
+ *
+ * This is the set a descendant scan for every attribute and every text node
+ * answers, reached by walking rather than by XPath, which is the point.
+ * fontoxpath evaluates a descendant step over an
+ * xmldom tree quadratically — 15 ms at 165 lines, 3060 ms at 4805 — where the
+ * walk is linear and reaches 2.7 ms on the same input for the same nodes
+ * (#635). Nothing here interprets a stylesheet; the checks' own XPath is still
+ * XPath, and only the scans this project issues on its own behalf are walked.
+ * @param {Document} xsl - Parsed stylesheet
+ * @return {Array.<Node>} - The nodes it carries, in document order
+ */
+const walked = function(xsl) {
+  if (!WALKED.has(xsl)) {
+    const found = []
+    /**
+     * Add what the node carries, then walk into the elements below it.
+     * @param {Node} node - The document, or an element within it
+     */
+    const visit = function(node) {
+      const carried = Array.from(node.attributes || [])
+        .filter((one) => !DECLARED.test(one.nodeName))
+        .sort((one, two) => (one.nodeName < two.nodeName ? -1 : 1))
+      for (const one of carried) {
+        found.push(one)
+      }
+      for (const kid of Array.from(node.childNodes)) {
+        if (kid.nodeType === 1) {
+          visit(kid)
+        } else if (CARRIED.includes(kid.nodeType)) {
+          found.push(kid)
+        }
+      }
+    }
+    visit(xsl)
+    WALKED.set(xsl, Object.freeze(found))
+  }
+  return WALKED.get(xsl)
+}
+
+module.exports = {
+  walked,
+}

--- a/src/xpath-validator.js
+++ b/src/xpath-validator.js
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes, isValid} = require('./xpath')
+const {isValid} = require('./xpath')
+const {walked} = require('./tree')
+const {XSLT} = require('./xsl-version')
 const {yaml} = require('./helpers')
 const path = require('path')
 const {logger} = require('./logger')
@@ -35,11 +37,24 @@ const names = [CHECK]
  * and sequence types (as) are not expressions and stay out.
  * @type {string}
  */
-const EXPRESSIONS =
-  '//xsl:*/@*[local-name() = (' +
-  '"select", "test", "use", "value", "group-by", "group-adjacent", ' +
-  '"key", "initial-value", "xpath", "context-item", "with-params", ' +
-  '"namespace-context")]'
+const EXPRESSIONS = [
+  'select', 'test', 'use', 'value', 'group-by', 'group-adjacent',
+  'key', 'initial-value', 'xpath', 'context-item', 'with-params',
+  'namespace-context',
+]
+
+/**
+ * Whether the walked node is one of those attributes on an XSLT element. The
+ * walk answers the same set a descendant scan did and answers it linearly
+ * (#635), so the name test that was a predicate inside the XPath is a filter
+ * here.
+ * @param {Node} node - A node of the walk
+ * @return {boolean} - True when it holds an expression to validate
+ */
+const held = function(node) {
+  return node.nodeType === 2 && EXPRESSIONS.includes(node.localName) &&
+    node.ownerElement.namespaceURI === XSLT
+}
 
 /**
  * A reference to an entity left unresolved in a parsed expression — an entity
@@ -68,7 +83,7 @@ const validate = function(corpus, suppressions = []) {
   const defects = []
   const suppressed = suppressions.some((sup) => CHECK.includes(sup))
   for (const source of corpus) {
-    for (const expression of nodes(source.xsl, EXPRESSIONS)) {
+    for (const expression of walked(source.xsl).filter(held)) {
       if (isValid(expression.nodeValue)) {
         expressions.push({source: source, expression: expression})
       } else if (UNRESOLVED.test(expression.nodeValue)) {


### PR DESCRIPTION
Closes #633 and #635.

```text
lines    before      now
   85    0.18 s    0.06 s
  405    1.55 s    0.09 s
 1205   13.62 s    0.32 s
 4005       --     1.86 s
```

Three changes. The first two are #633 and sit in `src/attributes.js`; the third
is #635 and adds `src/tree.js`.

### Eight linters, one list

`expressionsOf` walks every attribute and text node of a stylesheet, and eight
code-based linters asked it for the same list in a single run. At 485 lines that
was 118 ms each and 981 ms of the 1004 ms those linters took between them.

It is remembered against the document, in a `WeakMap` rather than a `Map` keyed by
anything the corpus outlives — the mistake #611's review caught in the line-offset
memo, and worth not repeating in the same file's neighbour. The list is frozen,
since eight callers now share one array.

### Nineteen scans, one scan

`SELECTOR` was `ATTRIBUTES.map(selectorOf).join(' | ')` — nineteen `//` descendant
scans unioned — and that union is where the quadratic term lived:

```text
lines   19-way union   one scan + a filter
   85          26 ms          2 ms
  325         114              7
  805         618             38
 2005        4379            273
```

One scan of every XSLT attribute, filtered by name in JavaScript, answers the
identical set. `selectorOf` stays for the linters that narrow to a single
attribute; it was only asking for all nineteen at once that cost.

### Unchanged output

Every `.xsl` under `test/resources` linted before and after and the reports
diffed — check name, line, column, `from`, and the whole `fix` object:

```text
87 stylesheets, 247 defects, byte-identical
```

That is the evidence the change is invisible; the suite passing is the weaker
claim, and this is the check the last branch taught me to run rather than reason
about.

### A gate that had been failing quietly

`npm run coverage` now exits 0 on my machine. `should test default directory`
lints the whole repository and had been over mocha's ten-second limit under
instrumentation — on master too, so it was not this branch's doing, but it means
the coverage gate had been red locally for anyone whose machine is not as fast as
CI's.

974 tests, 100% branch coverage (922/922), ESLint, xcop, markdownlint and the
fixtures gate clean locally, all read from exit codes rather than through a
filter.

### #635: walk the tree rather than ask XPath to descend it

fontoxpath evaluates a descendant step over an xmldom tree quadratically, and
that was the whole of what remained:

```text
lines    descendant scan    DOM walk    nodes
  165              15 ms      0.2 ms      366
  645              49         0.5        1446
 2005             486         1.7        4506
 4805            3060         2.7       10806
```

Both internal scans walk now — `expressionsOf` and the validator's, whose name
test moves from an XPath predicate to a filter. `expressionsOf` drops from the
dominant stage to 8 ms on a 2405-line stylesheet.

Matching the old node sequence exactly took two details, and I found both by
diffing the sequences across every fixture rather than by reading the spec:
XPath does not count a namespace declaration among an element's attributes
though the DOM lists it, and fontoxpath yields attributes sorted by name where
the DOM gives them as written — `zeta alpha mid` comes back `alpha mid zeta`.
XPath leaves that order to the implementation, so matching it is what keeps this
invisible. Reporting in written order may read better; that is a change to make
deliberately rather than as a side effect of a performance fix.

### What is left, and why it is not this PR

End to end the run improves by less than the scan does. At 2405 lines:

```text
parse                            18 ms
expressionsOf (walk)              8
xpath-validator (walk + isValid) 150
xpath-linter (67 checks' XPath)  509
corpus-linter (checks' XPath)    491
13 code-based linters            570
```

The two largest are the declarative checks' own XPath — that is the check, not a
scan this project chose, so it stays XPath. #635 named `corpus-linter` among the
places to change and that was wrong of me: its scans are `check.declaration` and
`check.usage` straight out of the YAML. Making those cheaper means compiling the
checks differently or a faster engine, which is its own question.

So: 405 lines is 93 ms and comfortable for an editor, 1205 is 320 ms and wants
debouncing, 4005 is 1.9 s and is still felt. Better than 13.6 s, not yet finished.

### Unchanged output, three times over

Every `.xsl` under `test/resources` linted before and after each change, reports
diffed on check name, line, column, `from` and the whole `fix` object:

```text
87 stylesheets, 247 defects, byte-identical
```

974 tests, 100% branch coverage (941/941), and every gate read from its exit code
rather than through a filter.
