### PR TITLE
bug(#647): validate every attribute that holds an expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,8 +401,8 @@ Validators:
 - **XPath syntax** — every bare XPath expression (in `select`, `test`,
   `use`, `value`, `group-by`, `group-adjacent`, and the XSLT 3.0 `key`,
   `initial-value`, `xpath`, `context-item`, `with-params`,
-  `namespace-context`) is parsed; the ones the processor cannot parse are
-  reported.
+  `namespace-context`, `for-each-item`, `for-each-source` and `use-when`) is
+  parsed; the ones the processor cannot parse are reported.
 
 Linters:
 

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -168,6 +168,7 @@ const expressionsOf = function(xsl) {
 
 module.exports = {
   ATTRIBUTES,
+  PATTERNS,
   selectorOf,
   expressionsOf,
 }

--- a/src/resources/motives/validation/invalid-xpath-expression.md
+++ b/src/resources/motives/validation/invalid-xpath-expression.md
@@ -4,8 +4,9 @@ An attribute carrying a bare XPath expression — `select`, `test`, `use`,
 `value`, `group-by`, `group-adjacent`, or the XSLT 3.0 `key`, `initial-value`,
 `xpath`, `context-item`, `with-params`, `namespace-context`, the
 `for-each-item` and `for-each-source` of an `xsl:merge-source`, and the static
-`use-when` — must hold an expression the processor can parse. A malformed expression breaks the
-transformation at runtime, so the sooner it surfaces the better. Only the
+`use-when` — must hold an expression the processor can parse. A malformed
+expression breaks the transformation at runtime, so the sooner it surfaces the
+better. Only the
 expression syntax is checked, not its formatting; pattern attributes such as
 `match` and attribute value templates are left to other checks.
 

--- a/src/resources/motives/validation/invalid-xpath-expression.md
+++ b/src/resources/motives/validation/invalid-xpath-expression.md
@@ -2,8 +2,9 @@
 
 An attribute carrying a bare XPath expression — `select`, `test`, `use`,
 `value`, `group-by`, `group-adjacent`, or the XSLT 3.0 `key`, `initial-value`,
-`xpath`, `context-item`, `with-params`, `namespace-context` — must hold an
-expression the processor can parse. A malformed expression breaks the
+`xpath`, `context-item`, `with-params`, `namespace-context`, the
+`for-each-item` and `for-each-source` of an `xsl:merge-source`, and the static
+`use-when` — must hold an expression the processor can parse. A malformed expression breaks the
 transformation at runtime, so the sooner it surfaces the better. Only the
 expression syntax is checked, not its formatting; pattern attributes such as
 `match` and attribute value templates are left to other checks.

--- a/src/xpath-validator.js
+++ b/src/xpath-validator.js
@@ -40,7 +40,7 @@ const names = [CHECK]
 const EXPRESSIONS = [
   'select', 'test', 'use', 'value', 'group-by', 'group-adjacent',
   'key', 'initial-value', 'xpath', 'context-item', 'with-params',
-  'namespace-context',
+  'namespace-context', 'for-each-item', 'for-each-source', 'use-when',
 ]
 
 /**

--- a/src/xpath-validator.js
+++ b/src/xpath-validator.js
@@ -4,6 +4,7 @@
  */
 
 const {isValid} = require('./xpath')
+const {ATTRIBUTES, PATTERNS} = require('./attributes')
 const {walked} = require('./tree')
 const {XSLT} = require('./xsl-version')
 const {yaml} = require('./helpers')
@@ -31,17 +32,21 @@ const META = yaml.parsedFromFile(
 const names = [CHECK]
 
 /**
- * Attribute nodes that carry a bare Xpath expression, scoped to XSLT elements
- * so literal result elements are left alone. Pattern attributes (match, count,
- * from, group-starting-with, group-ending-with), attribute value templates,
- * and sequence types (as) are not expressions and stay out.
- * @type {string}
+ * The attributes carrying a bare Xpath expression: every attribute a linter
+ * reads, less the ones holding a pattern. A pattern is a different language
+ * and waits on a grammar of its own (#589); an attribute value template and a
+ * sequence type are not expressions either, and neither is in the list to
+ * begin with.
+ *
+ * Derived rather than written out, because a second list is a second opinion
+ * about what a stylesheet carries and drifts from the first. That is not a
+ * hypothetical: #627 added `for-each-item` and `for-each-source` to
+ * `src/attributes.js` alone, and the three attributes nothing validated (#647)
+ * were what came of it. Subtracting one list from the other leaves nowhere for
+ * the next one to hide.
+ * @type {Array.<string>}
  */
-const EXPRESSIONS = [
-  'select', 'test', 'use', 'value', 'group-by', 'group-adjacent',
-  'key', 'initial-value', 'xpath', 'context-item', 'with-params',
-  'namespace-context', 'for-each-item', 'for-each-source', 'use-when',
-]
+const EXPRESSIONS = ATTRIBUTES.filter((name) => !PATTERNS.includes(name))
 
 /**
  * Whether the walked node is one of those attributes on an XSLT element. The

--- a/test/lint.test.js
+++ b/test/lint.test.js
@@ -99,6 +99,14 @@ describe('lint (programmatic API)', function() {
       [],
     )
   })
+  it('reports a malformed expression in every attribute that holds one', function() {
+    assert.deepEqual(
+      lint([source('refused/unvalidated-expression-attributes.xsl')])
+        .filter((defect) => defect.name === 'invalid-xpath-expression')
+        .map((defect) => `${defect.line}:${defect.pos}`),
+      ['9:41', '11:39', '14:41'],
+    )
+  })
   it('keeps both declarative fixes on the valid template', function() {
     assert.deepEqual(
       lint([source('refused/refused-by-a-declarative-fix.xsl')])

--- a/test/resources/refused/unvalidated-expression-attributes.xsl
+++ b/test/resources/refused/unvalidated-expression-attributes.xsl
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" id="unvalidated">
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <xsl:variable name="alpha" use-when="1 +" select="beta"/>
+    <xsl:merge>
+      <xsl:merge-source for-each-item="2 +" select="doc">
+        <xsl:merge-key select="gamma"/>
+      </xsl:merge-source>
+      <xsl:merge-source for-each-source="3 +" select="other">
+        <xsl:merge-key select="delta"/>
+      </xsl:merge-source>
+    </xsl:merge>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Closes #647.

`EXPRESSIONS` at `src/xpath-validator.js:40` named twelve attributes.
`ATTRIBUTES` at `src/attributes.js:19`, which is what every code-based linter
reads its expressions from, names twenty. Five of the extra eight are the
patterns #589 owns. The other three hold ordinary XPath and nothing looked at
them:

```text
malformed expression placed in each attribute a linter reads
                          before      after
select                    REPORTED    REPORTED
test                      REPORTED    REPORTED
use, group-by, ...        REPORTED    REPORTED
for-each-item             SILENT      REPORTED
for-each-source           SILENT      REPORTED
use-when                  SILENT      REPORTED
```

Adding the three names is the whole diff, but not the whole effect: the
validated set also feeds `EXPRESSION_LINTERS`, so `redundant-whitespace` now
reports and fixes inside all three as well —
`use-when="count( a )  =  1"` draws two defects where the branch previously
found none. That is consistent with the code-based tier, which already read
these three through `expressionsOf`.

The list is derived rather than written out, so the drift cannot recur: ```js
const EXPRESSIONS = ATTRIBUTES.filter((name) => !PATTERNS.includes(name))
```

`ATTRIBUTES` is "expressions and patterns" and `PATTERNS` is "the patterns", so
the remainder is exactly what this validator is for — verified as the same
fifteen names in the same order, not a numeric coincidence. #627 added
`for-each-item` and `for-each-source` to one list only, and #647 is what came of
it; there is now no second list to drift.

`for-each-item` and `for-each-source` are the two an `xsl:merge-source` carries beside its `select`,
which #627 already recognised as expressions on the linter side; `use-when` is
static, so a malformed one stops a processor before it transforms anything,
which is precisely the fault this check exists to surface early.

The fixture puts each in the element that really carries it — an
`xsl:merge-source` inside an `xsl:merge` for the first two — rather than
inventing a host, so it reads as XSLT someone might write.

Two things deliberately left out.

**The literal result element spelling.** `use-when` is written `xsl:use-when` on
a literal result element, which is the only way a simplified stylesheet can carry
one, and both lists key on the bare name with an XSLT owner, so the namespaced
form is refused by each. It is read by no linter either, since `expressionsOf`
filters the same way — so it is a false negative across the whole format tier,
not just a missing report. Filed as **#654** with the one-rule fix, because it is
a different mechanism from a missing name and touches `src/attributes.js` too.

**A pattern is still unvalidated**, which is #589 and unchanged here.

`npm test` 776 passing, `npm run coverage` 100% of statements, branches,
functions and lines, and the new fixture passes `xcop` on its own. The motive and
`README.md` both list the covered attributes by name, so both gained the three.

