### PR TITLE
bug(#637): drop a freeze neither axis check had earned

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,6 +292,16 @@ check: its motive carries an `Incorrect:`/`Correct:` pair, and if it is fixable
 fixture pair exists and `fixer.test.js` runs it. The opinionated checks tracked
 in #499 are not marked mature until that issue is settled.
 
+**No check carries the flag today** (#637). The last two, both axis checks, were
+frozen around open bugs — `using-namespace-axis` around advice its own message
+cannot give inside a pattern (#632), `unabbreviated-axis` around a safe-tier fix
+that wrote a pattern no processor loads, re-flagged in `ad6bf7f` before it was
+true and then changed by six commits with the freeze still on. Nothing enforced
+the freeze either (#638), so the mark asserted what the tree could not back.
+Before adding it back, read the amendment in #644: nine checks have carried it
+and all nine were unfrozen, so the bar itself — not the discipline around it — is
+what is under review.
+
 ## Test packs
 
 Each linter owns a `test/resources/<name>-packs/` directory, auto-discovered by

--- a/src/resources/checks/format/unabbreviated-axis.yaml
+++ b/src/resources/checks/format/unabbreviated-axis.yaml
@@ -3,4 +3,3 @@
 ---
 severity: warning
 message: Verbose axis specifiers child::, attribute::, parent::node(), or self::node() are used. Replace them with the node name alone, @, .., or . respectively.
-mature: true

--- a/src/resources/checks/format/using-namespace-axis.yaml
+++ b/src/resources/checks/format/using-namespace-axis.yaml
@@ -3,4 +3,3 @@
 ---
 severity: warning
 message: "The namespace:: axis is deprecated in XSLT 2.0 and later. Use in-scope-prefixes() and namespace-uri-for-prefix() instead."
-mature: true

--- a/test/resources/axis-packs/three-axes-in-one-expression.yaml
+++ b/test/resources/axis-packs/three-axes-in-one-expression.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: unabbreviated-axis
+found:
+  amount: 5
+  positions: [ [ 4, 27 ], [ 4, 36 ], [ 4, 45 ], [ 5, 41 ], [ 5, 54 ] ]
+  fixes: [ "", "", "@", "", "" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:template match="/">
+      <xsl:value-of select="child::a/child::b/attribute::c"/>
+      <xsl:value-of select="descendant::x[child::y and child::z]"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/fix/unabbreviated-axis.fixed.xsl
+++ b/test/resources/fix/unabbreviated-axis.fixed.xsl
@@ -7,6 +7,7 @@
   <xsl:template match="R/qwer">
     <xsl:value-of select="title"/>
     <xsl:value-of select="@name"/>
+    <xsl:value-of select="a/b/@c"/>
     <xsl:apply-templates select=".."/>
     <xsl:value-of select="."/>
     <xsl:value-of select=".."/>

--- a/test/resources/fix/unabbreviated-axis.xsl
+++ b/test/resources/fix/unabbreviated-axis.xsl
@@ -7,6 +7,7 @@
   <xsl:template match="R/child::qwer">
     <xsl:value-of select="child::title"/>
     <xsl:value-of select="attribute::name"/>
+    <xsl:value-of select="child::a/child::b/attribute::c"/>
     <xsl:apply-templates select="parent::node()"/>
     <xsl:value-of select="self::node()"/>
     <xsl:value-of select="parent :: node ( )"/>


### PR DESCRIPTION
Closes #637.

Two `mature: true` lines are gone. **No check carries the flag now.**

`mature: true` is a freeze that asserts "no false positive and no false
negative", so a check frozen around an open bug is frozen around the bug. Neither
axis check held it honestly:

- **`using-namespace-axis`** is frozen around #632, whose whole point is that the
  message names two functions that cannot stand where a pattern step goes — so on
  `match="namespace::*"` the advice cannot be followed — and #632 defers itself
  *because the check is frozen*. A ticket that cannot be fixed because of the
  flag is the flag failing.
- **`unabbreviated-axis`** was re-flagged in `ad6bf7f` before it was true: at that
  commit `--fix` turned `match="y|self::node()"` into `match="y|."`, which is not
  a legal pattern in any version. A safe-tier fix on a frozen check wrote a
  stylesheet no processor loads. `master` is right today, but it got there
  through six commits to `src/xpath-axis-linter.js` with the freeze still on, the
  first of which withheld a false-positive class the freeze had certified absent.

**There is no failing test in this PR, and that is the honest shape of it.** The
defect is a false claim in data, not behaviour: nothing in `src/` reads `mature`,
only `test/conformance.test.js` does, and it merely *tightens* on checks carrying
the flag. Removing the two lines cannot make a passing test fail. Saying so is
better than manufacturing a test that pretends otherwise — and it is itself the
argument of #638, which is that nothing enforces the freeze at all.

What is testable, and is here, is the one pack gap #637 names against the bar:
the `child::`/`attribute::` branch never saw more than one occurrence in a single
expression, though the bar demands three or more to catch a first-match bug.
`test/resources/axis-packs/three-axes-in-one-expression.yaml` pins five, three of
them in one expression and two buried in a predicate:

```xsl
<xsl:value-of select="child::a/child::b/attribute::c"/>
<xsl:value-of select="descendant::x[child::y and child::z]"/>
```

It passes on arrival — this is coverage that was missing, not a bug — and
`descendant::` is correctly left alone, having no short form.

That pack pins what the linter *proposes* (`fix.replacement`). What a `--fix` run
*lands* is a separate question, and it is the one where the #571 overlap rule
could silently drop one of three fixes in a single expression, so the committed
fix fixture gained the case too:

```text
test/resources/fix/unabbreviated-axis.xsl        child::a/child::b/attribute::c
test/resources/fix/unabbreviated-axis.fixed.xsl  a/b/@c
```

The `.fixed` half was generated by running `--fix`, not written by hand, and
`fixer.test.js`'s `APPLIED` table already runs the pair and parses the result back
to prove the run left valid XML. Added in review: the first version of this PR had
verified that run by hand and left it uncommitted, which is a verification the
next change breaks in silence — the same argument #659 just landed.

**What was deliberately not done.** The rest of #637 — #632 and #631 for the one,
#629, #615 and #636 for the other, plus the severity question on an axis a 2.0
processor may reject outright with `XPST0010` — is what re-earning the mark would
take. None of it belongs in a change whose point is that the mark is currently a
false statement. #644 amends the plan further: nine checks have carried
`mature: true` and all nine were unfrozen at least once, so the bar itself is
under review, and the CLAUDE.md note added here points at that rather than
inviting the next author to re-flag something.

Much of both checks does deserve the mark and is untouched — the version handling
in particular, which reads the effective version at the node under judgement,
gates on a floor rather than a list, canonicalises the decimal, and is packed
against raised and lowered subtrees.

`npm test` 1030 passing and 0 failing, `npm run coverage` the same 1030 with 100%
of statements, branches, functions and lines, `npx mocha test/xcop.test.js
--forbid-pending` 251 passing, and `npx grunt docs` leaves the site unchanged —
the docs generator never read the flag.
