### PR TITLE
bug(#651): offer no declarative fix on a refused expression

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,10 +346,14 @@ the harness asserts too.
   reads an expression the XPath validator refused — it takes the whole corpus,
   not the validated part — so it still reports what it finds there, but `defect`
   withholds the fix, because rewriting text no processor parses is how
-  `select="child::"` became `select=""` (#636). That gate lives in `defect`, so
-  it covers the code-based linters only: a declarative fix from `src/fixers.js`
-  is attached in `src/xpath-linter.js`, never passes through `defect`, and is
-  still offered on an expression that does not parse (#651). A *safe* fix
+  `select="child::"` became `select=""` (#636). A declarative fix never passes
+  through `defect` — `src/xpath-linter.js` attaches it from `src/fixers.js` — so
+  it is gated there instead, against the same `expressionsOf` derivation: no fix
+  is offered on an attribute whose expression the engine refuses, nor on the
+  element carrying it, since a fixer names the attribute it wants inside itself
+  where no gate can see it (#651). Withholding every fix on such an element is
+  deliberate over-reach: an element holding an expression no processor parses is
+  not worth tidying. A *safe* fix
   (deterministic, semantics-preserving) is applied by `--fix`; a
   `suggestion: true` fix (changes behavior, or is one of several corrections) is
   applied only by `--fix-suggestions`. `--fix-dry-run` writes nothing.
@@ -372,7 +376,7 @@ the harness asserts too.
 | `src/reporters.js` | `reporterOf(format)` — `text`, `json`, `sarif`, or `github` output |
 | `src/xsl-validator.js` | Builds the corpus; reports each non-well-formed stylesheet |
 | `src/xpath-validator.js` | Splits corpus expressions into valid (kept) and malformed (reported) via `isValid` |
-| `src/xpath-linter.js` | Loads `checks/xpath/*.yaml`; attaches any `src/fixers.js` fix |
+| `src/xpath-linter.js` | Loads `checks/xpath/*.yaml`; attaches any `src/fixers.js` fix, unless the node — or the element carrying it — holds an expression the engine refuses (#651) |
 | `src/corpus-linter.js` | Loads `checks/corpus/*.yaml`; cross-file rules |
 | `src/*-linter.js` | Code-based `checks/format/*.yaml`, one construct each (axis, namespace, count, name, ...); see the flow diagram |
 | `src/checks.js` | Shared for code-based linters: `metaOf`, `suppressed`, `defect(check, meta, source, node, offset, expression, fix)` — walks the raw text so a wrapped or entity-shifted value reports where it truly stands (#611), and drops the `fix` when `expression` does not parse (#636) |

--- a/README.md
+++ b/README.md
@@ -345,12 +345,20 @@ Checks whose correction needs real judgment (a fresh name, a more specific
 path) stay report-only. A run without `--fix` reports how many defects each
 option would fix.
 
-An expression xslint cannot parse is never rewritten. It is reported as
-`invalid-xpath-expression`, and the other defects standing in it are reported
-too, with no correction offered — including the ones that would rewrite the
-attribute from the outside rather than the expression within it. A stylesheet
-whose real fault is a missing bracket comes back with that fault untouched, so
-fix the syntax and the corrections appear on the next run.
+An expression xslint cannot parse is never rewritten. The other defects standing
+in it are still reported, with no correction offered — including the ones that
+would rewrite the attribute from the outside rather than the expression within
+it. A stylesheet whose real fault is a missing bracket comes back with that
+fault untouched, so fix the syntax and the corrections appear on the next run.
+
+Where the expression sits decides whether you are told why. A bare one — a
+`select`, a `test`, and the rest listed under `invalid-xpath-expression` — is
+reported as malformed. A **pattern** such as `match`, and the braces of an
+attribute or text value template, are not yet parsed by that check
+([#589](https://github.com/xslint/xslint/issues/589)), so a broken one is silent:
+the corrections around it disappear with nothing said. Until that lands, a defect
+that reports without a correction where you expected one is the sign to check the
+expression's syntax by hand.
 
 Where two corrections cover the same piece of an expression — the redundant
 whitespace in `d[position()  =  1]` sits inside the predicate that becomes

--- a/README.md
+++ b/README.md
@@ -345,14 +345,12 @@ Checks whose correction needs real judgment (a fresh name, a more specific
 path) stay report-only. A run without `--fix` reports how many defects each
 option would fix.
 
-An expression xslint cannot parse is reported as `invalid-xpath-expression`,
-and the checks that read the expression itself — the axis, count, name,
-translate and whitespace family — report what they find in it without offering a
-correction. A stylesheet whose real fault is a missing bracket should come back
-with that fault and nothing else changed, so fix the syntax and the corrections
-appear on the next run. The checks that match on the attribute rather than on
-the expression inside it still offer their corrections there, which is tracked
-in [#651](https://github.com/xslint/xslint/issues/651).
+An expression xslint cannot parse is never rewritten. It is reported as
+`invalid-xpath-expression`, and the other defects standing in it are reported
+too, with no correction offered — including the ones that would rewrite the
+attribute from the outside rather than the expression within it. A stylesheet
+whose real fault is a missing bracket comes back with that fault untouched, so
+fix the syntax and the corrections appear on the next run.
 
 Where two corrections cover the same piece of an expression — the redundant
 whitespace in `d[position()  =  1]` sits inside the predicate that becomes

--- a/src/xpath-linter.js
+++ b/src/xpath-linter.js
@@ -56,12 +56,16 @@ const evaluateXpath = function(xsl, xpath) {
 const REFUSED = new WeakMap()
 
 /**
- * The nodes no fix may be attached to: every attribute holding an expression
- * the engine cannot parse, and the element carrying it. Both are listed because
- * a declarative rule selects either one — `starts-with-double-slash` matches
- * the `xsl:template` and its fixer then reaches for the `@match`, while another
- * rule may select the attribute itself — and a fixer names the attribute it
- * wants inside itself, where no gate can see it.
+ * The nodes no fix may be attached to: every node holding an expression the
+ * engine cannot parse — an attribute, or a text node whose braces carry a
+ * template — and the element around it. The element is there because a
+ * declarative rule selects it while the fix lands somewhere inside, and a fixer
+ * names that target within itself, where no gate can read it. It reaches in
+ * both directions: `starts-with-double-slash` matches the `xsl:template` and
+ * reaches sideways for its `@match`, while `text-outside-xsl-text` matches the
+ * instruction and reaches down into the loose text, which it rewrites whole —
+ * so on `delta {1 +} epsilon` it would wrap the unparsable brace in an
+ * `xsl:text` were the parent not listed here.
  *
  * Listing the element withholds every fix on it, including one aimed at a
  * sound attribute beside the broken one. That is deliberate: an element whose

--- a/src/xpath-linter.js
+++ b/src/xpath-linter.js
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes} = require('./xpath')
+const {nodes, isValid} = require('./xpath')
 const {FIXERS} = require('./fixers')
+const {expressionsOf} = require('./attributes')
 const {allFilesFrom, yaml} = require('./helpers')
 const path = require('path')
 const {logger} = require('./logger')
@@ -46,6 +47,45 @@ const evaluateXpath = function(xsl, xpath) {
 }
 
 /**
+ * The refusal already worked out for a document. A declarative fix is offered
+ * per defect, and the answer is a property of the stylesheet, so it is derived
+ * once and remembered against the document itself the way `expressionsOf` is —
+ * a `WeakMap` releases it when the corpus does.
+ * @type {WeakMap}
+ */
+const REFUSED = new WeakMap()
+
+/**
+ * The nodes no fix may be attached to: every attribute holding an expression
+ * the engine cannot parse, and the element carrying it. Both are listed because
+ * a declarative rule selects either one — `starts-with-double-slash` matches
+ * the `xsl:template` and its fixer then reaches for the `@match`, while another
+ * rule may select the attribute itself — and a fixer names the attribute it
+ * wants inside itself, where no gate can see it.
+ *
+ * Listing the element withholds every fix on it, including one aimed at a
+ * sound attribute beside the broken one. That is deliberate: an element whose
+ * expression no processor parses is not worth tidying, and the cost of being
+ * wrong here is a correction that waits for the syntax to be fixed, against a
+ * rewrite of text the same run reported malformed (#651).
+ * @param {Document} xsl - XSL document parsed as {@link Document}
+ * @return {Set.<Node>} - The nodes a fix must not be offered on
+ */
+const refused = function(xsl) {
+  if (!REFUSED.has(xsl)) {
+    const found = new Set()
+    for (const held of expressionsOf(xsl)) {
+      if (!isValid(held.expression)) {
+        found.add(held.node)
+        found.add(held.node.ownerElement || held.node.parentNode)
+      }
+    }
+    REFUSED.set(xsl, found)
+  }
+  return REFUSED.get(xsl)
+}
+
+/**
  * Lint the corpus of stylesheets by per-file Xpath packs.
  * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
  * @param {Array.<string>} suppressions - Array of suppressed checks
@@ -69,7 +109,8 @@ const lintByXpath = function(corpus, suppressions = []) {
           line: node.lineNumber,
           pos: node.columnNumber,
         }
-        const fix = FIXERS[pack.name] && FIXERS[pack.name](node)
+        const fix = FIXERS[pack.name] && !refused(xsl).has(node) &&
+          FIXERS[pack.name](node)
         if (fix) {
           defect.fix = fix
         }

--- a/test/lint.test.js
+++ b/test/lint.test.js
@@ -75,4 +75,36 @@ describe('lint (programmatic API)', function() {
       [true, true],
     )
   })
+  it('offers no declarative fix on a refused pattern or expression', function() {
+    assert.deepEqual(
+      lint([source('refused/refused-by-a-declarative-fix.xsl')])
+        .filter((defect) => [8, 9].includes(defect.line) && defect.fix)
+        .map((defect) => `${defect.name} at ${defect.line}:${defect.pos}`),
+      [],
+    )
+  })
+  it('still reports the double slash it refused to drop', function() {
+    assert.ok(
+      lint([source('refused/refused-by-a-declarative-fix.xsl')]).some(
+        (defect) =>
+          defect.name === 'starts-with-double-slash' && defect.line === 8,
+      ),
+    )
+  })
+  it('offers no declarative fix beside a refused text value template', function() {
+    assert.deepEqual(
+      lint([source('refused/refused-by-a-declarative-fix.xsl')])
+        .filter((defect) => defect.line === 14 && defect.fix)
+        .map((defect) => defect.name),
+      [],
+    )
+  })
+  it('keeps both declarative fixes on the valid template', function() {
+    assert.deepEqual(
+      lint([source('refused/refused-by-a-declarative-fix.xsl')])
+        .filter((defect) => [11, 12].includes(defect.line))
+        .map((defect) => Boolean(defect.fix)),
+      [true, true],
+    )
+  })
 })

--- a/test/resources/refused/refused-by-a-declarative-fix.xsl
+++ b/test/resources/refused/refused-by-a-declarative-fix.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" expand-text="yes" id="declared">
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="//child::">
+    <xsl:value-of select="//child::"/>
+  </xsl:template>
+  <xsl:template match="//alpha">
+    <xsl:value-of select="//beta"/>
+  </xsl:template>
+  <xsl:template match="//gamma">delta {1 +} epsilon</xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Closes #651, which is the half of #636 that #636 did not reach.

#636 put the gate in `defect` at `src/checks.js`, the one place every code-based
linter builds a defect through. A declarative fix never goes there:
`src/xpath-linter.js` attaches whatever `src/fixers.js` maps the check name to,
so it was still offered on text the same run had reported malformed. Both halves
of that showed on one stylesheet:

```text
$ node src/index.mjs d.xsl
[ERROR]   d.xsl(9:26) An XPath expression is malformed ... (invalid-xpath-expression)
[WARNING] d.xsl(9:5)  ... (select-starts-with-double-slash)
[WARNING] d.xsl(8:26) ... (unabbreviated-axis)      <- no fix, #636 working

$ node src/index.mjs d.xsl --fix                    # plain, no suggestions
-  <xsl:template match="//child::">
+  <xsl:template match="child::">

$ node src/index.mjs d.xsl --fix-suggestions
-    <xsl:value-of select="//child::"/>
+    <xsl:value-of select=".//child::"/>
```

So within one run `unabbreviated-axis` refused to touch the text while
`starts-with-double-slash` rewrote it, and the second edit rewrote an expression
the run had just called malformed.

The gate now sits where those fixes are attached, and asks the same question
against the same derivation — `expressionsOf`, so there is one answer to what a
stylesheet carries rather than a second opinion:

```js
const fix = FIXERS[pack.name] && !refused(xsl).has(node) &&
  FIXERS[pack.name](node)
```

`refused` collects every attribute whose expression the engine cannot parse
**and the element carrying it**. The element is there because a declarative rule
selects either one — `starts-with-double-slash` matches the `xsl:template` and
its fixer then reaches inside for the `@match` — so the node the gate sees is
often not the node the fix will touch, and a fixer names its own target where no
gate can read it.

That is deliberate over-reach, and worth saying plainly: an element with two
expressions, one broken, loses the fix on the sound one too. An element holding
an expression no processor parses is not worth tidying, and the cost of being
wrong in that direction is a correction that waits for the syntax to be fixed,
against a rewrite of text the run reported malformed. The alternative — matching
the fix's own target back to an attribute — couples the gate to each fixer's
column arithmetic, which is worse.

The set is derived once per document and held in a `WeakMap`, the way
`expressionsOf` holds its own, so a stylesheet with many declarative defects
pays for it once and releases it with the corpus.

The fixture carries both node kinds the scan yields, because 100% branch
coverage counts a branch one kind reaches as covered for all (#606): the
attribute case, and a 3.0 text value template whose `{1 +}` puts the *text*
node's parent element out of bounds. Without the second, `held.node.parentNode`
never runs.

End to end, on a stylesheet mixing the broken with the sound:

```text
match="//child::"        refused   untouched
select="count(a) = 0 ("  refused   untouched
select="not(not(b))"     parses    rewritten to boolean(b)
xmlns:unused="urn:zz"    n/a       removed
```

The last row is the point of the wording in `README.md`. Three fixers —
`namespace-linter`, `result-namespace-linter` and `import-linter` — attach a fix
outside `defect` and outside this gate, but none of them rewrites expression
text; they delete a namespace declaration, edit `exclude-result-prefixes`, or
drop an import. So the claim the README can now make is that an expression
xslint cannot parse is never rewritten, which #636's round of review correctly
refused to let it make on the code-based half alone. `CLAUDE.md` records where
the gate lives and why it takes the element with the attribute.

`npm test` 775 passing, `npm run coverage` 100% of statements, branches,
functions and lines, `test/xcop.test.js` 250 passing with the tool on PATH, and
the new fixture passes `xcop` on its own.



---

**Measured**, since #633 makes this the one area where a number belongs in the record. A generated sheet of 3203 lines, 2400 expressions and 800 declarative fixable defects, best of four runs:

```text
                              master      branch
800 fixable declarative        2972 ms     3071 ms     +3.3%
none fixable                   2960 ms     2932 ms     parity
```

The second row is the short-circuit: `refused` is never built unless a declarative fix is about to be attached, so a stylesheet with none pays nothing.
