### PR TITLE
bug(#645): run the tool to ask whether it runs

### DIFF
--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: 22
       - run: npm install
-      - run: npx mocha test/xcop.test.js --timeout 30000
+      - run: npx mocha test/xcop.test.js --timeout 30000 --forbid-pending
       - run: >-
           xcop --license LICENSE.txt
           --include '**/*.xsl' --include '**/*.xml'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,6 +325,13 @@ the harness asserts too.
   flags, which xcop would canonicalize away. The repo-wide sweep in the workflow
   excludes `test/resources/directives/wrapped*.xsl` for the same reason: they must
   keep the wrapped attribute value #611 is about, which xcop joins onto one line.
+  Where the tool does not run, every fixture is registered and **pending**, never
+  absent: a suite that asserts nothing must not read like one that passed, which
+  is how 250 assertions went missing on a developer machine for months (#645).
+  Whether it runs is settled by running it, not by looking it up in `PATH`. The
+  CI job passes `--forbid-pending`, so in the one place the tool must be there,
+  pending is a failure. A test registered behind a condition is banned by a
+  `no-restricted-syntax` selector — skip it in its body with `this.skip()`.
 - **Table-driven.** Where several `it` blocks differ only in data, express them as
   a data array plus one generator, not repeated blocks. When adding a test, add a
   row to the matching table (`test/fixer.test.js`, the pack harnesses,
@@ -395,4 +402,4 @@ the harness asserts too.
 | `src/logger.js` | 4-level logger |
 | `scripts/generate-docs.js` | Builds the `docs/` site from checks + motives |
 | `test/conformance.test.js` | Enforces naming, motives, selector hygiene, pack/test coverage, and the `mature` freeze across all kinds |
-| `test/xcop.test.js` | Runs xcop over the inline XSL of every `*-packs` directory |
+| `test/xcop.test.js` | Runs xcop over the inline XSL of every `*-packs` directory; pending, never absent, where the tool does not run |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -86,6 +86,12 @@ export default defineConfig([
         },
         {
           selector:
+            "IfStatement CallExpression[callee.name=/^(it|describe)$/], ConditionalExpression CallExpression[callee.name=/^(it|describe)$/]",
+          message:
+            "Register the test and skip it in its body with this.skip(); a test registered behind a condition disappears without a word, the way 249 xcop assertions did (#645)"
+        },
+        {
+          selector:
             "CallExpression[callee.property.name='getAttribute'][callee.object.property.name='documentElement'][arguments.0.value='version']",
           message:
             "Read the stylesheet version through versionOf in src/xsl-version.js, which handles a simplified stylesheet's xsl:version; do not read documentElement.getAttribute('version') directly"

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -5,24 +5,26 @@
 
 const path = require('path')
 const {execSync, spawnSync} = require('child_process')
-const os = require('os')
 
 /**
- * Run the console command
+ * Run the console command. A run told not to print captures nothing, and
+ * `execSync` answers `null` rather than a buffer for it, so the empty string
+ * stands in — without it the quiet form threw on every command that ran, which
+ * reads exactly like a command that is not there (#645).
  * @param {string} command - Console Command
  * @param {Array.<string>} args - Arguments
  * @param {boolean} print - Capture logs or not
  * @return {string} Stdout
  */
 const execCmd = function(command, args, print) {
-  return execSync(
+  return (execSync(
     `${command} ${args.join(' ')}`,
     {
       timeout: 120000,
       windowsHide: true,
       stdio: print ? null : 'ignore',
     },
-  ).toString()
+  ) ?? '').toString()
 }
 
 /**
@@ -83,15 +85,22 @@ const runXcop = function(arg, print = true) {
 }
 
 /**
- * Helper to check if command is available in the system.
+ * Whether the tool runs here, asked by running it with the argument that proves
+ * it does. Looking the name up in `PATH` was a proxy for that question, and the
+ * two disagree: `which` walks `PATH` literally while the shell that starts the
+ * tool expands a `~` in it, so an installed xcop read as absent and its 249
+ * assertions went with it (#645). Running the tool also retires the
+ * `where`/`which` fork, whose platform test compared a function with a string
+ * and so never once took the Windows arm it was written for.
  * @param {string} cmd - Command
+ * @param {Array.<string>} args - Arguments proving it runs
  * @param {boolean} print - Capture logs
  * @return {boolean} - Result
  */
-const cmdAvailable = function(cmd, print = true) {
+const cmdAvailable = function(cmd, args, print) {
   let available = true
   try {
-    execCmd(os.platform === 'win32' ? 'where' : 'which', [cmd], print)
+    execCmd(cmd, args, print)
   } catch {
     available = false
   }

--- a/test/xcop.test.js
+++ b/test/xcop.test.js
@@ -25,10 +25,11 @@ const PACKS = fs.readdirSync(RESOURCES)
   .flatMap((dir) => allFilesFrom(path.resolve(RESOURCES, dir)))
 
 /**
- * Whether xcop is installed.
+ * Whether xcop runs here, asked with the same command the tests run it by, so
+ * the probe cannot answer a different question from theirs.
  * @type {boolean}
  */
-const available = cmdAvailable('xcop')
+const available = cmdAvailable('xcop', ['--version'], false)
 
 /**
  * Packs whose fixture must carry a construct xcop rejects, so it cannot also be
@@ -47,22 +48,29 @@ const CHECKED = PACKS.filter(
   (pack) => !UNFORMATTED.includes(path.basename(pack)),
 )
 
+if (!available) {
+  console.warn(
+    'xcop does not run here, so its fixtures are pending, not passing',
+  )
+}
+
 describe('xcop', function() {
   CHECKED.forEach((pack) => {
     const yml = yaml.parsedFromFile(pack)
     const inputs = yml.inputs || [yml.input]
     inputs.forEach((input, index) => {
-      if (available) {
-        it(`should find 0 xcop errors in xsl #${index} of ${path.basename(pack)}`, function() {
-          const xsl = path.resolve(
-            __dirname, `temp-${path.basename(pack, '.yaml')}-${index}.xsl`,
-          )
-          fs.writeFileSync(xsl, `${xml.parsedFromString(input)}\n`)
-          const stdout = runXcop(xsl)
-          fs.unlinkSync(xsl)
-          assert.ok(stdout.includes(`${xsl} looks good`))
-        })
-      }
+      it(`should find 0 xcop errors in xsl #${index} of ${path.basename(pack)}`, function() {
+        if (!available) {
+          this.skip()
+        }
+        const xsl = path.resolve(
+          __dirname, `temp-${path.basename(pack, '.yaml')}-${index}.xsl`,
+        )
+        fs.writeFileSync(xsl, `${xml.parsedFromString(input)}\n`)
+        const stdout = runXcop(xsl)
+        fs.unlinkSync(xsl)
+        assert.ok(stdout.includes(`${xsl} looks good`))
+      })
     })
   })
 })


### PR DESCRIPTION
Closes #645.

On this checkout `npm test` reported **776 passing**. It now reports **1026**,
and not one assertion was written to get there — 250 xcop assertions had been
skipped in silence.

Three things were wrong, each hiding the next.

**The probe asked the wrong question.** `cmdAvailable` looked the tool up with
`which` and inferred it could run. `which` walks `PATH` literally; the shell that
starts the tool expands a `~` in it, and this machine's `PATH` carries the
literal `~/.rubies/ruby-3.4.2/bin`. So `which xcop` fails while `xcop --version`
answers `0.11.2`. It now runs the tool with the argument that proves it runs,
which is the same call the tests make — a probe that cannot answer a different
question from theirs.

**The quiet form of `execCmd` threw on every command.** `stdio: 'ignore'` makes
`execSync` return `null`, and the helper called `.toString()` on it, so
`execCmd(cmd, args, false)` raised a `TypeError` whether or not the command
existed — indistinguishable, to a `catch`, from a tool that is not there. Never
noticed, because the only caller took the default `print = true`. `?? ''` stands
in for the ignored stdout.

**The skip was silent.** The `it` blocks were built inside `if (available)`, so
an unreachable tool produced `0 passing` and exit `0` — a run that asserted
nothing, shaped exactly like one that passed. Every fixture is now registered and
skips in its own body, so the same run reads `250 pending`, with one line saying
why.

```text
$ mocha test/xcop.test.js          # before, this machine
  0 passing (0ms)

$ mocha test/xcop.test.js          # after
  250 passing (25s)

$ PATH=… mocha test/xcop.test.js   # after, tool unreachable
  xcop does not run here, so its fixtures are pending, not passing
  0 passing (22ms)
  250 pending
```

**Two guards, since a convention that is not machine-enforced is a wish.** An
ESLint `no-restricted-syntax` selector bans registering `it`/`describe` behind a
condition, in an `if` or a ternary — that was the reproduction here, failing on
`test/xcop.test.js:56` and nowhere else in the tree before the fix. And the CI
`xcop` job, the one place the tool must be present, now passes
`--forbid-pending`, so a pending fixture there is a failure (`exit 250`,
verified) rather than a green job that checked nothing.

Deliberately not a hard failure in `test/xcop.test.js` itself, which the ticket
weighed as the louder option: `grunt mochacli` runs that file in all six
`build` matrix jobs and on every contributor's machine, none of which install
Ruby. Failing there would make a green run impossible without the gem. Pending
locally and forbidden in CI puts the noise exactly where the tool is required.

The `os.platform === 'win32'` bug the ticket also names — a function compared
with a string, so `where` was never reached and Windows took a branch it has no
`which` for — is gone with the lookup itself rather than repaired.

`npm test` 1026 passing, `npm run coverage` 100% of statements, branches,
functions and lines, `npx eslint` clean.
