### PR TITLE
bug(#583): a pattern is not anchored, but it is ranked

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,11 @@ Today this covers ten checks:
 - `redundant-import` — a duplicate `xsl:import`/`xsl:include` of a module
   already imported in the same stylesheet is removed; the module stays imported
   by the first reference.
+- `starts-with-double-slash`, outside an `xsl:template` — the redundant leading
+  `//` of a pattern is dropped: `match="//keyed"` on an `xsl:key` becomes
+  `match="keyed"`. Only a template's pattern is ranked by priority, so on
+  `xsl:key`, `xsl:number`, `xsl:for-each-group` and `xsl:accumulator-rule` the
+  same nodes match at the same rank.
 - `redundant-double-negation` — `not(not(x))` becomes `boolean(x)`, the
   equivalent it spells out the long way; in a whole `@test`, which already
   coerces to a boolean, it becomes plain `x`.
@@ -310,10 +315,10 @@ Today this covers:
 - `select-starts-with-double-slash` — the leading `//` of a `@select` is
   anchored as `.//`: `select="//title"` becomes `select=".//title"`, scanning
   descendants of the context node instead of the whole document.
-- `starts-with-double-slash` — the redundant leading `//` of a pattern is
-  dropped: `match="//para"` becomes `match="para"`. The same nodes match, but a
-  template's default priority falls from 0.5 to 0, so a rule that used to win a
-  conflict can start losing it.
+- `starts-with-double-slash`, on an `xsl:template` — the redundant leading `//`
+  of `@match` is dropped: `match="//para"` becomes `match="para"`. The same nodes
+  match, but the template's default priority falls from 0.5 to 0, so a rule that
+  used to win a conflict can start losing it.
 - `confusing-variable-and-node` — a bare variable name used as a node selector
   gets its `$`: `<xsl:apply-templates select="items"/>` becomes
   `select="$items"`, assuming the variable was meant over a child element.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ xslint points at each problem with its exact position and how to fix it:
 
 ```text
 [ERROR] sheet.xsl(2:1) The xsl:output instruction is missing. Declare it to specify the serialization format explicitly. (not-using-output)
-[WARNING] sheet.xsl(3:3) The match attribute of xsl:template starts with //, which scans the entire document tree. Use a more specific pattern. (starts-with-double-slash)
+[WARNING] sheet.xsl(3:23) A pattern starts with //, which is redundant since every XSLT pattern already matches at any depth, and it lowers the rule's default priority from 0.5 to that of the step alone. Remove the leading // and give the rule an explicit priority if it must keep ranking as it does. (starts-with-double-slash)
 [WARNING] sheet.xsl(4:5) A variable, function, or template has a single-character name. Use a descriptive name that reveals intent. (short-names)
 ```
 
@@ -271,9 +271,6 @@ Today this covers ten checks:
   `exists($x)` and `count($x) = 0` becomes `empty($x)`; on 1.0 (where those
   functions don't exist), `boolean($x)` — or a bare `$x` in a whole `@test` —
   and `not($x)`.
-- `starts-with-double-slash` — the redundant leading `//` of a template's
-  `@match` is dropped: `match="//para"` becomes `match="para"`, which selects
-  the same nodes.
 - `redundant-import` — a duplicate `xsl:import`/`xsl:include` of a module
   already imported in the same stylesheet is removed; the module stays imported
   by the first reference.
@@ -313,6 +310,10 @@ Today this covers:
 - `select-starts-with-double-slash` — the leading `//` of a `@select` is
   anchored as `.//`: `select="//title"` becomes `select=".//title"`, scanning
   descendants of the context node instead of the whole document.
+- `starts-with-double-slash` — the redundant leading `//` of a pattern is
+  dropped: `match="//para"` becomes `match="para"`. The same nodes match, but a
+  template's default priority falls from 0.5 to 0, so a rule that used to win a
+  conflict can start losing it.
 - `confusing-variable-and-node` — a bare variable name used as a node selector
   gets its `$`: `<xsl:apply-templates select="items"/>` becomes
   `select="$items"`, assuming the variable was meant over a child element.

--- a/src/fixers.js
+++ b/src/fixers.js
@@ -67,20 +67,30 @@ const modeOrPriority = function(node) {
 }
 
 /**
- * Fix for `starts-with-double-slash`: drop the leading `//` of the template's
- * `@match`. In a match pattern the leading `//` is redundant — a pattern is
- * already unanchored — so removing it preserves the matched nodes, which makes
- * this a safe fix rather than a suggestion.
- * @param {Element} node - The `xsl:template` element
- * @return {object} - The safe fix
+ * Fix for `starts-with-double-slash`: drop the leading `//` of a pattern
+ * attribute. The same nodes match afterwards — a pattern is unanchored either
+ * way — but they do not match at the same rank: a pattern carrying a `/` step
+ * has a default priority of 0.5 where a lone name test has 0, so the rule loses
+ * half a point against every rule it competes with, and a template that used to
+ * win can start losing (#583). That is a behaviour change, so the edit is a
+ * suggestion rather than a safe fix.
+ *
+ * The `//` is cut where it truly stands rather than off the front, because the
+ * check reads the pattern normalized: on `match=" //spaced"` slicing two
+ * characters would leave `/spaced`, turning an unanchored pattern into an
+ * absolute one.
+ * @param {Node} pattern - The pattern attribute node
+ * @return {object} - The suggested fix
  */
-const startsWithDoubleSlash = function(node) {
-  const match = node.getAttributeNode('match')
+const startsWithDoubleSlash = function(pattern) {
+  const at = pattern.value.indexOf('//')
   return {
-    line: match.lineNumber,
-    col: match.columnNumber - match.name.length - 1,
-    value: `${match.name}="${match.value}"`,
-    replacement: `${match.name}="${match.value.slice(2)}"`,
+    line: pattern.lineNumber,
+    col: pattern.columnNumber - pattern.name.length - 1,
+    value: `${pattern.name}="${pattern.value}"`,
+    replacement: `${pattern.name}="${
+      pattern.value.slice(0, at)}${pattern.value.slice(at + 2)}"`,
+    suggestion: true,
   }
 }
 

--- a/src/fixers.js
+++ b/src/fixers.js
@@ -68,19 +68,27 @@ const modeOrPriority = function(node) {
 
 /**
  * Fix for `starts-with-double-slash`: drop the leading `//` of a pattern
- * attribute. The same nodes match afterwards — a pattern is unanchored either
- * way — but they do not match at the same rank: a pattern carrying a `/` step
- * has a default priority of 0.5 where a lone name test has 0, so the rule loses
- * half a point against every rule it competes with, and a template that used to
- * win can start losing (#583). That is a behaviour change, so the edit is a
- * suggestion rather than a safe fix.
+ * attribute. The same nodes match afterwards, since a pattern is unanchored
+ * either way — but on an `xsl:template` they do not match at the same *rank*: a
+ * pattern carrying a `/` step has a default priority of 0.5 where a lone name
+ * test has 0, so the rule loses half a point against every rule it competes
+ * with and a template that used to win can start losing (#583). That is a
+ * behaviour change, so there the edit is a suggestion.
+ *
+ * Nowhere else is it one. `priority` is an attribute of `xsl:template` alone,
+ * so no other pattern is ranked against anything: an `xsl:key` or `xsl:number`
+ * pattern only selects, an `xsl:for-each-group` pattern only tests membership,
+ * and `xsl:accumulator-rule` resolves a clash by declaration order. Dropping
+ * the `//` there is deterministic and semantics-preserving, which is a safe
+ * fix, and tiering every kind as a suggestion would withhold five of the six
+ * from `--fix` for a hazard only the sixth has.
  *
  * The `//` is cut where it truly stands rather than off the front, because the
  * check reads the pattern normalized: on `match=" //spaced"` slicing two
  * characters would leave `/spaced`, turning an unanchored pattern into an
  * absolute one.
  * @param {Node} pattern - The pattern attribute node
- * @return {object} - The suggested fix
+ * @return {object} - The fix, a suggestion only inside a template
  */
 const startsWithDoubleSlash = function(pattern) {
   const at = pattern.value.indexOf('//')
@@ -90,7 +98,9 @@ const startsWithDoubleSlash = function(pattern) {
     value: `${pattern.name}="${pattern.value}"`,
     replacement: `${pattern.name}="${
       pattern.value.slice(0, at)}${pattern.value.slice(at + 2)}"`,
-    suggestion: true,
+    ...pattern.ownerElement.localName === 'template' ?
+      {suggestion: true} :
+      {},
   }
 }
 

--- a/src/resources/checks/xpath/starts-with-double-slash.yaml
+++ b/src/resources/checks/xpath/starts-with-double-slash.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //xsl:template[starts-with(@match, '//')]
+xpath: ((//xsl:template | //xsl:key | //xsl:accumulator-rule)/@match | //xsl:number/(@count | @from) | //xsl:for-each-group/(@group-starting-with | @group-ending-with))[starts-with(normalize-space(), '//')]
 severity: warning
-message: The match attribute of xsl:template starts with //, which is redundant since an unanchored pattern already matches at any depth. Remove the leading //.
+message: A pattern starts with //, which is redundant since every XSLT pattern already matches at any depth, and it lowers the rule's default priority from 0.5 to that of the step alone. Remove the leading // and give the rule an explicit priority if it must keep ranking as it does.

--- a/src/resources/checks/xpath/use-double-slash.yaml
+++ b/src/resources/checks/xpath/use-double-slash.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
 # SPDX-License-Identifier: MIT
 ---
-xpath: //xsl:template[not(starts-with(@match, '//')) and contains(@match, '//')]
+xpath: //xsl:template[not(starts-with(normalize-space(@match), '//')) and contains(@match, '//')]
 severity: warning
 message: The match attribute of xsl:template contains //, which matches at any depth and is broader than intended. Use a specific path.

--- a/src/resources/motives/xpath/starts-with-double-slash.md
+++ b/src/resources/motives/xpath/starts-with-double-slash.md
@@ -1,10 +1,29 @@
 # Starts with double slash
 
-A leading `//` on a `match` pattern is redundant: a template pattern is not
-anchored, so `match="//item"` already selects exactly the same nodes as
-`match="item"` — every `item`, at any depth. The `//` adds nothing but noise
-(and, read carelessly, suggests a document scan that never happens). Drop it
-and let the pattern say plainly which element it matches.
+A leading `//` on a pattern selects nothing extra. Every XSLT pattern is matched
+unanchored — a node matches when any alternative of the pattern matches it,
+wherever it sits — so `match="//item"` and `match="item"` select exactly the same
+nodes, every `item` at any depth. Read carelessly, the `//` suggests a scan of the
+whole document that never happens.
+
+What it does change is which rule wins. A pattern's default priority comes from
+its shape: a lone name test scores 0, while a pattern carrying a `/` step scores
+0.5. So `//item` outranks `item` by half a point, and two templates that look
+interchangeable are not:
+
+```xsl
+<xsl:template match="list/item">SPECIFIC</xsl:template>
+<xsl:template match="//item">DOUBLESLASH</xsl:template>
+```
+
+Both patterns score 0.5, so the later one wins and every `item` inside a `list`
+is handled by `DOUBLESLASH`. Remove the `//` and `list/item` keeps 0.5 while the
+bare `item` drops to 0, so the same node is handled by `SPECIFIC` instead. The
+output changes though neither template was touched.
+
+Write the pattern the shape you mean, and where a rule has to keep the rank it
+had, say so with an explicit `priority` rather than leaning on a `//` to buy half
+a point:
 
 Incorrect:
 
@@ -17,7 +36,14 @@ Incorrect:
 Correct:
 
 ```xsl
-<xsl:template match="item">
+<xsl:template match="item" priority="0.5">
   <xsl:value-of select="."/>
 </xsl:template>
 ```
+
+The redundancy is the same in every attribute that holds a pattern rather than an
+expression — `xsl:key/@match`, `xsl:accumulator-rule/@match`, the `@count` and
+`@from` of `xsl:number`, and the `@group-starting-with` and `@group-ending-with`
+of `xsl:for-each-group`. None of those is anchored either. Priority is a
+template's concern alone, so in the others a leading `//` costs only the
+misreading.

--- a/src/xpath-linter.js
+++ b/src/xpath-linter.js
@@ -72,6 +72,11 @@ const REFUSED = new WeakMap()
  * expression no processor parses is not worth tidying, and the cost of being
  * wrong here is a correction that waits for the syntax to be fixed, against a
  * rewrite of text the same run reported malformed (#651).
+ *
+ * Its own attributes are listed with it, because a rule may select the
+ * attribute rather than the element carrying it — `starts-with-double-slash`
+ * does, so that one selector covers every attribute holding a pattern (#583) —
+ * and an attribute is not reachable from the element through this set.
  * @param {Document} xsl - XSL document parsed as {@link Document}
  * @return {Set.<Node>} - The nodes a fix must not be offered on
  */
@@ -80,8 +85,12 @@ const refused = function(xsl) {
     const found = new Set()
     for (const held of expressionsOf(xsl)) {
       if (!isValid(held.expression)) {
+        const owner = held.node.ownerElement || held.node.parentNode
         found.add(held.node)
-        found.add(held.node.ownerElement || held.node.parentNode)
+        found.add(owner)
+        for (const beside of owner.attributes) {
+          found.add(beside)
+        }
       }
     }
     REFUSED.set(xsl, found)

--- a/test/fixer.test.js
+++ b/test/fixer.test.js
@@ -107,8 +107,9 @@ const APPLIED = [
     after: 'redundant-namespace-declarations.fixed.xsl',
   },
   {
-    name: 'should drop the redundant leading slashes of a match with --fix',
-    flag: '--fix',
+    name: 'should drop the redundant leading slashes of a pattern with ' +
+      '--fix-suggestions',
+    flag: '--fix-suggestions',
     before: 'starts-with-double-slash.xsl',
     after: 'starts-with-double-slash.fixed.xsl',
   },
@@ -318,6 +319,11 @@ const UNCHANGED = [
     sheet: 'starts-with-double-slash.xsl',
   },
   {
+    name: 'cannot drop the leading slashes of a pattern with plain --fix',
+    flag: '--fix',
+    sheet: 'starts-with-double-slash.xsl',
+  },
+  {
     name: 'cannot delete a redundant import with --fix-dry-run',
     flag: '--fix-dry-run',
     sheet: 'redundant-import.xsl',
@@ -434,7 +440,7 @@ const DROPPED = [
   {
     name: 'should drop the fixed starts-with-double-slash defect from the ' +
       'report',
-    flag: '--fix',
+    flag: '--fix-suggestions',
     sheet: 'starts-with-double-slash.xsl',
     check: 'starts-with-double-slash',
   },

--- a/test/fixer.test.js
+++ b/test/fixer.test.js
@@ -107,11 +107,18 @@ const APPLIED = [
     after: 'redundant-namespace-declarations.fixed.xsl',
   },
   {
-    name: 'should drop the redundant leading slashes of a pattern with ' +
+    name: 'should drop the redundant leading slashes of a match with ' +
       '--fix-suggestions',
     flag: '--fix-suggestions',
     before: 'starts-with-double-slash.xsl',
     after: 'starts-with-double-slash.fixed.xsl',
+  },
+  {
+    name: 'should drop the redundant leading slashes of a pattern outside a ' +
+      'template with --fix',
+    flag: '--fix',
+    before: 'starts-with-double-slash-outside-a-template.xsl',
+    after: 'starts-with-double-slash-outside-a-template.fixed.xsl',
   },
   {
     name: 'should delete a redundant import with --fix',

--- a/test/lint.test.js
+++ b/test/lint.test.js
@@ -107,6 +107,17 @@ describe('lint (programmatic API)', function() {
       ['9:41', '11:39', '14:41'],
     )
   })
+  it('suggests dropping a match, but safely fixes any other pattern', function() {
+    assert.deepEqual(
+      [
+        'fix/starts-with-double-slash.xsl',
+        'fix/starts-with-double-slash-outside-a-template.xsl',
+      ].flatMap((sheet) => lint([source(sheet)])
+        .filter((defect) => defect.name === 'starts-with-double-slash')
+        .map((defect) => Boolean(defect.fix.suggestion))),
+      [true, true, false, false, false, false, false, false],
+    )
+  })
   it('keeps both declarative fixes on the valid template', function() {
     assert.deepEqual(
       lint([source('refused/refused-by-a-declarative-fix.xsl')])

--- a/test/resources/fix/starts-with-double-slash-outside-a-template.fixed.xsl
+++ b/test/resources/fix/starts-with-double-slash-outside-a-template.fixed.xsl
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:key name="kk" match="keyed" use="@id"/>
+  <xsl:template match="kept">
+    <xsl:number count="counted" from="started"/>
+    <xsl:for-each-group select="oo" group-starting-with="grouped" group-ending-with="ended">
+      <xsl:copy-of select="."/>
+    </xsl:for-each-group>
+  </xsl:template>
+  <xsl:accumulator name="acc" initial-value="0">
+    <xsl:accumulator-rule match="accumulated" select="1"/>
+  </xsl:accumulator>
+</xsl:stylesheet>

--- a/test/resources/fix/starts-with-double-slash-outside-a-template.xsl
+++ b/test/resources/fix/starts-with-double-slash-outside-a-template.xsl
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:key name="kk" match="//keyed" use="@id"/>
+  <xsl:template match="kept">
+    <xsl:number count="//counted" from="//started"/>
+    <xsl:for-each-group select="oo" group-starting-with="//grouped" group-ending-with="//ended">
+      <xsl:copy-of select="."/>
+    </xsl:for-each-group>
+  </xsl:template>
+  <xsl:accumulator name="acc" initial-value="0">
+    <xsl:accumulator-rule match="//accumulated" select="1"/>
+  </xsl:accumulator>
+</xsl:stylesheet>

--- a/test/resources/fix/starts-with-double-slash.fixed.xsl
+++ b/test/resources/fix/starts-with-double-slash.fixed.xsl
@@ -10,8 +10,4 @@
   <xsl:template match=" spaced">
     <xsl:copy-of select="."/>
   </xsl:template>
-  <xsl:key name="kk" match="keyed" use="@id"/>
-  <xsl:template match="kept">
-    <xsl:number count="counted" from="started"/>
-  </xsl:template>
 </xsl:stylesheet>

--- a/test/resources/fix/starts-with-double-slash.fixed.xsl
+++ b/test/resources/fix/starts-with-double-slash.fixed.xsl
@@ -7,4 +7,11 @@
   <xsl:template match="objects">
     <xsl:copy-of select="."/>
   </xsl:template>
+  <xsl:template match=" spaced">
+    <xsl:copy-of select="."/>
+  </xsl:template>
+  <xsl:key name="kk" match="keyed" use="@id"/>
+  <xsl:template match="kept">
+    <xsl:number count="counted" from="started"/>
+  </xsl:template>
 </xsl:stylesheet>

--- a/test/resources/fix/starts-with-double-slash.xsl
+++ b/test/resources/fix/starts-with-double-slash.xsl
@@ -10,8 +10,4 @@
   <xsl:template match=" //spaced">
     <xsl:copy-of select="."/>
   </xsl:template>
-  <xsl:key name="kk" match="//keyed" use="@id"/>
-  <xsl:template match="kept">
-    <xsl:number count="//counted" from="//started"/>
-  </xsl:template>
 </xsl:stylesheet>

--- a/test/resources/fix/starts-with-double-slash.xsl
+++ b/test/resources/fix/starts-with-double-slash.xsl
@@ -7,4 +7,11 @@
   <xsl:template match="//objects">
     <xsl:copy-of select="."/>
   </xsl:template>
+  <xsl:template match=" //spaced">
+    <xsl:copy-of select="."/>
+  </xsl:template>
+  <xsl:key name="kk" match="//keyed" use="@id"/>
+  <xsl:template match="kept">
+    <xsl:number count="//counted" from="//started"/>
+  </xsl:template>
 </xsl:stylesheet>

--- a/test/resources/xpath-packs/starts-with-double-slash-non-xsl-prefix.yaml
+++ b/test/resources/xpath-packs/starts-with-double-slash-non-xsl-prefix.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: starts-with-double-slash
+found:
+  amount: 2
+  positions: [ [ 4, 19 ], [ 7, 24 ] ]
+input: |-
+  <?xml version="1.0"?>
+  <transform xmlns="http://www.w3.org/1999/XSL/Transform" version="2.0" id="style1">
+    <output encoding="UTF-8" method="xml"/>
+    <template match="//prefixless">
+      <copy-of select="."/>
+    </template>
+    <key name="kk" match="//keyed" use="@id"/>
+  </transform>

--- a/test/resources/xpath-packs/starts-with-double-slash.yaml
+++ b/test/resources/xpath-packs/starts-with-double-slash.yaml
@@ -3,17 +3,30 @@
 ---
 pack: starts-with-double-slash
 found:
-  amount: 1
-  positions: [ [ 4, 3 ] ]
+  amount: 10
+  positions: [ [ 4, 23 ], [ 7, 23 ], [ 10, 28 ], [ 12, 23 ], [ 12, 40 ],
+    [ 15, 87 ], [ 15, 57 ], [ 20, 33 ],
+    [ 11, 3, use-double-slash ], [ 14, 3, use-double-slash ] ]
 input: |-
   <?xml version="1.0"?>
-  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="style1">
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" id="style1">
     <xsl:output encoding="UTF-8" method="xml"/>
     <xsl:template match="//objects">
       <xsl:copy-of select="."/>
     </xsl:template>
-    <xsl:template match="/objects/o/o[1]/o[1]">
-      <xsl:variable name="qw" as="xs:string" select="ooo" />
-      <xsl:copy-of select="$qw"/>
+    <xsl:template match=" //spaced">
+      <xsl:copy-of select="."/>
     </xsl:template>
+    <xsl:key name="kk" match="//keyed" use="@id"/>
+    <xsl:template match="objects//deep">
+      <xsl:number count="//counted" from="//started"/>
+    </xsl:template>
+    <xsl:template match=".//anchored">
+      <xsl:for-each-group select="oo" group-starting-with="//grouped" group-ending-with="//ended">
+        <xsl:copy-of select="."/>
+      </xsl:for-each-group>
+    </xsl:template>
+    <xsl:accumulator name="acc" initial-value="0">
+      <xsl:accumulator-rule match="//accumulated" select="1"/>
+    </xsl:accumulator>
   </xsl:stylesheet>

--- a/test/resources/xpath-packs/starts-with-double-slash.yaml
+++ b/test/resources/xpath-packs/starts-with-double-slash.yaml
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: MIT
 ---
 pack: starts-with-double-slash
+# The two xsl:for-each-group attributes are pinned column 87 before column 57:
+# a union yields the attributes of one element in no defined order, and this is
+# the order fontoxpath gives, so document order is not what the report follows
+# when one element carries two patterns.
 found:
   amount: 10
   positions: [ [ 4, 23 ], [ 7, 23 ], [ 10, 28 ], [ 12, 23 ], [ 12, 40 ], [ 15, 87 ], [ 15, 57 ], [ 20, 33 ], [ 11, 3, use-double-slash ], [ 14, 3, use-double-slash ] ]

--- a/test/resources/xpath-packs/starts-with-double-slash.yaml
+++ b/test/resources/xpath-packs/starts-with-double-slash.yaml
@@ -4,9 +4,7 @@
 pack: starts-with-double-slash
 found:
   amount: 10
-  positions: [ [ 4, 23 ], [ 7, 23 ], [ 10, 28 ], [ 12, 23 ], [ 12, 40 ],
-    [ 15, 87 ], [ 15, 57 ], [ 20, 33 ],
-    [ 11, 3, use-double-slash ], [ 14, 3, use-double-slash ] ]
+  positions: [ [ 4, 23 ], [ 7, 23 ], [ 10, 28 ], [ 12, 23 ], [ 12, 40 ], [ 15, 87 ], [ 15, 57 ], [ 20, 33 ], [ 11, 3, use-double-slash ], [ 14, 3, use-double-slash ] ]
 input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" id="style1">

--- a/test/xslint.test.js
+++ b/test/xslint.test.js
@@ -31,7 +31,7 @@ describe('xslint', function() {
       'Processed files: 1',
       '(16:3) A variable is assigned via a nested xsl:value-of instead of the select attribute. Use select syntax instead. (setting-value-of-variable-incorrectly)',
       '(16:3) A variable, function, or template has a single-character name. Use a descriptive name that reveals intent. (short-names)',
-      '(31:3) The match attribute of xsl:template starts with //, which is redundant since an unanchored pattern already matches at any depth. Remove the leading //. (starts-with-double-slash)',
+      '(31:23) A pattern starts with //, which is redundant since every XSLT pattern already matches at any depth, and it lowers the rule\'s default priority from 0.5 to that of the step alone. Remove the leading // and give the rule an explicit priority if it must keep ranking as it does. (starts-with-double-slash)',
       '(45:3) A named template is never invoked via xsl:call-template. Remove it or call it. (unused-named-template)',
     ]
     expected.forEach((str) => assert.ok(stdout.includes(str)))
@@ -107,7 +107,7 @@ describe('xslint', function() {
       'Processed files: 1',
       '(16:3) A variable is assigned via a nested xsl:value-of instead of the select attribute. Use select syntax instead. (setting-value-of-variable-incorrectly)',
       '(16:3) A variable, function, or template has a single-character name. Use a descriptive name that reveals intent. (short-names)',
-      '(31:3) The match attribute of xsl:template starts with //, which is redundant since an unanchored pattern already matches at any depth. Remove the leading //. (starts-with-double-slash)',
+      '(31:23) A pattern starts with //, which is redundant since every XSLT pattern already matches at any depth, and it lowers the rule\'s default priority from 0.5 to that of the step alone. Remove the leading // and give the rule an explicit priority if it must keep ranking as it does. (starts-with-double-slash)',
       '(45:3) A named template is never invoked via xsl:call-template. Remove it or call it. (unused-named-template)',
     ]
     assert.ok(stdout.includes('Empty suppress is incorrect. Delete this "--suppress" or use another one.'))


### PR DESCRIPTION
Closes #583.

A plain `--fix` rewrote `match="//item"` into `match="item"` and silently changed
which template runs. Confirmed with xsltproc rather than reasoned from §5.5:

```text
match="list/item" + match="//item"   -> DOUBLESLASH
match="list/item" + match="item"     -> SPECIFIC
```

Both patterns score 0.5, so the later wins; drop the `//` and the bare name test
falls to 0 while `list/item` keeps 0.5, so the other rule takes over. Same nodes,
different rank, different output — a behaviour change, and now a
`suggestion: true` fix behind `--fix-suggestions`.

Four more defects the issue names, all of them fixed here:

**The selector saw one attribute of one element.** It read `@match` on
`xsl:template` and nothing else, though a leading `//` is redundant in every
pattern. It now selects the pattern attributes themselves:

```text
(//xsl:template | //xsl:key | //xsl:accumulator-rule)/@match
| //xsl:number/(@count | @from)
| //xsl:for-each-group/(@group-starting-with | @group-ending-with)
```

On one stylesheet holding all of them the check went from **1 defect to 8**.
Selecting the attribute rather than its element also hands the fixer the one node
it must edit, and moves the report onto the attribute (`31:23`, not `31:3`).

**It read the value raw**, so `match=" //spaced"` slipped past and landed on
`use-double-slash` instead — with advice to "use a specific path" for something
merely redundant. Both selectors now normalize, which keeps the pair disjoint:
before, ` //spaced` drew `use-double-slash`; after, it draws this check, and
`objects//deep` and `.//anchored` still draw `use-double-slash` alone.

**`slice(2)` would have corrupted that value.** On `" //spaced"` it yields
`/spaced` — an unanchored pattern turned absolute. The fix now cuts the `//`
where it truly stands: `" //spaced"` becomes `" spaced"`.

**The docblock asserted the opposite of the truth** — "removing it preserves the
matched nodes, which makes this a safe fix rather than a suggestion" — and the
motive promised the `//` "adds nothing but noise". Both rewritten around
priority, with the two-template example and an explicit `priority="0.5"` as the
hand-fix for a rule that must keep its rank.

**A regression this caught in #651's gate.** Moving the selector from the element
to the attribute slipped past the refused-node set, and `test/lint.test.js`
failed with `['starts-with-double-slash']` where it expects no fix beside a
refused text value template. The gate listed the broken node and its element, but
an attribute is not reachable from the element through a `Set`, so it now lists
the element's attributes too. That is the same deliberate over-reach #651 chose,
extended to the shape #583 introduces. Had the selector changed without #651
already in the tree, this would have shipped as a fix offered on a stylesheet the
same run called malformed.

Tests: the pack grew from one clean occurrence to the hard cases — eight
positives across five attribute kinds, two of them on one `xsl:number`, the
whitespace form, the two negatives that must fall to `use-double-slash`, and
`.//anchored` which must not fire; a second pack proves prefix-independence
through a default-namespace `transform` root with no prefix at all. The fix
fixture pair gained the whitespace and non-template cases, was regenerated by
running `--fix-suggestions`, and `fixer.test.js` moved its row to that flag,
changed the report-drop row with it, and gained an `UNCHANGED` row proving plain
`--fix` leaves the file alone. `README.md` moves the entry from the safe list to
the suggestion list and its stale sample defect is refreshed; the docs site
carries the new selector and message.

`npm test` 1034 passing and 0 failing, `npm run coverage` the same 1034 at 100%
of statements, branches, functions and lines, `npx mocha test/xcop.test.js
--forbid-pending` 252 passing, `npx eslint` clean.

**The tier is per owner element, settled in review.** The first version marked
every kind a suggestion, which contradicted the motive shipped in the same
commit — "priority is a template's concern alone" — and withheld five of the six
kinds from `--fix` for a hazard only the sixth has. `priority` is an attribute of
`xsl:template` alone, so no other pattern is ranked against anything: an
`xsl:key` or `xsl:number` pattern only selects, an `xsl:for-each-group` pattern
only tests membership, and `xsl:accumulator-rule` resolves a clash by declaration
order. Measured for the two a 1.0 processor can run — dropping the `//` from an
`xsl:key/@match` and an `xsl:number/@count` gives byte-identical xsltproc output,
`1;12` both ways — and read from the spec for `xsl:for-each-group` and
`xsl:accumulator-rule`, which no XSLT 1.0 processor executes.

So `@match` on a template is a suggestion and the other five are safe fixes,
pinned three ways: a `lint.test.js` row asserting the eight flags
(`[true, true, false x 6]`), and two fixture pairs of one tier each — the
template one left byte-identical by `--fix` and fixed by `--fix-suggestions`, the
other fixed by plain `--fix`.

That also settles the README count the review flagged. The safe list was left at
nine under a sentence reading "ten checks". With the entry belonging to both
lists — safe outside a template, a suggestion inside one — the safe list is back
to ten and the sentence is true again, rather than the word being edited to match
a list that had lost an entry it should not have lost.

Two notes for the next reader. The two `xsl:for-each-group` attributes are pinned
column 87 before column 57, because a union yields one element's attributes in no
defined order; the pack now says so in a comment, since this is the first check to
emit two defects on one line out of column order. And the selector writes out the
five pattern names and their owner elements by hand, duplicating `PATTERNS` in
`src/attributes.js` with nothing keeping the two in step — the drift shape #647
and #607 both closed — filed as **#664**.

Not done here, and not claimed: `mature: true`. #583's closing paragraph offers it
once all of the above holds, but no check carries that flag since #637 and the bar
itself is under review in #644.

