### PR TITLE
bug(#615): retry an expression respelled for the engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,12 +374,12 @@ the harness asserts too.
 | `src/xsl-version.js` | `versionOf(node)` — the version in force at a node, from the nearest ancestor's `@version` (XSLT element) or `@xsl:version` (literal result element), canonicalised as a decimal; `since(version, floor)` for a lower-bound gate; shared `MODERN`/`KNOWN`/`DECIMAL` |
 | `src/comparisons.js` | `comparedToZero` — shared scan for a call compared with `0`/`1` (count, string-length) |
 | `src/expressions.js` | `masked`/`closes` lexer helpers (node-set, double-negation, boolean-call); `enclosed` — the expressions an AVT holds in its braces |
-| `src/tokens.js` | Positioned XPath lexer (`tokenized`, `TOKENS`), preserving whitespace; owns `WHITESPACE`, the XML `S` every reader of a gap shares |
+| `src/tokens.js` | Positioned XPath lexer (`tokenized`, `TOKENS`), preserving whitespace; owns `WHITESPACE`, the XML `S` a gap is spelled with, and `spelling`, which answers whether a name runs up to an offset. `src/xpath.js` borrows both; six code-based linters still read a gap as JavaScript's `\s`, which is wider (#643) |
 | `src/import-graph.js` | Resolves `xsl:import`/`xsl:include` hrefs: `importsOf`, `graphOf` |
 | `src/fixers.js` | Maps a declarative check name to a `node => fix` builder |
 | `src/fixes.js` | Shared fix builders (`deletion(attribute)`) |
 | `src/fixer.js` | Applies a defect's `fix` to source (decode-walk, verify-before-apply, end-to-start) |
-| `src/xpath.js` | fontoxpath environment: prefixes, evaluators, `isValid` — which retries the expression respelled when the engine refuses a spelling the grammar allows: the `namespace::` axis, ExprWhitespace around an axis's `::` or in front of a node test's bracket (#615). A squeeze runs only between a step's own parts, so it cannot write the `(:`/`:)` a deleted gap would spell |
+| `src/xpath.js` | fontoxpath environment: prefixes, evaluators, `isValid` — which retries the expression respelled when the engine refuses a spelling the grammar allows: the `namespace::` axis, ExprWhitespace around an axis's `::` or in front of a node test's bracket (#615). A squeeze runs only between a step's own parts, and asks `src/tokens.js`'s `spelling` where a name begins, so the axis of `1-namespace::x` is respelled and the name of `a-namespace::x` is not. What the retry cannot claim is that it only ever widens what the engine accepts: its guards read characters rather than a parse (#641) |
 | `src/helpers.js` | XML parsing (expands internal-subset entities), YAML parsing, file recursion |
 | `src/logger.js` | 4-level logger |
 | `scripts/generate-docs.js` | Builds the `docs/` site from checks + motives |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,7 +379,7 @@ the harness asserts too.
 | `src/fixers.js` | Maps a declarative check name to a `node => fix` builder |
 | `src/fixes.js` | Shared fix builders (`deletion(attribute)`) |
 | `src/fixer.js` | Applies a defect's `fix` to source (decode-walk, verify-before-apply, end-to-start) |
-| `src/xpath.js` | fontoxpath environment: prefixes, evaluators, `isValid` |
+| `src/xpath.js` | fontoxpath environment: prefixes, evaluators, `isValid` — which retries the expression respelled when the engine refuses a spelling the grammar allows: the `namespace::` axis, whitespace around an axis's `::` or a node test's bracket (#615) |
 | `src/helpers.js` | XML parsing (expands internal-subset entities), YAML parsing, file recursion |
 | `src/logger.js` | 4-level logger |
 | `scripts/generate-docs.js` | Builds the `docs/` site from checks + motives |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,12 +374,12 @@ the harness asserts too.
 | `src/xsl-version.js` | `versionOf(node)` — the version in force at a node, from the nearest ancestor's `@version` (XSLT element) or `@xsl:version` (literal result element), canonicalised as a decimal; `since(version, floor)` for a lower-bound gate; shared `MODERN`/`KNOWN`/`DECIMAL` |
 | `src/comparisons.js` | `comparedToZero` — shared scan for a call compared with `0`/`1` (count, string-length) |
 | `src/expressions.js` | `masked`/`closes` lexer helpers (node-set, double-negation, boolean-call); `enclosed` — the expressions an AVT holds in its braces |
-| `src/tokens.js` | Positioned XPath lexer (`tokenized`, `TOKENS`), preserving whitespace |
+| `src/tokens.js` | Positioned XPath lexer (`tokenized`, `TOKENS`), preserving whitespace; owns `WHITESPACE`, the XML `S` every reader of a gap shares |
 | `src/import-graph.js` | Resolves `xsl:import`/`xsl:include` hrefs: `importsOf`, `graphOf` |
 | `src/fixers.js` | Maps a declarative check name to a `node => fix` builder |
 | `src/fixes.js` | Shared fix builders (`deletion(attribute)`) |
 | `src/fixer.js` | Applies a defect's `fix` to source (decode-walk, verify-before-apply, end-to-start) |
-| `src/xpath.js` | fontoxpath environment: prefixes, evaluators, `isValid` — which retries the expression respelled when the engine refuses a spelling the grammar allows: the `namespace::` axis, whitespace around an axis's `::` or a node test's bracket (#615) |
+| `src/xpath.js` | fontoxpath environment: prefixes, evaluators, `isValid` — which retries the expression respelled when the engine refuses a spelling the grammar allows: the `namespace::` axis, ExprWhitespace around an axis's `::` or in front of a node test's bracket (#615). A squeeze runs only between a step's own parts, so it cannot write the `(:`/`:)` a deleted gap would spell |
 | `src/helpers.js` | XML parsing (expands internal-subset entities), YAML parsing, file recursion |
 | `src/logger.js` | 4-level logger |
 | `scripts/generate-docs.js` | Builds the `docs/` site from checks + motives |

--- a/src/resources/motives/validation/invalid-xpath-expression.md
+++ b/src/resources/motives/validation/invalid-xpath-expression.md
@@ -16,7 +16,10 @@ it rejects the implicit string-to-number coercion an XPath 1.0 stylesheet leans
 on — `substring-before($spans, ':') - 1` reads a numeric prefix in 1.0 — but
 that is a dialect difference, not a broken expression, so it is not reported.
 The `namespace::` axis is another such difference — XPath 3.0 dropped it, but
-1.0 and 2.0 define it, so `namespace::*` is left alone. Only genuine syntax
+1.0 and 2.0 define it, so `namespace::*` is left alone. Spacing is one more:
+whitespace stands between any two tokens of an expression, so `child :: a`
+names the step `child::a` names and `parent::node ( )` the one
+`parent::node()` names, and none of them is reported. Only genuine syntax
 mistakes are reported.
 
 Incorrect (`==` is not an XPath operator):

--- a/src/resources/motives/validation/invalid-xpath-expression.md
+++ b/src/resources/motives/validation/invalid-xpath-expression.md
@@ -16,11 +16,11 @@ it rejects the implicit string-to-number coercion an XPath 1.0 stylesheet leans
 on — `substring-before($spans, ':') - 1` reads a numeric prefix in 1.0 — but
 that is a dialect difference, not a broken expression, so it is not reported.
 The `namespace::` axis is another such difference — XPath 3.0 dropped it, but
-1.0 and 2.0 define it, so `namespace::*` is left alone. Spacing is one more:
-whitespace stands between any two tokens of an expression, so `child :: a`
-names the step `child::a` names and `parent::node ( )` the one
-`parent::node()` names, and none of them is reported. Only genuine syntax
-mistakes are reported.
+1.0 and 2.0 define it, so `namespace::*` is left alone. So is a step spaced
+inside itself: a gap around the `::` of an axis, or in front of the bracket of
+a node test, is whitespace the grammar allows, so `child :: a` and
+`parent::node ( )` are read as the steps `child::a` and `parent::node()` name.
+Only genuine syntax mistakes are reported.
 
 Incorrect (`==` is not an XPath operator):
 

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -470,6 +470,7 @@ const tokenized = function(xpath) {
 
 module.exports = {
   tokenized,
+  spelling,
   TOKENS,
   WHITESPACE,
 }

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -62,7 +62,8 @@ const TOKENS = {
 }
 
 /**
- * Characters XPath treats as insignificant whitespace.
+ * Characters XPath treats as insignificant whitespace: XML's `S` production,
+ * which ExprWhitespace is spelled with, and no others.
  * @type {string}
  */
 const WHITESPACE = ' \t\r\n'
@@ -470,4 +471,5 @@ const tokenized = function(xpath) {
 module.exports = {
   tokenized,
   TOKENS,
+  WHITESPACE,
 }

--- a/src/xpath.js
+++ b/src/xpath.js
@@ -7,6 +7,7 @@ const {
   evaluateXPath, evaluateXPathToNodes, evaluateXPathToStrings,
   compileXPathToJavaScript,
 } = require('fontoxpath')
+const {WHITESPACE} = require('./tokens')
 
 /**
  * Namespace URI of the xslint custom XPath functions.
@@ -85,21 +86,44 @@ const strings = function(xsl, xpath) {
 const CODED = /^[A-Z]{4}\d{4}/
 
 /**
- * The namespace axis, which XPath 3.0 dropped but 1.0 and 2.0 define. The
- * engine cannot parse it, so an expression that uses it is rewritten to a
- * supported axis before being retried.
- * @type {RegExp}
+ * One character of ExprWhitespace, which XPath 1.0 §3.7 spells as XML's `S`:
+ * a space, a tab, a carriage return or a newline, and nothing else. The lexer
+ * reads a gap through the same four. A wider class would be wrong rather than
+ * generous, because the six further characters JavaScript's `\s` counts — a
+ * no-break space and an em space among them — stand nowhere in an expression
+ * outside a string literal, so a gap spelled with one is malformed and must
+ * not be respelled into something the engine accepts.
+ * @type {string}
  */
-const NAMESPACE_AXIS = /namespace\s*::/g
+const SPACE = `[${WHITESPACE}]`
 
 /**
- * The axis separator together with the whitespace around it. XPath lexes `::`
- * as one token and allows whitespace between tokens, so `child :: a` names the
- * step `child::a` names, yet the engine reads the spaced spelling as a name
- * followed by rubbish.
- * @type {RegExp}
+ * What may stand where a node test stands: a name, or the wildcard. Nothing
+ * else follows an axis separator, so a gap in front of anything else is not a
+ * gap a step spells.
+ * @type {string}
  */
-const SPACED_AXIS = /\s*::\s*/g
+const TEST = '[*\\p{L}_]'
+
+/**
+ * What may stand inside the brackets of a node test: the closing bracket
+ * itself, a name, a wildcard, or the string literal a
+ * processing-instruction test names.
+ * @type {string}
+ */
+const ARGUMENT = '[)*\'"\\p{L}_]'
+
+/**
+ * A name the AxisName production spells, and the whole of it — an NCName is
+ * read as an axis only when it is one of these thirteen, so a gap behind any
+ * other name is not a gap a step spells.
+ * @type {Array.<string>}
+ */
+const AXES = [
+  'ancestor-or-self', 'ancestor', 'attribute', 'child', 'descendant-or-self',
+  'descendant', 'following-sibling', 'following', 'namespace', 'parent',
+  'preceding-sibling', 'preceding', 'self',
+]
 
 /**
  * The names a node test is spelled with: the four NodeTypes of XPath 1.0, the
@@ -113,18 +137,43 @@ const TESTS = [
 ]
 
 /**
- * A node test's name together with the whitespace between it and its `(`, and
- * whatever follows that bracket. XPath 1.0 §3.7 recognises one of these names
- * as a NodeType when a `(` follows it "possibly after intervening
- * ExprWhitespace", but the engine reads it as an element name unless the
- * bracket is adjacent, and refuses a `(` its `)` does not touch. The names are
- * spelled out rather than taken as any name, because it is only a node test a
- * bracket changes the meaning of; a name that merely ends in one is left
- * alone, so `my-text ()` stays the call it already was.
+ * An axis name spaced from the `::` behind it, up to the node test that
+ * follows. XPath lexes `::` as one token and lets a gap stand on either side,
+ * so `child :: a` names the step `child::a` names, yet the engine reads the
+ * spaced spelling as a name followed by rubbish. The axis in front and the
+ * test behind are both required, because deleting a gap between anything else
+ * writes a token that was not there: `(` next to `::` spells the comment
+ * opener `(:`, and `::` next to `)` the closer `:)`, either of which would
+ * bury a broken expression in a comment the engine skips.
+ * @type {RegExp}
+ */
+const SPACED_AXIS = new RegExp(
+  `(?<![\\w.-])(${AXES.join('|')})${SPACE}*::${SPACE}*(?=${TEST})`, 'gu',
+)
+
+/**
+ * The namespace axis, which XPath 3.0 dropped but 1.0 and 2.0 define. The
+ * engine cannot parse it, so an expression that uses it is rewritten to a
+ * supported axis before being retried. Its own gaps are gone by then, squeezed
+ * out with every other axis's.
+ * @type {RegExp}
+ */
+const NAMESPACE_AXIS = /(?<![\w.-])namespace::/g
+
+/**
+ * A node test's name spaced from its `(`, up to what the brackets hold. XPath
+ * 1.0 §3.7 recognises one of these names as a NodeType when a `(` follows it
+ * "possibly after intervening ExprWhitespace", but the engine reads it as an
+ * element name unless the bracket is adjacent, and refuses a `(` its `)` does
+ * not touch. The names are spelled out rather than taken as any name, because
+ * it is only a node test a bracket changes the meaning of; a name that merely
+ * ends in one is left alone, so `my-text ()` stays the call it already was.
+ * What the brackets hold is required for the same reason the axis is: a `(`
+ * pulled onto a `:` would spell a comment opener.
  * @type {RegExp}
  */
 const SPACED_TEST = new RegExp(
-  `(^|[^\\w.-])(${TESTS.join('|')})\\s*\\(\\s*`, 'g',
+  `(?<![\\w.-])(${TESTS.join('|')})${SPACE}*\\(${SPACE}*(?=${ARGUMENT})`, 'gu',
 )
 
 /**
@@ -151,20 +200,21 @@ const compiles = function(xpath) {
 }
 
 /**
- * The expression respelled the one way the engine reads it: the namespace axis
- * rewritten to a supported one, the whitespace around an axis separator and
- * around the bracket of a node test squeezed out. Every one of these is a
- * spelling the grammar allows and the engine alone refuses, and squeezing
- * whitespace out of a step cannot make a broken expression whole — `child ::`
- * still has no node test once its gap is gone.
+ * The expression respelled the one way the engine reads it: an axis pulled
+ * onto its separator, a node test onto its bracket, and the namespace axis
+ * rewritten to a supported one — in that order, so the rewrite meets a
+ * separator whose gaps are already gone. Each squeeze runs between a step's
+ * own parts and nowhere else, so it deletes a gap the grammar allows and never
+ * writes a token: what surrounds the gap reads as a step before the squeeze
+ * and after it, which is why a broken expression cannot come out whole.
  * @param {string} xpath - Xpath expression
  * @return {string} - The same expression, spelled for the engine
  */
 const squeezed = function(xpath) {
   return xpath
+    .replace(SPACED_AXIS, '$1::')
     .replace(NAMESPACE_AXIS, 'child::')
-    .replace(SPACED_AXIS, '::')
-    .replace(SPACED_TEST, '$1$2(')
+    .replace(SPACED_TEST, '$1(')
 }
 
 /**
@@ -172,9 +222,9 @@ const squeezed = function(xpath) {
  * runs the rules parses it, so an expression is valid here exactly when the
  * processor can parse it. Every prefix resolves, isolating syntax from
  * unresolved-prefix errors. What the engine refuses yet the grammar spells —
- * the namespace axis of the older dialects, whitespace around an axis
- * separator or a node test's bracket (#615) — is retried respelled, and an
- * expression the respelling gets through is valid too.
+ * the namespace axis of the older dialects, ExprWhitespace around an axis
+ * separator or in front of a node test's bracket (#615) — is retried
+ * respelled, and an expression the respelling gets through is valid too.
  * @param {string} xpath - Xpath expression
  * @return {boolean} - True when the expression parses
  */

--- a/src/xpath.js
+++ b/src/xpath.js
@@ -90,7 +90,42 @@ const CODED = /^[A-Z]{4}\d{4}/
  * supported axis before being retried.
  * @type {RegExp}
  */
-const NAMESPACE_AXIS = /namespace\s*::/
+const NAMESPACE_AXIS = /namespace\s*::/g
+
+/**
+ * The axis separator together with the whitespace around it. XPath lexes `::`
+ * as one token and allows whitespace between tokens, so `child :: a` names the
+ * step `child::a` names, yet the engine reads the spaced spelling as a name
+ * followed by rubbish.
+ * @type {RegExp}
+ */
+const SPACED_AXIS = /\s*::\s*/g
+
+/**
+ * The names a node test is spelled with: the four NodeTypes of XPath 1.0, the
+ * kind tests 2.0 added, and the one 3.0 added.
+ * @type {Array.<string>}
+ */
+const TESTS = [
+  'node', 'text', 'comment', 'processing-instruction',
+  'document-node', 'element', 'attribute', 'schema-element',
+  'schema-attribute', 'namespace-node',
+]
+
+/**
+ * A node test's name together with the whitespace between it and its `(`, and
+ * whatever follows that bracket. XPath 1.0 §3.7 recognises one of these names
+ * as a NodeType when a `(` follows it "possibly after intervening
+ * ExprWhitespace", but the engine reads it as an element name unless the
+ * bracket is adjacent, and refuses a `(` its `)` does not touch. The names are
+ * spelled out rather than taken as any name, because it is only a node test a
+ * bracket changes the meaning of; a name that merely ends in one is left
+ * alone, so `my-text ()` stays the call it already was.
+ * @type {RegExp}
+ */
+const SPACED_TEST = new RegExp(
+  `(^|[^\\w.-])(${TESTS.join('|')})\\s*\\(\\s*`, 'g',
+)
 
 /**
  * Whether the engine compiles the expression, counting a static-type
@@ -116,19 +151,35 @@ const compiles = function(xpath) {
 }
 
 /**
+ * The expression respelled the one way the engine reads it: the namespace axis
+ * rewritten to a supported one, the whitespace around an axis separator and
+ * around the bracket of a node test squeezed out. Every one of these is a
+ * spelling the grammar allows and the engine alone refuses, and squeezing
+ * whitespace out of a step cannot make a broken expression whole — `child ::`
+ * still has no node test once its gap is gone.
+ * @param {string} xpath - Xpath expression
+ * @return {string} - The same expression, spelled for the engine
+ */
+const squeezed = function(xpath) {
+  return xpath
+    .replace(NAMESPACE_AXIS, 'child::')
+    .replace(SPACED_AXIS, '::')
+    .replace(SPACED_TEST, '$1$2(')
+}
+
+/**
  * Whether given Xpath expression is syntactically valid. The same engine that
  * runs the rules parses it, so an expression is valid here exactly when the
  * processor can parse it. Every prefix resolves, isolating syntax from
- * unresolved-prefix errors. The namespace axis is the one construct the engine
- * cannot parse yet the older dialects allow, so an expression that parses once
- * its namespace:: axis is rewritten to a supported one is valid too.
+ * unresolved-prefix errors. What the engine refuses yet the grammar spells —
+ * the namespace axis of the older dialects, whitespace around an axis
+ * separator or a node test's bracket (#615) — is retried respelled, and an
+ * expression the respelling gets through is valid too.
  * @param {string} xpath - Xpath expression
  * @return {boolean} - True when the expression parses
  */
 const isValid = function(xpath) {
-  return compiles(xpath) ||
-    (NAMESPACE_AXIS.test(xpath) &&
-      compiles(xpath.replace(/namespace\s*::/g, 'child::')))
+  return compiles(xpath) || compiles(squeezed(xpath))
 }
 
 module.exports = {

--- a/src/xpath.js
+++ b/src/xpath.js
@@ -7,7 +7,7 @@ const {
   evaluateXPath, evaluateXPathToNodes, evaluateXPathToStrings,
   compileXPathToJavaScript,
 } = require('fontoxpath')
-const {WHITESPACE} = require('./tokens')
+const {WHITESPACE, spelling} = require('./tokens')
 
 /**
  * Namespace URI of the xslint custom XPath functions.
@@ -89,10 +89,10 @@ const CODED = /^[A-Z]{4}\d{4}/
  * One character of ExprWhitespace, which XPath 1.0 §3.7 spells as XML's `S`:
  * a space, a tab, a carriage return or a newline, and nothing else. The lexer
  * reads a gap through the same four. A wider class would be wrong rather than
- * generous, because the six further characters JavaScript's `\s` counts — a
- * no-break space and an em space among them — stand nowhere in an expression
- * outside a string literal, so a gap spelled with one is malformed and must
- * not be respelled into something the engine accepts.
+ * generous, because the twenty-one further characters JavaScript's `\s` counts
+ * — a no-break space and an em space among them — stand nowhere in an
+ * expression outside a string literal, so a gap spelled with one is malformed
+ * and must not be respelled into something the engine accepts.
  * @type {string}
  */
 const SPACE = `[${WHITESPACE}]`
@@ -148,7 +148,7 @@ const TESTS = [
  * @type {RegExp}
  */
 const SPACED_AXIS = new RegExp(
-  `(?<![\\w.-])(${AXES.join('|')})${SPACE}*::${SPACE}*(?=${TEST})`, 'gu',
+  `(${AXES.join('|')})${SPACE}*::${SPACE}*(?=${TEST})`, 'gu',
 )
 
 /**
@@ -158,7 +158,7 @@ const SPACED_AXIS = new RegExp(
  * out with every other axis's.
  * @type {RegExp}
  */
-const NAMESPACE_AXIS = /(?<![\w.-])namespace::/g
+const NAMESPACE_AXIS = /(namespace)::/g
 
 /**
  * A node test's name spaced from its `(`, up to what the brackets hold. XPath
@@ -173,7 +173,7 @@ const NAMESPACE_AXIS = /(?<![\w.-])namespace::/g
  * @type {RegExp}
  */
 const SPACED_TEST = new RegExp(
-  `(?<![\\w.-])(${TESTS.join('|')})${SPACE}*\\(${SPACE}*(?=${ARGUMENT})`, 'gu',
+  `(${TESTS.join('|')})${SPACE}*\\(${SPACE}*(?=${ARGUMENT})`, 'gu',
 )
 
 /**
@@ -200,21 +200,74 @@ const compiles = function(xpath) {
 }
 
 /**
- * The expression respelled the one way the engine reads it: an axis pulled
- * onto its separator, a node test onto its bracket, and the namespace axis
- * rewritten to a supported one — in that order, so the rewrite meets a
- * separator whose gaps are already gone. Each squeeze runs between a step's
- * own parts and nowhere else, so it deletes a gap the grammar allows and never
- * writes a token: what surrounds the gap reads as a step before the squeeze
- * and after it, which is why a broken expression cannot come out whole.
+ * The same expression with each match of the pattern rewritten, except where a
+ * name is still being spelled in front of it. A `-` continues a name a letter
+ * started and subtracts everywhere else, and no lookbehind can tell the two
+ * apart, because it reads characters where the question is about tokens. The
+ * lexer answers it instead: `spelling` walks the run of name characters back
+ * and asks whether it begins the way a name may, so the `namespace` of
+ * `a-namespace::x` is the tail of one name and is left alone, while the one in
+ * `1-namespace::x` stands behind a minus and opens a step of its own.
+ * @param {string} xpath - Xpath expression
+ * @param {RegExp} pattern - Pattern whose first group is the name it opens on
+ * @param {function(string): string} replacement - What that name becomes
+ * @param {function(string, number): boolean} swallowed - Whether a longer name
+ *  takes the match in, leaving nothing of its own to respell
+ * @return {string} - The expression rewritten wherever no name runs into it
+ */
+const rewritten = function(xpath, pattern, replacement, swallowed) {
+  return xpath.replace(
+    pattern,
+    (match, name, at) => swallowed(xpath, at) ? match : replacement(name),
+  )
+}
+
+/**
+ * Whether the node test's name at the offset is the tail of a longer name
+ * rather than a test standing on its own. `spelling` answers most of it, but a
+ * `:` is a name character to the lexer — a QName carries one — and the `::`
+ * that puts a node test where it stands is an axis separator, not a name. So
+ * the `node` of `parent::node ()` opens a test though a name reads back from
+ * it, while the `text` of `my-text ()` is the end of one name. A prefixed name
+ * loses nothing by the exception: the engine compiles `my:node ( )` outright.
+ * @param {string} xpath - Xpath expression
+ * @param {number} at - Offset the name opens at
+ * @return {boolean} - True when a longer name swallows the test
+ */
+const tailed = function(xpath, at) {
+  return spelling(xpath, at) && xpath[at - 1] !== ':'
+}
+
+/**
+ * The respellings, in the order they run: an axis pulled onto its separator,
+ * the namespace axis then rewritten to a supported one — second, so the
+ * rewrite meets a separator whose gaps are already gone — and a node test
+ * pulled onto its bracket last.
+ * @type {Array.<Array>}
+ */
+const SQUEEZES = [
+  [SPACED_AXIS, (name) => `${name}::`, spelling],
+  [NAMESPACE_AXIS, () => 'child::', spelling],
+  [SPACED_TEST, (name) => `${name}(`, tailed],
+]
+
+/**
+ * The expression respelled the one way the engine reads it. Each squeeze runs
+ * between a step's own parts and nowhere else, so the gap it deletes is one the
+ * grammar lets stand there, and the tests hold every merge a deletion elsewhere
+ * would spell. What the retry cannot claim is that it only ever widens what is
+ * accepted: its guards are a regex over characters and one borrowed lexer
+ * question, not a parse, so an expression it declines to respell is refused on
+ * the engine's word alone. #641 tracks what that costs.
  * @param {string} xpath - Xpath expression
  * @return {string} - The same expression, spelled for the engine
  */
 const squeezed = function(xpath) {
-  return xpath
-    .replace(SPACED_AXIS, '$1::')
-    .replace(NAMESPACE_AXIS, 'child::')
-    .replace(SPACED_TEST, '$1(')
+  return SQUEEZES.reduce(
+    (expression, [pattern, replacement, swallowed]) =>
+      rewritten(expression, pattern, replacement, swallowed),
+    xpath,
+  )
 }
 
 /**

--- a/test/resources/xpath-validator-packs/valid-spaced-axis.yaml
+++ b/test/resources/xpath-validator-packs/valid-spaced-axis.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: invalid-xpath-expression
+found:
+  amount: 0
+  positions: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:template match="/">
+      <xsl:for-each select="child ::o">
+        <xsl:value-of select="ancestor:: b"/>
+        <xsl:if test="count(parent::node ()) = 1">
+          <xsl:value-of select="self :: node ( )"/>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/xpath.test.js
+++ b/test/xpath.test.js
@@ -6,6 +6,41 @@
 const {isValid} = require('../src/xpath')
 const assert = require('assert')
 
+/**
+ * Expressions XPath 1.0 §3.7 spells with whitespace an axis name or a node
+ * test may be followed by, each paired with the place that whitespace sits in.
+ * @type {Array.<Array.<string>>}
+ */
+const SPACED = [
+  ['child ::a', 'in front of an axis separator'],
+  ['child:: a', 'behind an axis separator'],
+  ['child  ::  a', 'on both sides of an axis separator'],
+  ['a[child :: b]', 'around an axis separator inside a predicate'],
+  ['descendant ::b/child ::c/parent ::d', 'around every separator of a path'],
+  ['namespace :: *', 'around the separator of the namespace axis'],
+  ['count(//a[parent :: b]) = 1', 'around a separator buried in a call'],
+  ['parent::node ()', 'in front of the bracket of a node test'],
+  ['parent::node( )', 'inside an empty node test'],
+  ['parent::node ( )', 'on both sides of the bracket of an empty node test'],
+  ['a/text ()[1]', 'in front of the bracket of a text test'],
+  ['comment ()|child::comment ()', 'in front of every comment test'],
+  ['processing-instruction (\'x\')', 'in front of the bracket of a named test'],
+  ['child::namespace-node ()', 'in front of the bracket of a namespace test'],
+  ['. instance of node ()', 'in front of a node test in a sequence type'],
+  ['self :: node ()', 'around both a separator and the bracket after it'],
+]
+
+/**
+ * Expressions no spelling of the grammar reaches, each paired with what makes
+ * it broken.
+ * @type {Array.<Array.<string>>}
+ */
+const REFUSED = [
+  ['child ::', 'an axis that no node test follows'],
+  ['//foo ::bar', 'a name that names no axis'],
+  ['parent::node (', 'a node test that never closes'],
+]
+
 describe('xpath', function() {
   it('accepts a syntactically valid expression', function() {
     assert.ok(isValid('count(//o) = 2'))
@@ -18,5 +53,21 @@ describe('xpath', function() {
   })
   it('resolves a non-standard namespace prefix rather than failing', function() {
     assert.ok(isValid('zq:thing'))
+  })
+  SPACED.forEach(function([xpath, where]) {
+    it(`accepts whitespace ${where}`, function() {
+      assert.ok(
+        isValid(xpath),
+        `${xpath} is refused, though XPath spells whitespace ${where}`,
+      )
+    })
+  })
+  REFUSED.forEach(function([xpath, what]) {
+    it(`cannot accept ${what}`, function() {
+      assert.ok(
+        !isValid(xpath),
+        `${xpath} passes, though it carries ${what}`,
+      )
+    })
   })
 })

--- a/test/xpath.test.js
+++ b/test/xpath.test.js
@@ -28,17 +28,44 @@ const SPACED = [
   ['child::namespace-node ()', 'in front of the bracket of a namespace test'],
   ['. instance of node ()', 'in front of a node test in a sequence type'],
   ['self :: node ()', 'around both a separator and the bracket after it'],
+  ['child\t::a', 'spelled as the tab it may also be'],
+  ['child\n::a', 'spelled as the newline a wrapped attribute puts there'],
+  ['child :: *', 'in front of a wildcard node test'],
+  ['element (*)', 'in front of the bracket of a wildcard kind test'],
+  ['document-node (element(a))', 'in front of the bracket of a nested test'],
+]
+
+/**
+ * Expressions whose gap is one of the characters JavaScript counts as
+ * whitespace and XML's `S` production does not, each paired with the gap and
+ * the place it sits in. No name may carry the character either, so the
+ * expression is malformed however it is read.
+ * @type {Array.<Array.<string>>}
+ */
+const ALIEN = [
+  ['child\u00a0::alpha', 'a no-break space in front of a separator'],
+  ['parent::node\u00a0()', 'a no-break space in front of a test bracket'],
+  ['namespace\u00a0::x', 'a no-break space in the namespace axis'],
+  ['child\u2003::alpha', 'an em space in front of a separator'],
+  ['parent::node(\u000b)', 'a vertical tab inside a node test'],
 ]
 
 /**
  * Expressions no spelling of the grammar reaches, each paired with what makes
- * it broken.
+ * it broken. The comments among them are the token merges a squeeze must not
+ * make: `(:` and `:)` are one token each, so a gap deleted between a bracket
+ * and a colon would fabricate a comment and hide the wreckage inside it.
  * @type {Array.<Array.<string>>}
  */
 const REFUSED = [
   ['child ::', 'an axis that no node test follows'],
   ['//foo ::bar', 'a name that names no axis'],
   ['parent::node (', 'a node test that never closes'],
+  ['a (: b :: )', 'a comment that never closes'],
+  ['a ( :: b :)', 'a bracket that never closes'],
+  ['a (: b namespace :: )', 'a comment the namespace axis stands in'],
+  ['count(node ( :) 1 :) )', 'a colon a node test brackets'],
+  ['a[text ( :) + :) ]', 'a colon a node test brackets in a predicate'],
 ]
 
 describe('xpath', function() {
@@ -59,6 +86,14 @@ describe('xpath', function() {
       assert.ok(
         isValid(xpath),
         `${xpath} is refused, though XPath spells whitespace ${where}`,
+      )
+    })
+  })
+  ALIEN.forEach(function([xpath, gap]) {
+    it(`cannot accept ${gap}`, function() {
+      assert.ok(
+        !isValid(xpath),
+        `${gap} passes, though XPath spells a gap with XML whitespace alone`,
       )
     })
   })

--- a/test/xpath.test.js
+++ b/test/xpath.test.js
@@ -31,8 +31,36 @@ const SPACED = [
   ['child\t::a', 'spelled as the tab it may also be'],
   ['child\n::a', 'spelled as the newline a wrapped attribute puts there'],
   ['child :: *', 'in front of a wildcard node test'],
-  ['element (*)', 'in front of the bracket of a wildcard kind test'],
   ['document-node (element(a))', 'in front of the bracket of a nested test'],
+]
+
+/**
+ * Expressions whose axis stands behind a `-`, each paired with what the `-`
+ * subtracts from. A `-` continues a name a letter started and is the operator
+ * everywhere else, so the axis behind one opens a step and must be respelled
+ * like any other. The pair below them is the name the same characters spell
+ * when a letter does start the run.
+ * @type {Array.<Array.<string>>}
+ */
+const OPERATED = [
+  ['1-namespace::x', 'a number'],
+  ['count(a)-namespace::x', 'a call'],
+  ['\'s\'-namespace::x', 'a string'],
+  ['a -namespace::x', 'a name a gap stands behind'],
+  ['-namespace::x', 'nothing, being unary'],
+  ['1-child ::a', 'a number, in front of a spaced axis'],
+  ['count(a)-parent ::b', 'a call, in front of a spaced axis'],
+]
+
+/**
+ * Expressions whose `-` continues a name rather than subtracting, each paired
+ * with the name it continues. No axis opens inside a name, so none of these is
+ * respelled and the engine's refusal stands.
+ * @type {Array.<Array.<string>>}
+ */
+const NAMED = [
+  ['a-namespace::x', 'a-namespace'],
+  ['a-child::x', 'a-child'],
 ]
 
 /**
@@ -102,6 +130,22 @@ describe('xpath', function() {
       assert.ok(
         !isValid(xpath),
         `${xpath} passes, though it carries ${what}`,
+      )
+    })
+  })
+  OPERATED.forEach(function([xpath, from]) {
+    it(`accepts an axis behind a minus that subtracts from ${from}`, function() {
+      assert.ok(
+        isValid(xpath),
+        `${xpath} is refused, though its minus subtracts from ${from}`,
+      )
+    })
+  })
+  NAMED.forEach(function([xpath, name]) {
+    it(`reads no axis inside the name ${name}`, function() {
+      assert.ok(
+        !isValid(xpath),
+        `${xpath} passes, though ${name} is one name and names no axis`,
       )
     })
   })


### PR DESCRIPTION
Closes #615, the half of it that is fontoxpath's.

`isValid` handed the expression to fontoxpath and took the answer as final,
with one carve-out for the namespace axis. The engine will not lex an axis name
across a gap, nor a node test whose bracket does not touch its name, so
`select="child ::a"` and `test="count(parent::node ()) = 1"` came back
`invalid-xpath-expression` — an error printed beside the `unabbreviated-axis`
defect the very same run reported and `--fix` shortened correctly. XPath 1.0
§3.7 spells both out: an NCName is an AxisName when `::` follows it "possibly
after intervening ExprWhitespace", and a NodeType when `(` does.

The retry the namespace axis already used is now one respelling of the whole
expression, tried when the engine refuses the way it was written. Each of the
three runs between a step's own parts and nowhere else, and each asks the lexer
where a name begins before it touches anything:

```js
const SQUEEZES = [
  [SPACED_AXIS, (name) => `${name}::`, spelling],
  [NAMESPACE_AXIS, () => 'child::', spelling],
  [SPACED_TEST, (name) => `${name}(`, tailed],
]
```

That guard is the whole of the design. A gap is deleted only between one of the
thirteen `AxisName`s and its `::`, or one of the ten node-test names and its
`(`, with what follows required in both cases — a gap deleted anywhere else
writes a token that was not there, since `(:` and `:)` are the comment
delimiters, and a gap spelled with a no-break space is malformed rather than
spaced, so the class is XML's `S` and not JavaScript's `\s`.

The name boundary comes from `src/tokens.js`. A `-` continues a name that a
letter started and is the subtraction operator everywhere else, and no
lookbehind can tell those apart, because it reads characters where the question
is about tokens: an earlier revision of this branch used one and reported
`1-namespace::x`, which is legal XPath that `master` accepts. `spelling` walks
the run of name characters back and asks whether it *begins* the way a name may,
which is the same question `opensAxis` already asks, so `a-namespace::x` is one
name and left alone while `1-namespace::x` and `count(a)-parent ::b` are steps
and are respelled. The node-test position asks `tailed` — `spelling`, except
that a `:` in front is an axis separator rather than a name, so
`parent::node ()` still squeezes.

A full rebuild from the token stream, the other route offered, is deliberately
not what landed: `src/tokens.js` lexes `element ( a )` as `e` / `le` / `ment`
(#617, an operator inside a name), so rebuilding from tokens would refuse two
expressions that pass today. The lexer is borrowed for the boundary question it
answers correctly, not for the tokenisation.

The retry makes no claim to widen only. Its guards read characters rather than a
parse, and #641 tracks what that leaves; the docblock and `CLAUDE.md` say so
rather than promising a broken expression cannot come out whole.

Evidence, since the bar is no false positives: over 11,880 expressions — 11
heads including `1-`, `count(a)-`, `-`, `a -`, `my-`, `my:`, a complete comment
and a bare `:`, against 4 axes, 3 gaps on each side of the `::`, 6 node tests
and 5 tails — there is **no** expression `master` accepts and this branch
refuses. Of the 1,848 newly accepted, every one carrying a `(:` or `:)` holds a
balanced pair the source already had, and none is unbalanced, which is the shape
a fabricated delimiter would take. `npm test` 768 passing, `npm run coverage`
100% of statements, branches, functions and lines.

Left out, and recorded rather than shrugged off: whitespace in front of the `)`
of a kind test that carries an argument and the sequence-type keywords, so
`element( a )` and `item ()` are still refused (#639); the gap in front of an
axis's `::` that `redundant-whitespace` misses now that the expression reaches
it at all (#642 — the defect is in `opensAxis` and `redundancies`, not in the
validator); and the six code-based linters that still read a gap as `\s` (#643),
which is #636 reached by a second route. This unblocks #636, which waited on it.
