### PR TITLE
bug(#621): the gap before the bracket is part of the call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,9 @@ Then run `npm test`, `npm run coverage`, and `npx grunt docs`.
   counting — write `x` and `not(x)`, never `count(x) > 0` or `count(x) = 0`,
   the same anti-pattern `count-compared-to-zero` flags in a user's sheet.
   A comparison that asks a real cardinality (`count(x) >= 2`) is fine. This is
-  machine-enforced by `test/conformance.test.js`.
+  machine-enforced by `test/conformance.test.js`, and the gap XPath allows before
+  the `(` is part of the call, so `count (x) > 0` is caught too — it was not until
+  #621, which let one selector spend the space the user-facing check reports.
 - **Fix in the same change.** If a check is fixable, land the fix with the
   detection — never defer it. A declarative rule gets a `node => fix` builder in
   `src/fixers.js`; a code-based linter attaches the `fix` to its defect. Mark it

--- a/src/resources/checks/xpath/output-method-xml.yaml
+++ b/src/resources/checks/xpath/output-method-xml.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: (/xsl:stylesheet | /xsl:transform)/xsl:output[@method = 'xml'][//xsl:template[starts-with(@match, '/') and (count (.//html | .//HTML) > 0)]]
+xpath: (/xsl:stylesheet | /xsl:transform)/xsl:output[@method = 'xml'][//xsl:template[starts-with(@match, '/') and (.//html | .//HTML)]]
 severity: warning
 message: "xsl:output declares method='xml' while the root template generates HTML elements. Change the method to 'html'."

--- a/test/conformance.test.js
+++ b/test/conformance.test.js
@@ -61,10 +61,16 @@ const KEBAB = /^[a-z0-9]+(-[a-z0-9]+)*$/
  * A `count(...)` call compared with zero — the existence test spelled the slow
  * way, which `count-compared-to-zero` flags in a user's stylesheet and a
  * check's own selector must therefore not commit. One level of nested
- * parentheses is enough for the argument of a count.
+ * parentheses is enough for the argument of a count. The gap before the `(` is
+ * part of the call: XPath reads an NCName as a FunctionName when a `(` follows
+ * it, "possibly after intervening ExprWhitespace", so `count (x) > 0` is the
+ * same slow test spelled differently, and the user-facing check does flag it
+ * (#621). A gate blind to the space permitted in our own selectors what the
+ * check reports in someone else's.
  * @type {RegExp}
  */
-const COUNTED = /count\((?:[^()]|\([^()]*\))*\)\s*(?:!?=|[<>]=?)\s*0(?!\d)/
+const COUNTED =
+  /count\s*\((?:[^()]|\([^()]*\))*\)\s*(?:!?=|[<>]=?)\s*0(?!\d)/
 
 /**
  * Names of the checks of a kind.

--- a/test/conformance.test.js
+++ b/test/conformance.test.js
@@ -69,8 +69,7 @@ const KEBAB = /^[a-z0-9]+(-[a-z0-9]+)*$/
  * check reports in someone else's.
  * @type {RegExp}
  */
-const COUNTED =
-  /count\s*\((?:[^()]|\([^()]*\))*\)\s*(?:!?=|[<>]=?)\s*0(?!\d)/
+const COUNTED = /count\s*\((?:[^()]|\([^()]*\))*\)\s*(?:!?=|[<>]=?)\s*0(?!\d)/
 
 /**
  * Names of the checks of a kind.


### PR DESCRIPTION
Closes #621.

The selector-hygiene gate matched `count(` as one string, so a single space
walked past it. XPath reads an NCName as a FunctionName when a `(` follows,
"possibly after intervening ExprWhitespace" (XPath 1.0 §3.7), which makes
`count (x) > 0` the same slow existence test spelled differently.

```diff
-const COUNTED = /count\((?:[^()]|\([^()]*\))*\)\s*(?:!?=|[<>]=?)\s*0(?!\d)/
+const COUNTED =
+  /count\s*\((?:[^()]|\([^()]*\))*\)\s*(?:!?=|[<>]=?)\s*0(?!\d)/
```

Widened first, and it failed naming `xpath/output-method-xml` — the one selector
in the tree spending the space, and the reproduction:

```diff
-...starts-with(@match, '/') and (count (.//html | .//HTML) > 0)...
+...starts-with(@match, '/') and (.//html | .//HTML)...
```

**The asymmetry was checked, not quoted.** The sharp part of the ticket is that
the user-facing check tolerates what our own gate permitted, so a stylesheet
carrying all three spellings was run through the CLI:

```text
count(a) > 0     4:19  count-compared-to-zero
count (a) > 0    5:19  count-compared-to-zero
count  (a) > 0   6:19  count-compared-to-zero
```

All three flagged. xslint really was reporting a spelling its own selectors were
allowed to use.

**Equivalence of the rewrite was measured rather than argued.** A node-set in a
boolean context is true exactly when non-empty, in 1.0 and in the 2.0+ effective
boolean value alike, so `count(X) > 0` and `X` should agree — but "should" is not
evidence, and this predicate decides a real report. Both selectors were evaluated
over **every input of every `xpath-packs` pack, 118 of them**: they agree on all
118, and the old one selects 2 nodes in total, which are the two positive
`use-output-method-xml-for-html-*` packs. The pack needs no new row, and both
negatives (`use-output-method-xml-not-for-html`, `use-output-method-html-1`) still
find nothing.

**No neighbouring hole to file.** Every other counting comparison in
`src/resources/checks/` asks a genuine cardinality — `count(*) = 1`,
`count(xsl:when) >= 2`, `count(//xsl:template) >= 10`, `count(.//xsl:*) > 100`,
and a `string-length(@name) = 1` that means a one-character name. None is
existence in disguise, and `count(x) >= 1` appears nowhere, so the widened gate
finds the tree clean.

The gate keeps JavaScript's `\s`, which is wider than the XML `S` that XPath
means (#643). In a gate over our own selectors, wider is the safe direction: it
can only catch more of our spellings, never fewer, and it cannot produce a false
report to a user.

**The docs claim in the first version of this body was wrong, twice.** It said
`grunt docs` leaves the site unchanged and that the generator renders motives and
messages rather than selectors. `scripts/generate-docs.js:111` renders
`lint.xpath` straight into a `<code class="xpath">`, and generating the site from
`master` and from this branch differs in exactly one line, which is the corrected
selector:

```text
docs/checks/output-method-xml.html:75
- ...and (count (.//html | .//HTML) &gt; 0)]]</code>
+ ...and (.//html | .//HTML)]]</code>
```

The page changing is the right outcome — the published selector should be the
corrected one. What misled the check is that `docs/` is `.gitignore`d at line 2,
so `git status` after `grunt docs` is clean whatever the generator does. That
signal cannot show docs drift, which is the same shape as reading a coverage
table instead of the result line. `docs/` is generated, not committed, so nothing
is staged here.

`npm test` 1030 passing and 0 failing, `npm run coverage` the same 1030 with 100%
of statements, branches, functions and lines, `npx mocha test/xcop.test.js
--forbid-pending` 251 passing, and `npx eslint` clean.
