### PR TITLE
bug(#607): assert the fix of every format pack, and derive which packs those are

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,15 @@ its harness — no registration. A pack is `pack` (the check name), `found`, and
 `[fileIndex, line, col]` for cross-file packs, or `[line, col, other-check]` for
 a co-firing check. A code-based linter's pack also carries `found.fixes` aligned
 with `positions` (the expected `fix.replacement`, `null` for report-only), which
-the harness asserts too.
+the harness asserts too. That alignment is machine-enforced: `conformance.test.js`
+fails any pack whose `pack:` names a `checks/format/` check and whose `fixes` are
+missing or do not stand one per position, and no harness falls back to an empty
+array any more, so a dropped key throws rather than asserting nothing. It was
+opt-in until #607, and 33 of 92 packs had opted out — among them every
+`redundant-whitespace` replacement, and the whole of `import-packs`, whose
+harness asserted no fix at all while `redundant-import` emits one. A `null` is
+as much of an assertion as a string: it pins a check as report-only, so an
+accidentally attached fix turns red.
 
 - **Test the hard cases.** A pack must exercise more than one clean, top-level
   occurrence: the construct **buried** in a larger expression (a predicate, an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,14 +301,16 @@ its harness — no registration. A pack is `pack` (the check name), `found`, and
 `[fileIndex, line, col]` for cross-file packs, or `[line, col, other-check]` for
 a co-firing check. A code-based linter's pack also carries `found.fixes` aligned
 with `positions` (the expected `fix.replacement`, `null` for report-only), which
-the harness asserts too. That alignment is machine-enforced: `conformance.test.js`
-fails any pack whose `pack:` names a `checks/format/` check and whose `fixes` are
-missing or do not stand one per position, and no harness falls back to an empty
-array any more, so a dropped key throws rather than asserting nothing. It was
-opt-in until #607, and 33 of 92 packs had opted out — among them every
-`redundant-whitespace` replacement, and the whole of `import-packs`, whose
-harness asserted no fix at all while `redundant-import` emits one. A `null` is
-as much of an assertion as a string: it pins a check as report-only, so an
+the harness asserts too. Both halves are machine-enforced by
+`conformance.test.js`: a pack whose `pack:` names a `checks/format/` check must
+carry `fixes` standing one per position, **and** the harness reading that pack's
+directory must mention `found.fixes` at all — the pack declaring a fix and
+nobody reading it is how `import-packs` asserted none while `redundant-import`
+emitted one. No harness falls back to an empty array for `fixes` any more
+(`found.values` is a separate, still opt-in key), so a dropped key throws rather
+than quietly asserting nothing. It was opt-in until #607, and 33 of 98 packs had
+opted out, among them every `redundant-whitespace` replacement. A `null` is as
+much of an assertion as a string: it pins a check as report-only, so an
 accidentally attached fix turns red.
 
 - **Test the hard cases.** A pack must exercise more than one clean, top-level

--- a/test/conformance.test.js
+++ b/test/conformance.test.js
@@ -172,6 +172,24 @@ describe('conformance', function() {
       'a format pack whose fixes do not stand one per position asserts nothing about them',
     )
   })
+  it('reads the fixes of every format pack in the harness owning it', function() {
+    const formats = new Set(names('format'))
+    const suites = allFilesFrom(path.resolve(__dirname))
+      .filter((file) => file.endsWith('.test.js'))
+      .map((file) => fs.readFileSync(file, 'utf-8'))
+    assert.deepEqual(
+      [...new Set(
+        allFilesFrom(RESOURCES)
+          .filter((file) => file.endsWith('.yaml'))
+          .filter((file) => formats.has(yaml.parsedFromFile(file).pack))
+          .map((file) => path.basename(path.dirname(file))),
+      )].filter((dir) => !suites.some(
+        (suite) => suite.includes(`'${dir}'`) && suite.includes('found.fixes'),
+      )),
+      [],
+      'a pack directory whose harness never reads found.fixes leaves every fix in it unasserted',
+    )
+  })
   it('tests every validation check by name in a test file', function() {
     const suite = allFilesFrom(path.resolve(__dirname))
       .filter((file) => file.endsWith('.test.js'))

--- a/test/conformance.test.js
+++ b/test/conformance.test.js
@@ -155,6 +155,23 @@ describe('conformance', function() {
       assert.ok(packed.has(name), `format/${name} has no test pack`)
     }
   })
+  it('pins the fix of every format pack against its positions', function() {
+    const formats = new Set(names('format'))
+    const packs = allFilesFrom(RESOURCES)
+      .filter((file) => file.endsWith('.yaml'))
+      .map((file) => ({
+        name: path.relative(RESOURCES, file), yml: yaml.parsedFromFile(file),
+      }))
+      .filter((pack) => formats.has(pack.yml.pack))
+    assert.deepEqual(
+      packs
+        .filter((pack) => !Array.isArray(pack.yml.found.fixes) ||
+          pack.yml.found.fixes.length !== pack.yml.found.positions.length)
+        .map((pack) => pack.name),
+      [],
+      'a format pack whose fixes do not stand one per position asserts nothing about them',
+    )
+  })
   it('tests every validation check by name in a test file', function() {
     const suite = allFilesFrom(path.resolve(__dirname))
       .filter((file) => file.endsWith('.test.js'))

--- a/test/count-linter.test.js
+++ b/test/count-linter.test.js
@@ -28,8 +28,7 @@ describe('count-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes
-        fixes.forEach((expected, index) => {
+        yml.found.fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,
             expected,

--- a/test/count-linter.test.js
+++ b/test/count-linter.test.js
@@ -28,7 +28,7 @@ describe('count-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes || []
+        const fixes = yml.found.fixes
         fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,

--- a/test/import-linter.test.js
+++ b/test/import-linter.test.js
@@ -30,6 +30,12 @@ describe('import-linter', function() {
           assert.equal(defects[index].line, pos[1])
           assert.equal(defects[index].pos, pos[2])
         })
+        yml.found.fixes.forEach((expected, index) => {
+          assert.equal(
+            defects[index].fix ? defects[index].fix.replacement : null,
+            expected,
+          )
+        })
       })
     })
   })

--- a/test/name-linter.test.js
+++ b/test/name-linter.test.js
@@ -28,8 +28,7 @@ describe('name-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes
-        fixes.forEach((expected, index) => {
+        yml.found.fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,
             expected,

--- a/test/name-linter.test.js
+++ b/test/name-linter.test.js
@@ -28,7 +28,7 @@ describe('name-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes || []
+        const fixes = yml.found.fixes
         fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,

--- a/test/namespace-linter.test.js
+++ b/test/namespace-linter.test.js
@@ -28,7 +28,7 @@ describe('namespace-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes || []
+        const fixes = yml.found.fixes
         fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,

--- a/test/namespace-linter.test.js
+++ b/test/namespace-linter.test.js
@@ -28,8 +28,7 @@ describe('namespace-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes
-        fixes.forEach((expected, index) => {
+        yml.found.fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,
             expected,

--- a/test/node-set-linter.test.js
+++ b/test/node-set-linter.test.js
@@ -28,7 +28,7 @@ describe('node-set-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes || []
+        const fixes = yml.found.fixes
         fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,

--- a/test/node-set-linter.test.js
+++ b/test/node-set-linter.test.js
@@ -28,8 +28,7 @@ describe('node-set-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes
-        fixes.forEach((expected, index) => {
+        yml.found.fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,
             expected,

--- a/test/predicate-position-linter.test.js
+++ b/test/predicate-position-linter.test.js
@@ -28,7 +28,7 @@ describe('predicate-position-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes || []
+        const fixes = yml.found.fixes
         fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,

--- a/test/predicate-position-linter.test.js
+++ b/test/predicate-position-linter.test.js
@@ -28,8 +28,7 @@ describe('predicate-position-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes
-        fixes.forEach((expected, index) => {
+        yml.found.fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,
             expected,

--- a/test/redundant-boolean-call-linter.test.js
+++ b/test/redundant-boolean-call-linter.test.js
@@ -28,8 +28,7 @@ describe('redundant-boolean-call-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes
-        fixes.forEach((expected, index) => {
+        yml.found.fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,
             expected,

--- a/test/redundant-boolean-call-linter.test.js
+++ b/test/redundant-boolean-call-linter.test.js
@@ -28,7 +28,7 @@ describe('redundant-boolean-call-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes || []
+        const fixes = yml.found.fixes
         fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,

--- a/test/redundant-double-negation-linter.test.js
+++ b/test/redundant-double-negation-linter.test.js
@@ -28,8 +28,7 @@ describe('redundant-double-negation-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes
-        fixes.forEach((expected, index) => {
+        yml.found.fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,
             expected,

--- a/test/redundant-double-negation-linter.test.js
+++ b/test/redundant-double-negation-linter.test.js
@@ -28,7 +28,7 @@ describe('redundant-double-negation-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes || []
+        const fixes = yml.found.fixes
         fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,

--- a/test/resources/axis-packs/abbreviated-axis.yaml
+++ b/test/resources/axis-packs/abbreviated-axis.yaml
@@ -5,6 +5,7 @@ pack: unabbreviated-axis
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">

--- a/test/resources/count-packs/count-edge-cases.yaml
+++ b/test/resources/count-packs/count-edge-cases.yaml
@@ -5,6 +5,7 @@ pack: count-compared-to-zero
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:my="urn:m" version="2.0" id="s">

--- a/test/resources/count-packs/count-with-arithmetic-operand.yaml
+++ b/test/resources/count-packs/count-with-arithmetic-operand.yaml
@@ -5,6 +5,7 @@ pack: count-compared-to-zero
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">

--- a/test/resources/count-packs/does-not-compare-count-to-zero.yaml
+++ b/test/resources/count-packs/does-not-compare-count-to-zero.yaml
@@ -5,6 +5,7 @@ pack: count-compared-to-zero
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">

--- a/test/resources/import-packs/circular-import.yaml
+++ b/test/resources/import-packs/circular-import.yaml
@@ -5,6 +5,7 @@ pack: circular-import
 found:
   amount: 2
   positions: [ [ 0, 3, 3 ], [ 1, 3, 3 ] ]
+  fixes: [ null, null ]
 inputs:
   - |-
     <?xml version="1.0"?>

--- a/test/resources/import-packs/distinct-imports.yaml
+++ b/test/resources/import-packs/distinct-imports.yaml
@@ -5,6 +5,7 @@ pack: redundant-import
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 inputs:
   - |-
     <?xml version="1.0"?>

--- a/test/resources/import-packs/external-import.yaml
+++ b/test/resources/import-packs/external-import.yaml
@@ -5,6 +5,7 @@ pack: circular-import
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 inputs:
   - |-
     <?xml version="1.0"?>

--- a/test/resources/import-packs/no-cycle.yaml
+++ b/test/resources/import-packs/no-cycle.yaml
@@ -5,6 +5,7 @@ pack: circular-import
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 inputs:
   - |-
     <?xml version="1.0"?>

--- a/test/resources/import-packs/redundant-import.yaml
+++ b/test/resources/import-packs/redundant-import.yaml
@@ -5,6 +5,7 @@ pack: redundant-import
 found:
   amount: 1
   positions: [ [ 0, 4, 3 ] ]
+  fixes: [ "" ]
 inputs:
   - |-
     <?xml version="1.0"?>

--- a/test/resources/import-packs/self-import.yaml
+++ b/test/resources/import-packs/self-import.yaml
@@ -5,6 +5,7 @@ pack: circular-import
 found:
   amount: 1
   positions: [ [ 0, 3, 3 ] ]
+  fixes: [ null ]
 inputs:
   - |-
     <?xml version="1.0"?>

--- a/test/resources/name-packs/name-compared-to-invalid-name.yaml
+++ b/test/resources/name-packs/name-compared-to-invalid-name.yaml
@@ -5,6 +5,7 @@ pack: name-compared-to-string
 found:
   amount: 1
   positions: [ [ 4, 27 ] ]
+  fixes: [ null ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">

--- a/test/resources/name-packs/name-edge-cases.yaml
+++ b/test/resources/name-packs/name-edge-cases.yaml
@@ -5,6 +5,7 @@ pack: name-compared-to-string
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:my="urn:m" version="2.0" id="s">

--- a/test/resources/namespace-packs/used-namespaces.yaml
+++ b/test/resources/namespace-packs/used-namespaces.yaml
@@ -5,6 +5,7 @@ pack: redundant-namespace-declarations
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:f="http://www.w3.org/1999/XSL/Format" version="2.0" id="style1">

--- a/test/resources/node-set-packs/does-not-use-node-set-extension.yaml
+++ b/test/resources/node-set-packs/does-not-use-node-set-extension.yaml
@@ -5,6 +5,7 @@ pack: use-node-set-extension
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">

--- a/test/resources/node-set-packs/node-set-edge-cases.yaml
+++ b/test/resources/node-set-packs/node-set-edge-cases.yaml
@@ -5,6 +5,7 @@ pack: use-node-set-extension
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">

--- a/test/resources/node-set-packs/node-set-in-result-attribute.yaml
+++ b/test/resources/node-set-packs/node-set-in-result-attribute.yaml
@@ -5,6 +5,7 @@ pack: use-node-set-extension
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">

--- a/test/resources/redundant-boolean-call-packs/boolean-call-in-result-attribute.yaml
+++ b/test/resources/redundant-boolean-call-packs/boolean-call-in-result-attribute.yaml
@@ -5,6 +5,7 @@ pack: redundant-boolean-call
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">

--- a/test/resources/redundant-double-negation-packs/not-double-negation.yaml
+++ b/test/resources/redundant-double-negation-packs/not-double-negation.yaml
@@ -5,6 +5,7 @@ pack: redundant-double-negation
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">

--- a/test/resources/result-namespace-packs/all-result-prefixes-excluded.yaml
+++ b/test/resources/result-namespace-packs/all-result-prefixes-excluded.yaml
@@ -5,6 +5,7 @@ pack: leaking-result-namespace
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" exclude-result-prefixes="#all">

--- a/test/resources/result-namespace-packs/constructed-name-uses-prefix.yaml
+++ b/test/resources/result-namespace-packs/constructed-name-uses-prefix.yaml
@@ -5,6 +5,7 @@ pack: leaking-result-namespace
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:my="urn:my" version="2.0">

--- a/test/resources/result-namespace-packs/excluded-prefix.yaml
+++ b/test/resources/result-namespace-packs/excluded-prefix.yaml
@@ -5,6 +5,7 @@ pack: leaking-result-namespace
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" exclude-result-prefixes="xs">

--- a/test/resources/result-namespace-packs/extension-element-prefix.yaml
+++ b/test/resources/result-namespace-packs/extension-element-prefix.yaml
@@ -5,6 +5,7 @@ pack: leaking-result-namespace
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:exsl="http://exslt.org/common" extension-element-prefixes="exsl" version="1.0">

--- a/test/resources/result-namespace-packs/no-literal-result.yaml
+++ b/test/resources/result-namespace-packs/no-literal-result.yaml
@@ -5,6 +5,7 @@ pack: leaking-result-namespace
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0">

--- a/test/resources/result-namespace-packs/result-uses-prefix.yaml
+++ b/test/resources/result-namespace-packs/result-uses-prefix.yaml
@@ -5,6 +5,7 @@ pack: leaking-result-namespace
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:my="urn:my" version="2.0">

--- a/test/resources/result-namespace-packs/text-output.yaml
+++ b/test/resources/result-namespace-packs/text-output.yaml
@@ -5,6 +5,7 @@ pack: leaking-result-namespace
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0">

--- a/test/resources/result-namespace-packs/two-leaking-prefixes.yaml
+++ b/test/resources/result-namespace-packs/two-leaking-prefixes.yaml
@@ -5,6 +5,7 @@ pack: leaking-result-namespace
 found:
   amount: 2
   positions: [ [ 2, 66 ], [ 2, 110 ] ]
+  fixes: [ null, null ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:my="urn:my" version="2.0">

--- a/test/resources/string-length-packs/string-length-edge-cases.yaml
+++ b/test/resources/string-length-packs/string-length-edge-cases.yaml
@@ -5,6 +5,7 @@ pack: string-length-compared-to-zero
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:my="urn:m" version="2.0" id="s">

--- a/test/resources/string-length-packs/string-length-with-arithmetic-operand.yaml
+++ b/test/resources/string-length-packs/string-length-with-arithmetic-operand.yaml
@@ -5,6 +5,7 @@ pack: string-length-compared-to-zero
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">

--- a/test/resources/translate-packs/translate-edge-cases.yaml
+++ b/test/resources/translate-packs/translate-edge-cases.yaml
@@ -5,6 +5,7 @@ pack: translate-for-case
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:my="urn:m" version="2.0" id="s">

--- a/test/resources/translate-packs/translate-for-case-in-xslt-1-0.yaml
+++ b/test/resources/translate-packs/translate-for-case-in-xslt-1-0.yaml
@@ -5,6 +5,7 @@ pack: translate-for-case
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" id="s">

--- a/test/resources/xpath-format-packs/clean-expressions.yaml
+++ b/test/resources/xpath-format-packs/clean-expressions.yaml
@@ -5,6 +5,7 @@ pack: redundant-whitespace
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">

--- a/test/resources/xpath-format-packs/redundant-whitespace.yaml
+++ b/test/resources/xpath-format-packs/redundant-whitespace.yaml
@@ -5,6 +5,7 @@ pack: redundant-whitespace
 found:
   amount: 3
   positions: [ [ 4, 31 ], [ 5, 27 ], [ 6, 29 ] ]
+  fixes: [ " ", "", "" ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">

--- a/test/resources/xpath-format-packs/skips-invalid-expression.yaml
+++ b/test/resources/xpath-format-packs/skips-invalid-expression.yaml
@@ -5,6 +5,7 @@ pack: redundant-whitespace
 found:
   amount: 0
   positions: [ ]
+  fixes: [ ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">

--- a/test/result-namespace-linter.test.js
+++ b/test/result-namespace-linter.test.js
@@ -28,7 +28,7 @@ describe('result-namespace-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes || []
+        const fixes = yml.found.fixes
         fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,

--- a/test/result-namespace-linter.test.js
+++ b/test/result-namespace-linter.test.js
@@ -28,8 +28,7 @@ describe('result-namespace-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes
-        fixes.forEach((expected, index) => {
+        yml.found.fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,
             expected,

--- a/test/string-length-linter.test.js
+++ b/test/string-length-linter.test.js
@@ -29,8 +29,7 @@ describe('string-length-linter', function() {
             assert.equal(defects[index].line, pos[0])
             assert.equal(defects[index].pos, pos[1])
           })
-          const fixes = yml.found.fixes
-          fixes.forEach((expected, index) => {
+          yml.found.fixes.forEach((expected, index) => {
             assert.equal(
               defects[index].fix ? defects[index].fix.replacement : null,
               expected,

--- a/test/string-length-linter.test.js
+++ b/test/string-length-linter.test.js
@@ -29,7 +29,7 @@ describe('string-length-linter', function() {
             assert.equal(defects[index].line, pos[0])
             assert.equal(defects[index].pos, pos[1])
           })
-          const fixes = yml.found.fixes || []
+          const fixes = yml.found.fixes
           fixes.forEach((expected, index) => {
             assert.equal(
               defects[index].fix ? defects[index].fix.replacement : null,

--- a/test/translate-linter.test.js
+++ b/test/translate-linter.test.js
@@ -28,7 +28,7 @@ describe('translate-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes || []
+        const fixes = yml.found.fixes
         fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,

--- a/test/translate-linter.test.js
+++ b/test/translate-linter.test.js
@@ -28,8 +28,7 @@ describe('translate-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes
-        fixes.forEach((expected, index) => {
+        yml.found.fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,
             expected,

--- a/test/using-namespace-axis-linter.test.js
+++ b/test/using-namespace-axis-linter.test.js
@@ -28,7 +28,7 @@ describe('using-namespace-axis-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes || []
+        const fixes = yml.found.fixes
         fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,

--- a/test/using-namespace-axis-linter.test.js
+++ b/test/using-namespace-axis-linter.test.js
@@ -28,8 +28,7 @@ describe('using-namespace-axis-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes
-        fixes.forEach((expected, index) => {
+        yml.found.fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,
             expected,

--- a/test/xpath-axis-linter.test.js
+++ b/test/xpath-axis-linter.test.js
@@ -28,8 +28,7 @@ describe('xpath-axis-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes
-        fixes.forEach((expected, index) => {
+        yml.found.fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,
             expected,

--- a/test/xpath-axis-linter.test.js
+++ b/test/xpath-axis-linter.test.js
@@ -28,7 +28,7 @@ describe('xpath-axis-linter', function() {
           assert.equal(defects[index].line, pos[0])
           assert.equal(defects[index].pos, pos[1])
         })
-        const fixes = yml.found.fixes || []
+        const fixes = yml.found.fixes
         fixes.forEach((expected, index) => {
           assert.equal(
             defects[index].fix ? defects[index].fix.replacement : null,

--- a/test/xpath-format-linter.test.js
+++ b/test/xpath-format-linter.test.js
@@ -31,8 +31,7 @@ describe('xpath-format-linter', function() {
             assert.equal(defects[index].line, pos[0])
             assert.equal(defects[index].pos, pos[1])
           })
-          const fixes = yml.found.fixes
-          fixes.forEach((expected, index) => {
+          yml.found.fixes.forEach((expected, index) => {
             assert.equal(
               defects[index].fix ? defects[index].fix.replacement : null,
               expected,

--- a/test/xpath-format-linter.test.js
+++ b/test/xpath-format-linter.test.js
@@ -31,7 +31,7 @@ describe('xpath-format-linter', function() {
             assert.equal(defects[index].line, pos[0])
             assert.equal(defects[index].pos, pos[1])
           })
-          const fixes = yml.found.fixes || []
+          const fixes = yml.found.fixes
           fixes.forEach((expected, index) => {
             assert.equal(
               defects[index].fix ? defects[index].fix.replacement : null,


### PR DESCRIPTION
Closes #607.

The `found.fixes` assertion was opt-in. Every harness read
`yml.found.fixes || []`, so a pack that never declared the key handed the loop an
empty array and the body never ran. **33 of 98 packs had opted out.**

Twenty-seven of those find nothing, so their fixes are vacuously `[ ]`. Six pin
ten positions between them, and every replacement at those was unasserted:

```text
pack                                          positions   asserted before   now
xpath-format/redundant-whitespace                     3          none        " ", "", ""
import/redundant-import                               1          none        ""
import/circular-import                                2          none        null, null
import/self-import                                    1          none        null
name/name-compared-to-invalid-name                    1          none        null
result-namespace/two-leaking-prefixes                 2          none        null, null
```

**The ticket undercounted, and deriving the set is what found the rest.** It
names thirteen harnesses and 29 packs; the gate is written to ask which packs
*are* format packs rather than to trust a list, so it reads `pack:` and tests it
against `checks/format/`. That turned up `import-packs`, a fourteenth directory
whose harness carries no fixes assertion at all — not even the opt-in one — while
`src/import-linter.js:135` attaches a real safe deletion to every
`redundant-import`. Its replacement had never been checked by anything. Same
lesson as #647: a second list of what the tree contains drifts from the tree.

Three changes, in the order they were made:

1. **The gate**, in `conformance.test.js`: a pack whose `pack:` names a format
   check must carry `found.fixes` standing one per `found.positions`. Added
   first, and it failed listing exactly those 33 — that is the reproduction.
2. **The packs**, all 33 filled. The nine real ones were computed by running
   their linters and then read back against what each check promises: a
   `redundant-whitespace` collapsing `"  "` to `" "` and dropping two gaps, the
   whole-line deletion `redundant-import` documents, and `null` wherever the
   check is report-only.
3. **The fallback, gone.** No harness says `|| []` for `fixes` any more
   (`found.values`, read by two harnesses and declared by one pack, keeps its
   own), and `import-linter.test.js` gained the block it never had. A dropped
   key now throws where it used to assert nothing.
4. **A second gate**, added in review: the pack declaring a fix is worth nothing
   if no harness reads it. Deleting the six lines this PR adds to
   `import-linter.test.js` left the suite at 1027 passing, exit 0 — the found
   bug, silently reintroducible by the next linter that ships a harness without
   the block. So `conformance.test.js` now also fails a pack directory whose
   harness never mentions `found.fixes`. With the block deleted it names
   `import-packs`; with it restored, green.

Verified by mutation rather than by assuming, since a test that asserts nothing
passes exactly like one that asserts everything:

```text
change " " to "x" in redundant-whitespace   -> xpath-format-linter  1 failing
change ""  to "nonsense" in redundant-import-> import-linter        1 failing
change null to "" in name-compared-to-...   -> name-linter          1 failing
delete the fixes key from a pack            -> conformance + name-linter 2 failing
```

The last two matter most. A `null` is as much of an assertion as a string: it
pins a check as report-only, so the `using-namespace-axis` contract #600 locked
can no longer be broken by an accidentally attached fix. And a deleted key fails
in both layers, not one.

**Left out on purpose.** `found.values`, which pins `fix.value`, has the same
opt-in shape and is declared by one pack of 98. Real second hole, different
assertion, 98 packs of work — its own ticket.

The ticket's other suggestion, folding the fourteen copies of the harness into
one, is **#660**, filed rather than done here. It is the better fix and would
have prevented `import-packs` structurally, where the second gate only catches
it; but it rewrites fourteen test files, which is not what a bug ticket about an
unasserted key should carry. The gate holds the line until then, and #660 deletes
the gate when it lands.

`npm test` 1028 passing and 0 failing, `npm run coverage` the same 1028 with
100% of statements, branches, functions and lines, and
`npx mocha test/xcop.test.js --forbid-pending` 250 passing — runnable that way
here because #645 landed first.

**A second commit is on this branch because the first one shipped broken, and
the reason is worth recording.** The mutation runs above were done on unstaged
edits and reverted with `git checkout <file>`, which restores from the index —
empty at that point — and so from `HEAD`. Three packs silently lost the `fixes`
key they had just been given: the very three that pin real positions. CI caught
it in all six `build` jobs and in `coverage`. It should have been caught here
first: the `npm run coverage` run afterwards did print `1023 passing, 4 failing`,
and it was read by tailing the last few lines, which showed only the 100%
coverage table. A coverage summary is not a test result. The mutation runs have
been redone against a staged index, each restore verified by reading the key
back.

The counts in this body were wrong too, and are corrected above: 98 format packs,
not 92, split 27 vacuous and 6 real. The 92 came from a hardcoded list of thirteen
pack directories — the same mistake the gate exists to prevent, made in the prose
describing it. The table's six rows were right.
