### PR TITLE
bug(#636): offer no fix on an expression the validator refused

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,12 @@ the harness asserts too.
   `xslint-disable-line`, `xslint-disable-file`, each with optional space-separated
   rule names (`src/directives.js`); an unused directive is reported.
 - **Fix tiers**: a defect is fixable when it carries
-  `fix: {line, col, value, replacement, suggestion?}`. A *safe* fix
+  `fix: {line, col, value, replacement, suggestion?}`, and only when the
+  expression it stands in parses. A code-based linter still reads an expression
+  the XPath validator refused — it takes the whole corpus, not the validated
+  part — so it still reports what it finds there, but `defect` withholds the
+  fix, because rewriting text no processor parses is how `select="child::"`
+  became `select=""` (#636). A *safe* fix
   (deterministic, semantics-preserving) is applied by `--fix`; a
   `suggestion: true` fix (changes behavior, or is one of several corrections) is
   applied only by `--fix-suggestions`. `--fix-dry-run` writes nothing.
@@ -368,7 +373,7 @@ the harness asserts too.
 | `src/xpath-linter.js` | Loads `checks/xpath/*.yaml`; attaches any `src/fixers.js` fix |
 | `src/corpus-linter.js` | Loads `checks/corpus/*.yaml`; cross-file rules |
 | `src/*-linter.js` | Code-based `checks/format/*.yaml`, one construct each (axis, namespace, count, name, ...); see the flow diagram |
-| `src/checks.js` | Shared for code-based linters: `metaOf`, `suppressed`, `defect(check, meta, source, node, offset, fix)` — walks the raw text so a wrapped or entity-shifted value reports where it truly stands (#611) |
+| `src/checks.js` | Shared for code-based linters: `metaOf`, `suppressed`, `defect(check, meta, source, node, offset, expression, fix)` — walks the raw text so a wrapped or entity-shifted value reports where it truly stands (#611), and drops the `fix` when `expression` does not parse (#636) |
 | `src/source.js` | Raw-text walking shared by `checks` and `fixer`: `offsetAt`, `placeAt`, `character`, `skip` |
 | `src/attributes.js` | `expressionsOf(xsl)` — every expression a stylesheet carries: a bare/AVT attribute, a 3.0 text value template, or a shadow attribute, each saying whether it is a `pattern`; `PATTERNS` names the five attributes that hold one; `selectorOf(name)` for a linter that narrows |
 | `src/xsl-version.js` | `versionOf(node)` — the version in force at a node, from the nearest ancestor's `@version` (XSLT element) or `@xsl:version` (literal result element), canonicalised as a decimal; `since(version, floor)` for a lower-bound gate; shared `MODERN`/`KNOWN`/`DECIMAL` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,12 +342,14 @@ the harness asserts too.
   `xslint-disable-line`, `xslint-disable-file`, each with optional space-separated
   rule names (`src/directives.js`); an unused directive is reported.
 - **Fix tiers**: a defect is fixable when it carries
-  `fix: {line, col, value, replacement, suggestion?}`, and only when the
-  expression it stands in parses. A code-based linter still reads an expression
-  the XPath validator refused — it takes the whole corpus, not the validated
-  part — so it still reports what it finds there, but `defect` withholds the
-  fix, because rewriting text no processor parses is how `select="child::"`
-  became `select=""` (#636). A *safe* fix
+  `fix: {line, col, value, replacement, suggestion?}`. A code-based linter still
+  reads an expression the XPath validator refused — it takes the whole corpus,
+  not the validated part — so it still reports what it finds there, but `defect`
+  withholds the fix, because rewriting text no processor parses is how
+  `select="child::"` became `select=""` (#636). That gate lives in `defect`, so
+  it covers the code-based linters only: a declarative fix from `src/fixers.js`
+  is attached in `src/xpath-linter.js`, never passes through `defect`, and is
+  still offered on an expression that does not parse (#651). A *safe* fix
   (deterministic, semantics-preserving) is applied by `--fix`; a
   `suggestion: true` fix (changes behavior, or is one of several corrections) is
   applied only by `--fix-suggestions`. `--fix-dry-run` writes nothing.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,12 @@ Checks whose correction needs real judgment (a fresh name, a more specific
 path) stay report-only. A run without `--fix` reports how many defects each
 option would fix.
 
+An expression xslint cannot parse is never rewritten. It is reported as
+`invalid-xpath-expression`, and any other defect standing in it is reported
+too, but with no correction offered: a stylesheet whose real fault is a missing
+bracket should come back with that fault and nothing else changed. Fix the
+syntax and the corrections appear on the next run.
+
 Where two corrections cover the same piece of an expression — the redundant
 whitespace in `d[position()  =  1]` sits inside the predicate that becomes
 `d[1]` — only the wider one is applied, and the other is announced as skipped.

--- a/README.md
+++ b/README.md
@@ -345,11 +345,14 @@ Checks whose correction needs real judgment (a fresh name, a more specific
 path) stay report-only. A run without `--fix` reports how many defects each
 option would fix.
 
-An expression xslint cannot parse is never rewritten. It is reported as
-`invalid-xpath-expression`, and any other defect standing in it is reported
-too, but with no correction offered: a stylesheet whose real fault is a missing
-bracket should come back with that fault and nothing else changed. Fix the
-syntax and the corrections appear on the next run.
+An expression xslint cannot parse is reported as `invalid-xpath-expression`,
+and the checks that read the expression itself — the axis, count, name,
+translate and whitespace family — report what they find in it without offering a
+correction. A stylesheet whose real fault is a missing bracket should come back
+with that fault and nothing else changed, so fix the syntax and the corrections
+appear on the next run. The checks that match on the attribute rather than on
+the expression inside it still offer their corrections there, which is tracked
+in [#651](https://github.com/xslint/xslint/issues/651).
 
 Where two corrections cover the same piece of an expression — the redundant
 whitespace in `d[position()  =  1]` sits inside the predicate that becomes

--- a/src/checks.js
+++ b/src/checks.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+const {isValid} = require('./xpath')
 const {yaml} = require('./helpers')
 const {offsetAt, placeAt, skip} = require('./source')
 const path = require('path')
@@ -54,11 +55,15 @@ const LEAD = {2: 1, 4: '<![CDATA['.length}
  *  normalised away are still visible
  * @param {Node} node - The attribute, text, or CDATA node
  * @param {number} offset - Offset of the defect within the node value
+ * @param {string} expression - The expression the defect stands in, whose own
+ *  text decides whether a fix may be offered at all
  * @param {?{value: string, replacement: string, suggestion?: boolean}} [fix] -
  *  The fix, or undefined for a report-only defect
  * @return {object} - Defect
  */
-const defect = function(check, meta, source, node, offset, fix = undefined) {
+const defect = function(
+  check, meta, source, node, offset, expression, fix = undefined,
+) {
   const {line, pos} = placeAt(
     source.content,
     skip(
@@ -68,7 +73,7 @@ const defect = function(check, meta, source, node, offset, fix = undefined) {
       offset,
     ),
   )
-  const anchored = fix === undefined ?
+  const anchored = fix === undefined || !isValid(expression) ?
     undefined :
     {line: line, col: pos, ...fix}
   return {

--- a/src/count-linter.js
+++ b/src/count-linter.js
@@ -112,7 +112,7 @@ const lintByCount = function(corpus, suppressions = []) {
           const whole = node.nodeName === 'test' &&
             node.nodeValue.trim() === value
           defects.push(
-            defect(CHECK, META, source, node, start + offset, {
+            defect(CHECK, META, source, node, start + offset, expression, {
               value: value,
               replacement: rewritten(test, argument, modern, whole),
             }),

--- a/src/name-linter.js
+++ b/src/name-linter.js
@@ -139,7 +139,7 @@ const lintByName = function(corpus, suppressions = []) {
           expression, modern,
         )) {
           defects.push(
-            defect(CHECK, META, source, node, start + offset,
+            defect(CHECK, META, source, node, start + offset, expression,
               replacement === null ?
                 undefined : {value, replacement, suggestion: true},
             ),

--- a/src/node-set-linter.js
+++ b/src/node-set-linter.js
@@ -83,7 +83,8 @@ const lintByNodeSet = function(corpus, suppressions = []) {
           )) {
             defects.push(
               defect(
-                CHECK, META, source, attribute, offset, {value, replacement},
+                CHECK, META, source, attribute, offset, attribute.nodeValue,
+                {value, replacement},
               ),
             )
           }

--- a/src/predicate-position-linter.js
+++ b/src/predicate-position-linter.js
@@ -127,7 +127,8 @@ const lintByPredicatePosition = function(corpus, suppressions = []) {
         for (const {offset, value, replacement} of literals(expression)) {
           defects.push(
             defect(
-              CHECK, META, source, node, start + offset, {value, replacement},
+              CHECK, META, source, node, start + offset, expression,
+              {value, replacement},
             ),
           )
         }

--- a/src/redundant-boolean-call-linter.js
+++ b/src/redundant-boolean-call-linter.js
@@ -81,10 +81,11 @@ const lintByBooleanCall = function(corpus, suppressions = []) {
         const strip = stripped(attribute.nodeValue)
         if (strip) {
           defects.push(
-            defect(CHECK, META, source, attribute, strip.offset, {
-              value: strip.value,
-              replacement: strip.replacement,
-            }),
+            defect(
+              CHECK, META, source, attribute, strip.offset,
+              attribute.nodeValue,
+              {value: strip.value, replacement: strip.replacement},
+            ),
           )
         }
       }

--- a/src/redundant-double-negation-linter.js
+++ b/src/redundant-double-negation-linter.js
@@ -97,7 +97,7 @@ const lintByDoubleNegation = function(corpus, suppressions = []) {
           const bare = node.nodeName === 'test' &&
             node.nodeValue.trim() === value
           defects.push(
-            defect(CHECK, META, source, node, start + offset, {
+            defect(CHECK, META, source, node, start + offset, expression, {
               value: value,
               replacement: bare ? argument : `boolean(${argument})`,
             }),

--- a/src/string-length-linter.js
+++ b/src/string-length-linter.js
@@ -118,7 +118,7 @@ const lintByStringLength = function(corpus, suppressions = []) {
       for (const {node, start, expression} of expressionsOf(source.xsl)) {
         for (const {offset, value, replacement} of comparisons(expression)) {
           defects.push(
-            defect(CHECK, META, source, node, start + offset,
+            defect(CHECK, META, source, node, start + offset, expression,
               replacement === null ?
                 undefined : {value, replacement, suggestion: true},
             ),

--- a/src/translate-linter.js
+++ b/src/translate-linter.js
@@ -145,7 +145,7 @@ const lintByTranslate = function(corpus, suppressions = []) {
         if (since(versionOf(node), MODERN)) {
           for (const {offset, value, replacement} of folded(expression)) {
             defects.push(
-              defect(CHECK, META, source, node, start + offset,
+              defect(CHECK, META, source, node, start + offset, expression,
                 {value, replacement, suggestion: true},
               ),
             )

--- a/src/using-namespace-axis-linter.js
+++ b/src/using-namespace-axis-linter.js
@@ -58,7 +58,9 @@ const lintByNamespaceAxis = function(corpus, suppressions = []) {
       for (const {node, start, expression} of expressionsOf(source.xsl)) {
         if (since(versionOf(node), MODERN)) {
           for (const offset of axes(expression)) {
-            defects.push(defect(CHECK, META, source, node, start + offset))
+            defects.push(
+              defect(CHECK, META, source, node, start + offset, expression),
+            )
           }
         }
       }

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -173,7 +173,11 @@ const lintByAxis = function(corpus, suppressions = []) {
         for (const {offset, fix} of abbreviable(
           expression, since(versionOf(node), MODERN), held.pattern,
         )) {
-          defects.push(defect(CHECK, META, source, node, start + offset, fix))
+          defects.push(
+            defect(
+              CHECK, META, source, node, start + offset, expression, fix,
+            ),
+          )
         }
       }
     }

--- a/src/xpath-format-linter.js
+++ b/src/xpath-format-linter.js
@@ -75,7 +75,10 @@ const lintByFormat = function(expressions, suppressions = []) {
         expression.nodeValue,
       )) {
         defects.push(
-          defect(CHECK, META, source, expression, offset, {value, replacement}),
+          defect(
+            CHECK, META, source, expression, offset, expression.nodeValue,
+            {value, replacement},
+          ),
         )
       }
     }

--- a/src/xpath-validator.js
+++ b/src/xpath-validator.js
@@ -67,9 +67,14 @@ const UNRESOLVED = /&[A-Za-z_][\w.-]*;/
 
 /**
  * Validate every Xpath expression in the corpus, splitting the valid ones out
- * for the linters to consume from the malformed ones, which become defects.
- * An expression that cannot be parsed by the engine that would run it is
- * reported and dropped, so no linter ever reasons over broken input.
+ * for the expression linters to consume from the malformed ones, which become
+ * defects. An expression that cannot be parsed by the engine that would run it
+ * is reported here and never handed on. A code-based linter is staged
+ * differently — it takes the whole corpus and reads its own expressions from
+ * `src/attributes.js`, patterns and attribute value templates included, which
+ * this validator does not cover — so it does still read a refused expression
+ * and report what it finds. What it may not do is offer to rewrite one, and
+ * `defect` in `src/checks.js` is where that is withheld (#636).
  * @param {Array.<{file: string, content: string, xsl: Document}>} corpus -
  *  Parsed stylesheets
  * @param {Array.<string>} suppressions - Array of suppressed checks

--- a/test/lint.test.js
+++ b/test/lint.test.js
@@ -20,6 +20,23 @@ const source = function(name) {
   }
 }
 
+/**
+ * Lines of `refused/refused-expressions.xsl` whose expression the XPath
+ * validator refuses. A code-based linter still reads them, so it still reports
+ * what it finds there, but a fix it offered would rewrite text no processor
+ * parses — `select="child::"` shortened to `select=""` — so none may carry one.
+ * @type {Array.<number>}
+ */
+const REFUSED = [9, 10]
+
+/**
+ * Lines of the same stylesheet whose expression parses, one of them spaced
+ * inside its own step (#615). Their fixes are the ones a validity gate must not
+ * take with it.
+ * @type {Array.<number>}
+ */
+const KEPT = [13, 14]
+
 describe('lint (programmatic API)', function() {
   it('returns defects for in-memory sources', function() {
     const defects = lint([source('stylesheets/xsl-with-some-violations.xsl')])
@@ -51,5 +68,29 @@ describe('lint (programmatic API)', function() {
   it('exposes the fix engine for callers to apply', function() {
     const sources = [source('stylesheets/xsl-with-no-violations.xsl')]
     assert.equal(fixed(sources, lint(sources)).contents.size, 0)
+  })
+  it('offers no fix on an expression the validator refused', function() {
+    assert.deepEqual(
+      lint([source('refused/refused-expressions.xsl')])
+        .filter((defect) => REFUSED.includes(defect.line) && defect.fix)
+        .map((defect) => `${defect.name} at ${defect.line}:${defect.pos}`),
+      [],
+    )
+  })
+  it('still reports what it finds on a refused expression', function() {
+    assert.ok(
+      lint([source('refused/refused-expressions.xsl')]).some(
+        (defect) => defect.name === 'unabbreviated-axis' &&
+          defect.line === REFUSED[0],
+      ),
+    )
+  })
+  it('keeps the fix on a valid expression beside a refused one', function() {
+    assert.deepEqual(
+      lint([source('refused/refused-expressions.xsl')])
+        .filter((defect) => KEPT.includes(defect.line))
+        .map((defect) => Boolean(defect.fix)),
+      [true, true],
+    )
   })
 })

--- a/test/lint.test.js
+++ b/test/lint.test.js
@@ -20,23 +20,6 @@ const source = function(name) {
   }
 }
 
-/**
- * Lines of `refused/refused-expressions.xsl` whose expression the XPath
- * validator refuses. A code-based linter still reads them, so it still reports
- * what it finds there, but a fix it offered would rewrite text no processor
- * parses — `select="child::"` shortened to `select=""` — so none may carry one.
- * @type {Array.<number>}
- */
-const REFUSED = [9, 10]
-
-/**
- * Lines of the same stylesheet whose expression parses, one of them spaced
- * inside its own step (#615). Their fixes are the ones a validity gate must not
- * take with it.
- * @type {Array.<number>}
- */
-const KEPT = [13, 14]
-
 describe('lint (programmatic API)', function() {
   it('returns defects for in-memory sources', function() {
     const defects = lint([source('stylesheets/xsl-with-some-violations.xsl')])
@@ -69,26 +52,25 @@ describe('lint (programmatic API)', function() {
     const sources = [source('stylesheets/xsl-with-no-violations.xsl')]
     assert.equal(fixed(sources, lint(sources)).contents.size, 0)
   })
-  it('offers no fix on an expression the validator refused', function() {
+  it('offers no fix on the refused axis or the refused comparison', function() {
     assert.deepEqual(
       lint([source('refused/refused-expressions.xsl')])
-        .filter((defect) => REFUSED.includes(defect.line) && defect.fix)
+        .filter((defect) => [9, 10].includes(defect.line) && defect.fix)
         .map((defect) => `${defect.name} at ${defect.line}:${defect.pos}`),
       [],
     )
   })
-  it('still reports what it finds on a refused expression', function() {
+  it('still reports the verbose axis it refused to shorten', function() {
     assert.ok(
       lint([source('refused/refused-expressions.xsl')]).some(
-        (defect) => defect.name === 'unabbreviated-axis' &&
-          defect.line === REFUSED[0],
+        (defect) => defect.name === 'unabbreviated-axis' && defect.line === 9,
       ),
     )
   })
-  it('keeps the fix on a valid expression beside a refused one', function() {
+  it('keeps the fix on the two valid axes beside the refused ones', function() {
     assert.deepEqual(
       lint([source('refused/refused-expressions.xsl')])
-        .filter((defect) => KEPT.includes(defect.line))
+        .filter((defect) => [13, 14].includes(defect.line))
         .map((defect) => Boolean(defect.fix)),
       [true, true],
     )

--- a/test/resources/refused/refused-expressions.xsl
+++ b/test/resources/refused/refused-expressions.xsl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" id="refused">
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <xsl:value-of select="child::"/>
+    <xsl:if test="count(alpha) = 0 (">
+      <xsl:value-of select="."/>
+    </xsl:if>
+    <xsl:value-of select="child::beta"/>
+    <xsl:value-of select="child ::gamma"/>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Closes #636.

`lint` partitions the expressions and then hands the whole corpus to every
code-based linter, so an expression `invalid-xpath-expression` has already
refused still reaches `expressionsOf` and still collects a fix. On
`select="child::"` the run reported the malformed expression and offered a
plain `--fix` that wrote `select=""`, replacing text the user wrote with an
empty attribute and leaving the syntax error in place for the next run.
`test="count(alpha) = 0 ("` behaved the same way.

The fix is withheld rather than the report, which is the smaller of the two
corrections the ticket weighs: a linter that read a broken expression may well
have found something real in it, and saying so costs nothing, while rewriting it
cannot be right. `defect` in `src/checks.js` is the one place every code-based
linter builds a defect through, so the gate goes there:

```js
const anchored = fix === undefined || !isValid(expression) ?
  undefined :
  {line: line, col: pos, ...fix}
```

The expression is now a parameter of `defect` rather than something it could
infer. It cannot be inferred: for a bare attribute the node's value is the
expression, but for one an attribute value template encloses in braces, or a
3.0 text value template, the node's value is not an expression at all and
would never parse. Every call site already had the text in scope.

Making it a required parameter is also what keeps the convention from drifting.
The project's own `no-missing-argument` rule weighs `Function.length`, so a
linter added later that calls `defect` without its expression is a lint error at
that call, not a silent return to the old behaviour. That is the
machine-enforcement CLAUDE.md asks for, and it costs nothing beyond the
parameter.

`isValid` runs only when a fix is actually offered — `fix === undefined`
short-circuits ahead of it — so the cost is one compile per fixable defect, not
one per expression. Measured rather than assumed: 0.082 ms a call, so 82 ms at a
thousand fixable defects, which no real run reaches.

End to end, over a fixture holding both kinds beside each other:

```text
<xsl:value-of select="child::"/>              refused, no fix, file untouched
<xsl:if test="count(alpha) = 0 (">            refused, no fix, file untouched
<xsl:value-of select="child::beta"/>          fixed to select="beta"
<xsl:value-of select="child ::gamma"/>        fixed to select="gamma"
```

The last row is the one #636 waited on #615 for. A spaced axis was refused by
`isValid` until #640 landed, so gating on validity before that would have
silenced a correct fix; it now parses, so it keeps its fix and only the genuinely
broken expressions lose theirs.

Two pieces of prose came with the behaviour. `validate`'s docblock promised that
"no linter ever reasons over broken input", which was never true of the
code-based linters and is not what this change makes true either — they still
read a refused expression and still report on it. It now says what the staging
actually does and where the fix is withheld. `README.md` gains the user-facing
half: an expression xslint cannot parse is never rewritten, and the corrections
appear once the syntax is fixed.

A pattern is judged by `isValid` too, and that is where this change is not
free. Patterns are almost a subset of expressions, so a pattern the engine
cannot parse loses its fix rather than gaining a wrong one — the safe direction —
but the loss is real and I measured its edge rather than assuming it away. Of
twenty-seven legal `match` patterns, exactly two are refused, both the XSLT 3.0
item-type form:

```text
~xs:string      refused
~element(a)     refused
```

Everything else — `/`, `a//b`, `@id`, `document-node(element(a))`,
`key('k','v')`, `root()`, the axes and the kind tests — parses and keeps its fix.
So on a 3.0 sheet a fixable defect inside something like
`match="~element(a)[count(b) = 0]"` is now reported without its correction. That
is a narrow and quiet regression, not a wrong rewrite, and #589 is where patterns
get a grammar of their own; naming it here so the next reader does not have to
rediscover it.

Left out deliberately: the staging itself. Handing code-based linters only the
validated expressions would drop the reports as well as the fixes, and would
mean `expressionsOf` — which covers patterns, attribute value templates and text
value templates that the validator never looks at — answering to a validator
that does not cover them. That is #589's and Phase 2's business, not this
ticket's.

`npm test` 771 passing, `npm run coverage` 100% of statements, branches,
functions and lines, `test/xcop.test.js` 250 passing with the tool on PATH, and
the new fixture passes `xcop` on its own.
