### PR TITLE
bug(#643): one spelling of a gap, and a ban on the other

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,12 @@ the exit — decides what it carries: a lookup keyed on the deciding values
 enclosing function, so a `map`/`every` callback carrying its own single `return`
 is fine, and an arrow with an expression body has none at all.
 
+A gap is spelled one way: `GAP` (or `WHITESPACE`) from `src/tokens.js`, the four
+characters of XML's `S`. JavaScript's `\s` is banned by a `no-restricted-syntax`
+selector in every regex literal and template, because it also matches a no-break
+space and the Unicode spaces, so a scan spelling its gap that way reads a call in
+`boolean&#xA0;(a)` that no processor parses (#643).
+
 **Every style or consistency convention must be machine-enforced.** When you fix
 one, do not just fix the instances — in the same change add a check that fails on
 the next violation (prefer a new `no-restricted-syntax` selector so no dependency
@@ -414,7 +420,7 @@ accidentally attached fix turns red.
 | `src/xsl-version.js` | `versionOf(node)` — the version in force at a node, from the nearest ancestor's `@version` (XSLT element) or `@xsl:version` (literal result element), canonicalised as a decimal; `since(version, floor)` for a lower-bound gate; shared `MODERN`/`KNOWN`/`DECIMAL` |
 | `src/comparisons.js` | `comparedToZero` — shared scan for a call compared with `0`/`1` (count, string-length) |
 | `src/expressions.js` | `masked`/`closes` lexer helpers (node-set, double-negation, boolean-call); `enclosed` — the expressions an AVT holds in its braces |
-| `src/tokens.js` | Positioned XPath lexer (`tokenized`, `TOKENS`), preserving whitespace; owns `WHITESPACE`, the XML `S` a gap is spelled with, and `spelling`, which answers whether a name runs up to an offset. `src/xpath.js` borrows both; six code-based linters still read a gap as JavaScript's `\s`, which is wider (#643) |
+| `src/tokens.js` | Positioned XPath lexer (`tokenized`, `TOKENS`), preserving whitespace; owns the one definition of a gap — `WHITESPACE`, the XML `S` a gap is spelled with, and `GAP`, the same four characters as a regular-expression class — plus `spelling`, which answers whether a name runs up to an offset. Every reader of a gap borrows one of them, and a `no-restricted-syntax` selector bans `\s` outright, because JavaScript's class also takes a no-break space and so reads a call in `boolean&#xA0;(a)` where no processor sees one (#643) |
 | `src/import-graph.js` | Resolves `xsl:import`/`xsl:include` hrefs: `importsOf`, `graphOf` |
 | `src/fixers.js` | Maps a declarative check name to a `node => fix` builder |
 | `src/fixes.js` | Shared fix builders (`deletion(attribute)`) |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -80,7 +80,7 @@ export default defineConfig([
             "Do not use the 'node:' prefix in import; use the bare name"
         },
         {
-          selector: "Literal[regex.pattern=/\\\\s/], TemplateElement[value.cooked=/\\\\s/]",
+          selector: "Literal[regex.pattern=/\\\\s/], Literal[value=/\\\\s/], TemplateElement[value.cooked=/\\\\s/]",
           message:
             "Do not spell a whitespace gap as \\s: JavaScript's class is wider than the XML S that XPath and XSLT mean, so it reads a gap where the grammar has none. Use GAP (or WHITESPACE) from src/tokens.js"
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -80,6 +80,11 @@ export default defineConfig([
             "Do not use the 'node:' prefix in import; use the bare name"
         },
         {
+          selector: "Literal[regex.pattern=/\\\\s/], TemplateElement[value.cooked=/\\\\s/]",
+          message:
+            "Do not spell a whitespace gap as \\s: JavaScript's class is wider than the XML S that XPath and XSLT mean, so it reads a gap where the grammar has none. Use GAP (or WHITESPACE) from src/tokens.js"
+        },
+        {
           selector: "Literal[value=/\\/\\/@/]",
           message:
             "Do not select attributes with a bare '//@name' XPath, which reads a literal result element as XPath; go through src/attributes.js (expressionsOf, selectorOf)"

--- a/src/comparisons.js
+++ b/src/comparisons.js
@@ -4,6 +4,7 @@
  */
 
 const {masked, closes} = require('./expressions')
+const {GAP} = require('./tokens')
 
 /**
  * The comparison that follows a call: an operator, then a `0` or `1` as the
@@ -12,7 +13,10 @@ const {masked, closes} = require('./expressions')
  * (`+`, `-`, `*`, `div`, `mod`), so `count(x) > 0 + $n` does not match on `0`.
  * @type {RegExp}
  */
-const TAIL = /^\s*(!=|<=|>=|=|<|>)\s*([01])(?![\w.])(?!\s*(?:[-+*]|div\b|mod\b))/
+const TAIL = new RegExp(
+  `^${GAP}*(!=|<=|>=|=|<|>)${GAP}*([01])(?![\\w.])` +
+  `(?!${GAP}*(?:[-+*]|div\\b|mod\\b))`,
+)
 
 /**
  * The operand-reversed comparison just before a call, as in `0 < f(x)`. The
@@ -22,7 +26,10 @@ const TAIL = /^\s*(!=|<=|>=|=|<|>)\s*([01])(?![\w.])(?!\s*(?:[-+*]|div\b|mod\b))
  * part of a wider operand, so `$max + 1 > count(x)` does not match on `1`.
  * @type {RegExp}
  */
-const HEAD = /(^\s*|[([,]\s*|\b(?:and|or)\b\s*)([01])\s*(!=|<=|>=|=|<|>)\s*$/
+const HEAD = new RegExp(
+  `(^${GAP}*|[([,]${GAP}*|\\b(?:and|or)\\b${GAP}*)` +
+  `([01])${GAP}*(!=|<=|>=|=|<|>)${GAP}*$`,
+)
 
 /**
  * Each operator with its sides swapped, so a reversed `0 < f(x)` reads as
@@ -51,7 +58,7 @@ const FLIP = {
  *  each carrying the fields `decide` returned
  */
 const comparedToZero = function(expression, name, decide) {
-  const call = new RegExp(`(^|[^\\w:.-])${name}\\s*\\(`, 'g')
+  const call = new RegExp(`(^|[^\\w:.-])${name}${GAP}*\\(`, 'g')
   const found = []
   const blanked = masked(expression)
   for (const match of blanked.matchAll(call)) {

--- a/src/directives.js
+++ b/src/directives.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+const {GAP, WHITESPACE} = require('./tokens')
+
 /**
  * Directive keywords and the scope each one covers: the whole file, the line
  * after the comment, or the comment's own line.
@@ -22,9 +24,9 @@ const TYPES = {
  * @type {RegExp}
  */
 const DIRECTIVE = new RegExp(
-  '<!--\\s*xslint-(' +
+  `<!--${GAP}*xslint-(` +
   [TYPES.FILE, TYPES.NEXT_LINE, TYPES.LINE].join('|') +
-  ')([a-z0-9\\s-]*)-->',
+  `)([a-z0-9${WHITESPACE}-]*)-->`,
   'g',
 )
 
@@ -41,7 +43,7 @@ const directivesFrom = function(content) {
     directives.push({
       type: match[1],
       line: content.slice(0, match.index).split('\n').length,
-      names: match[2].trim().split(/\s+/).filter((name) => name.length > 0),
+      names: match[2].trim().split(new RegExp(`${GAP}+`)).filter((name) => name.length > 0),
     })
   }
   return directives

--- a/src/directives.js
+++ b/src/directives.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {GAP, WHITESPACE} = require('./tokens')
+const {GAP, GAPS, WHITESPACE} = require('./tokens')
 
 /**
  * Directive keywords and the scope each one covers: the whole file, the line
@@ -43,7 +43,7 @@ const directivesFrom = function(content) {
     directives.push({
       type: match[1],
       line: content.slice(0, match.index).split('\n').length,
-      names: match[2].trim().split(new RegExp(`${GAP}+`)).filter((name) => name.length > 0),
+      names: match[2].trim().split(GAPS).filter((name) => name.length > 0),
     })
   }
   return directives

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,6 +7,7 @@ const fs = require('fs')
 const path = require('path')
 const {DOMParser} = require('@xmldom/xmldom')
 const yaml = require('yaml')
+const {GAP} = require('./tokens')
 
 /**
  * A reference to a general entity, `&name;`, as it survives in a parsed value.
@@ -28,7 +29,9 @@ const REFERENCE = /&([A-Za-z_][\w.-]*);/g
 const declaredEntities = function(str) {
   const entities = new Map()
   for (const match of str.matchAll(
-    /<!ENTITY\s+([A-Za-z_][\w.-]*)\s+(?:"([^"]*)"|'([^']*)')/g)) {
+    new RegExp(
+      `<!ENTITY${GAP}+([A-Za-z_][\\w.-]*)${GAP}+` +
+      `(?:"([^"]*)"|'([^']*)')`, 'g'))) {
     entities.set(match[1], match[2] === undefined ? match[3] : match[2])
   }
   return entities
@@ -43,7 +46,7 @@ const declaredEntities = function(str) {
  * @return {boolean} - True when an external subset is in play
  */
 const external = function(str) {
-  return /<!ENTITY\s+%/.test(str) ||
+  return new RegExp(`<!ENTITY${GAP}+%`).test(str) ||
     /<!DOCTYPE[^>[]*\b(?:SYSTEM|PUBLIC)\b/.test(str)
 }
 

--- a/src/name-linter.js
+++ b/src/name-linter.js
@@ -4,6 +4,7 @@
  */
 
 const {masked, closes} = require('./expressions')
+const {GAP} = require('./tokens')
 const {metaOf, suppressed, defect} = require('./checks')
 const {expressionsOf} = require('./attributes')
 const {MODERN, since, versionOf} = require('./xsl-version')
@@ -32,19 +33,19 @@ const names = [CHECK]
  * alone.
  * @type {RegExp}
  */
-const CALL = /(^|[^\w:.-])(name|local-name)\s*\(/g
+const CALL = new RegExp(`(^|[^\\w:.-])(name|local-name)${GAP}*\\(`, 'g')
 
 /**
  * The comparison that follows the call, `= 'x'` or `!= 'x'`.
  * @type {RegExp}
  */
-const TAIL = /^\s*(=|!=)\s*'([^']*)'/
+const TAIL = new RegExp(`^${GAP}*(=|!=)${GAP}*'([^']*)'`)
 
 /**
  * The operand-reversed comparison sitting just before the call, `'x' = `.
  * @type {RegExp}
  */
-const HEAD = /'([^']*)'\s*(=|!=)\s*$/
+const HEAD = new RegExp(`'([^']*)'${GAP}*(=|!=)${GAP}*$`)
 
 /**
  * A valid unprefixed or prefixed name, so `self::` can be built from it. A

--- a/src/node-set-linter.js
+++ b/src/node-set-linter.js
@@ -5,6 +5,7 @@
 
 const {nodes} = require('./xpath')
 const {masked, closes} = require('./expressions')
+const {GAP} = require('./tokens')
 const {metaOf, suppressed, defect} = require('./checks')
 const {selectorOf} = require('./attributes')
 const {MODERN, since, versionOf} = require('./xsl-version')
@@ -32,7 +33,7 @@ const names = [CHECK]
  * Pattern of a `prefix:node-set(` call opener.
  * @type {RegExp}
  */
-const CALL = /[\w.-]+:node-set\s*\(/g
+const CALL = new RegExp(`[\\w.-]+:node-set${GAP}*\\(`, 'g')
 
 /**
  * The node-set() wrappers in a select value: each carries the offset it starts

--- a/src/redundant-boolean-call-linter.js
+++ b/src/redundant-boolean-call-linter.js
@@ -5,6 +5,7 @@
 
 const {nodes} = require('./xpath')
 const {masked, closes} = require('./expressions')
+const {GAP} = require('./tokens')
 const {metaOf, suppressed, defect} = require('./checks')
 const {selectorOf} = require('./attributes')
 const {logger} = require('./logger')
@@ -32,7 +33,7 @@ const names = [CHECK]
  * `my:boolean()` or a `boolean()` nested in a larger expression is left alone.
  * @type {RegExp}
  */
-const WRAPPER = /^\s*boolean\s*\(/
+const WRAPPER = new RegExp(`^${GAP}*boolean${GAP}*\\(`)
 
 /**
  * The redundant `boolean(...)` wrapping a whole `@test`, or null when the test

--- a/src/redundant-double-negation-linter.js
+++ b/src/redundant-double-negation-linter.js
@@ -4,6 +4,7 @@
  */
 
 const {masked, closes} = require('./expressions')
+const {GAP} = require('./tokens')
 const {metaOf, suppressed, defect} = require('./checks')
 const {expressionsOf} = require('./attributes')
 const {logger} = require('./logger')
@@ -30,13 +31,13 @@ const names = [CHECK]
  * An unprefixed `not(` opener, so a custom `my:not()` is left alone.
  * @type {RegExp}
  */
-const CALL = /(^|[^\w:.-])not\s*\(/g
+const CALL = new RegExp(`(^|[^\\w:.-])not${GAP}*\\(`, 'g')
 
 /**
  * The inner `not(` that must open the outer `not`'s content.
  * @type {RegExp}
  */
-const INNER = /^\s*not\s*\(/
+const INNER = new RegExp(`^${GAP}*not${GAP}*\\(`)
 
 /**
  * The double negations in an expression: an outer `not(...)` whose only content

--- a/src/result-namespace-linter.js
+++ b/src/result-namespace-linter.js
@@ -4,7 +4,7 @@
  */
 
 const {metaOf, suppressed} = require('./checks')
-const {GAP} = require('./tokens')
+const {GAPS} = require('./tokens')
 const {logger} = require('./logger')
 
 /**
@@ -183,10 +183,10 @@ const lintByResultNamespace = function(corpus, suppressions = []) {
       const root = xsl.documentElement
       const elements = Array.from(xsl.getElementsByTagName('*'))
       const extension = new Set(
-        (root.getAttribute('extension-element-prefixes') || '').split(new RegExp(`${GAP}+`)),
+        (root.getAttribute('extension-element-prefixes') || '').split(GAPS),
       )
       const excluded = new Set(
-        (root.getAttribute('exclude-result-prefixes') || '').split(new RegExp(`${GAP}+`)),
+        (root.getAttribute('exclude-result-prefixes') || '').split(GAPS),
       )
       const leaks = !excluded.has('#all') &&
         !textual(elements) &&

--- a/src/result-namespace-linter.js
+++ b/src/result-namespace-linter.js
@@ -4,6 +4,7 @@
  */
 
 const {metaOf, suppressed} = require('./checks')
+const {GAP} = require('./tokens')
 const {logger} = require('./logger')
 
 /**
@@ -182,10 +183,10 @@ const lintByResultNamespace = function(corpus, suppressions = []) {
       const root = xsl.documentElement
       const elements = Array.from(xsl.getElementsByTagName('*'))
       const extension = new Set(
-        (root.getAttribute('extension-element-prefixes') || '').split(/\s+/),
+        (root.getAttribute('extension-element-prefixes') || '').split(new RegExp(`${GAP}+`)),
       )
       const excluded = new Set(
-        (root.getAttribute('exclude-result-prefixes') || '').split(/\s+/),
+        (root.getAttribute('exclude-result-prefixes') || '').split(new RegExp(`${GAP}+`)),
       )
       const leaks = !excluded.has('#all') &&
         !textual(elements) &&

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -79,6 +79,15 @@ const WHITESPACE = ' \t\r\n'
 const GAP = `[${WHITESPACE}]`
 
 /**
+ * A run of one or more of them, ready to split a whitespace-separated list on —
+ * the rule names of an inline directive, or the prefixes of an
+ * `exclude-result-prefixes`. Built once here rather than per call, and carrying
+ * no `g` flag, so it holds no `lastIndex` for a caller to trip over.
+ * @type {RegExp}
+ */
+const GAPS = new RegExp(`${GAP}+`)
+
+/**
  * Quote characters that open a string literal.
  * @type {string}
  */
@@ -484,4 +493,5 @@ module.exports = {
   TOKENS,
   WHITESPACE,
   GAP,
+  GAPS,
 }

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -69,6 +69,16 @@ const TOKENS = {
 const WHITESPACE = ' \t\r\n'
 
 /**
+ * The same characters as a regular-expression class, so a scan that reads a gap
+ * out of expression text spells it the one way the grammar does. JavaScript's
+ * `\s` is wider — it also takes a no-break space, a vertical tab, a form feed,
+ * the Unicode spaces and U+FEFF — and a scan spelling its gap that way reads a
+ * call in `boolean\u00a0(a)`, where no processor sees one (#643).
+ * @type {string}
+ */
+const GAP = `[${WHITESPACE}]`
+
+/**
  * Quote characters that open a string literal.
  * @type {string}
  */
@@ -473,4 +483,5 @@ module.exports = {
   spelling,
   TOKENS,
   WHITESPACE,
+  GAP,
 }

--- a/src/translate-linter.js
+++ b/src/translate-linter.js
@@ -4,6 +4,7 @@
  */
 
 const {masked, closes} = require('./expressions')
+const {GAP} = require('./tokens')
 const {metaOf, suppressed, defect} = require('./checks')
 const {expressionsOf} = require('./attributes')
 const {MODERN, since, versionOf} = require('./xsl-version')
@@ -31,7 +32,7 @@ const names = [CHECK]
  * A `translate(` call opener, unprefixed so a custom one is left alone.
  * @type {RegExp}
  */
-const CALL = /(^|[^\w:.-])translate\s*\(/g
+const CALL = new RegExp(`(^|[^\\w:.-])translate${GAP}*\\(`, 'g')
 
 /**
  * The uppercase ASCII alphabet.

--- a/test/conformance.test.js
+++ b/test/conformance.test.js
@@ -4,6 +4,7 @@
  */
 
 const {allFilesFrom, yaml} = require('../src/helpers')
+const {GAP} = require('../src/tokens')
 const {FIXERS} = require('../src/fixers')
 const {DECIMAL} = require('../src/xsl-version')
 const path = require('path')
@@ -69,7 +70,9 @@ const KEBAB = /^[a-z0-9]+(-[a-z0-9]+)*$/
  * check reports in someone else's.
  * @type {RegExp}
  */
-const COUNTED = /count\s*\((?:[^()]|\([^()]*\))*\)\s*(?:!?=|[<>]=?)\s*0(?!\d)/
+const COUNTED = new RegExp(
+  `count${GAP}*\\((?:[^()]|\\([^()]*\\))*\\)${GAP}*(?:!?=|[<>]=?)${GAP}*0(?!\\d)`,
+)
 
 /**
  * Names of the checks of a kind.
@@ -250,7 +253,7 @@ describe('conformance', function() {
     )
   })
   it('reads @xsl:version too wherever a selector tests @version', function() {
-    const versioned = /@version\s*!?=/
+    const versioned = new RegExp(`@version${GAP}*!?=`)
     for (const [kind, keys] of Object.entries(SELECTORS)) {
       for (const name of names(kind)) {
         const check = yaml.parsedFromFile(

--- a/test/resources/count-packs/no-break-space-before-the-bracket.yaml
+++ b/test/resources/count-packs/no-break-space-before-the-bracket.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: count-compared-to-zero
+# The gap before each bracket is a no-break space, which XPath's S production
+# does not admit, so none of these holds a call at all and the check must stay
+# quiet where a JavaScript \s gap saw one (#643).
+found:
+  amount: 0
+  positions: [ ]
+  fixes: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <xsl:if test="count&#xA0;(@x) = 0">
+        <xsl:value-of select="."/>
+      </xsl:if>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/name-packs/no-break-space-before-the-bracket.yaml
+++ b/test/resources/name-packs/no-break-space-before-the-bracket.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: name-compared-to-string
+# The gap before each bracket is a no-break space, which XPath's S production
+# does not admit, so none of these holds a call at all and the check must stay
+# quiet where a JavaScript \s gap saw one (#643).
+found:
+  amount: 0
+  positions: [ ]
+  fixes: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <xsl:if test="name&#xA0;(.) = 'a'">
+        <xsl:value-of select="."/>
+      </xsl:if>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/redundant-boolean-call-packs/no-break-space-before-the-bracket.yaml
+++ b/test/resources/redundant-boolean-call-packs/no-break-space-before-the-bracket.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: redundant-boolean-call
+# The gap before each bracket is a no-break space, which XPath's S production
+# does not admit, so none of these holds a call at all and the check must stay
+# quiet where a JavaScript \s gap saw one (#643).
+found:
+  amount: 0
+  positions: [ ]
+  fixes: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <xsl:if test="boolean&#xA0;(@x)">
+        <xsl:value-of select="."/>
+      </xsl:if>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/redundant-double-negation-packs/no-break-space-before-the-bracket.yaml
+++ b/test/resources/redundant-double-negation-packs/no-break-space-before-the-bracket.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: redundant-double-negation
+# The gap before each bracket is a no-break space, which XPath's S production
+# does not admit, so none of these holds a call at all and the check must stay
+# quiet where a JavaScript \s gap saw one (#643).
+found:
+  amount: 0
+  positions: [ ]
+  fixes: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <xsl:if test="not&#xA0;(not&#xA0;(@x))">
+        <xsl:value-of select="."/>
+      </xsl:if>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/string-length-packs/no-break-space-before-the-bracket.yaml
+++ b/test/resources/string-length-packs/no-break-space-before-the-bracket.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: string-length-compared-to-zero
+# The gap before each bracket is a no-break space, which XPath's S production
+# does not admit, so none of these holds a call at all and the check must stay
+# quiet where a JavaScript \s gap saw one (#643).
+found:
+  amount: 0
+  positions: [ ]
+  fixes: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <xsl:if test="string-length&#xA0;(@x) = 0">
+        <xsl:value-of select="."/>
+      </xsl:if>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/translate-packs/no-break-space-before-the-bracket.yaml
+++ b/test/resources/translate-packs/no-break-space-before-the-bracket.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: translate-for-case
+# The gap before each bracket is a no-break space, which XPath's S production
+# does not admit, so none of these holds a call at all and the check must stay
+# quiet where a JavaScript \s gap saw one (#643).
+found:
+  amount: 0
+  positions: [ ]
+  fixes: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <xsl:value-of select="translate&#xA0;(., 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/xcop.test.js
+++ b/test/xcop.test.js
@@ -34,11 +34,19 @@ const available = cmdAvailable('xcop', ['--version'], false)
 /**
  * Packs whose fixture must carry a construct xcop rejects, so it cannot also be
  * canonical XML — an unused namespace declaration is the very thing
- * `redundant-namespace-declarations` exists to flag. Excluded from the
- * formatting check, as the fix fixtures are in the xcop workflow.
+ * `redundant-namespace-declarations` exists to flag, and the gap a
+ * `no-break-space-before-the-bracket` pack puts before a bracket is the very
+ * character #643 is about: xcop insists on seeing it written `&#xA0;`, which is
+ * how the pack does write it, but the check re-serializes through xmldom first
+ * and xmldom emits the raw character. One name covers all six such packs, one
+ * per linter. Excluded from the formatting check, as the fix fixtures are in
+ * the xcop workflow.
  * @type {Array.<string>}
  */
-const UNFORMATTED = ['redundant-namespace-declarations.yaml']
+const UNFORMATTED = [
+  'redundant-namespace-declarations.yaml',
+  'no-break-space-before-the-bracket.yaml',
+]
 
 /**
  * Packs whose inline XSL is well-formed and worth formatting-checking.


### PR DESCRIPTION
Closes #643.

Eleven regexes across six linters spelled an XPath gap as JavaScript's `\s`,
which matches far more than the grammar admits. `ExprWhitespace` is XML's `S` —
space, tab, CR, LF, and nothing else — while `\s` also takes a no-break space, a
vertical tab, a form feed, the Unicode spaces and U+FEFF. So each of those scans
read a call in text that holds none.

**The ticket's premise needed correcting before the fix, and this is the
correction.** It says `boolean (a)` "is not a function call — the engine refuses
the whole expression". Measured against `master`, the engine *accepts* it:

```text
boolean(a)                    no gap            ENGINE ACCEPTS
boolean (a)                   ordinary space    ENGINE ACCEPTS
boolean (a)                   no-break space    engine refuses
not (not (b))                 ordinary spaces   ENGINE ACCEPTS
not (not (b))                 no-break spaces   engine refuses
count (a) > 0                 ordinary space    ENGINE ACCEPTS
count (a) > 0                 no-break space    engine refuses
```

An ordinary space before `(` is legal — XPath 1.0 §3.7 recognises an NCName as a
FunctionName "possibly after intervening ExprWhitespace", the same clause #621
turned on — and #640's respelling retry covers the engine's own strictness. So
the bug is not the space the ticket names; it is exactly the characters `\s`
adds and `S` does not. That narrows the defect and makes it sharper.

On a stylesheet whose gaps are no-break spaces, `master` reports the four
syntax errors and then three defects that are not there:

```text
before                              after
5:18 invalid-xpath-expression       5:18 invalid-xpath-expression
6:18 invalid-xpath-expression       6:18 invalid-xpath-expression
7:18 invalid-xpath-expression       7:18 invalid-xpath-expression
8:26 invalid-xpath-expression       8:26 invalid-xpath-expression
7:19 count-compared-to-zero         —
6:19 redundant-double-negation      —
5:19 redundant-boolean-call         —
```

The fixes were already withheld by #636, so what was left was the double report:
a second defect derived from a construct the reader invented, beside the error
that says the text does not parse.

**One definition.** `src/tokens.js` already owned `WHITESPACE`; it now also
exports `GAP`, the same four characters as a character class, derived from it
rather than written again. All eleven regexes are built from it.

**And a ban on the other spelling**, since a convention nothing enforces is a
wish: a `no-restricted-syntax` selector rejects `\s` in every regex literal and
every template. Verified by reintroducing one of each shape into
`src/translate-linter.js` — both caught, tree clean again after restoring.

Making that ban exception-free took three more files. `src/directives.js`,
`src/helpers.js` and `src/result-namespace-linter.js` spell an *XML* gap with
`\s` — a comment's `<!--\s*xslint-`, a DTD's `<!ENTITY\s+`, and the
whitespace-separated `exclude-result-prefixes` list. XML's `S` is the same four
characters there, so `\s` is wrong for the same reason, and converting them is
what lets the selector apply to `src/**` with no carve-out. The alternative was
scoping the ban to a hand-written list of files, which the next linter would have
been added outside of. `test/conformance.test.js` went with them: its own gap
regexes now ask the same question the engine asks.

**Coverage would have hidden all of this**, which is the ticket's last point: a
branch an ASCII gap reaches counts as covered for every gap. So there is one new
pack per linter — `count`, `string-length`, `name`, `translate`,
`redundant-boolean-call`, `redundant-double-negation` — each holding the same
construct with a no-break space before the bracket and expecting **nothing**.
They write it `&#xA0;` rather than as a raw byte, so a reader can see what the
fixture is about; the pack is listed in `xcop.test.js`'s `UNFORMATTED` because
xcop insists on the reference form while xmldom re-serializes it as the raw
character, and one basename covers all six.

`npm test` 1043 passing and 0 failing, `npm run coverage` the same 1043 at 100%
of statements, branches, functions and lines, `npx mocha test/xcop.test.js
--forbid-pending` 252 passing, `yamllint` 0 errors over tracked and new files
both, `npx eslint` clean, `npx grunt docs` regenerated.

**The ban missed the shape that caused this, found in review.** Three ways exist
to write a `\s`, and the selector caught two:

```text
/a\s+b/                   regex literal     caught
new RegExp(`a\\s+${x}`)    template          caught
new RegExp('a\\s+b')       string literal    MISSED
```

The missed one is not hypothetical — it is how `src/directives.js` and
`src/helpers.js` were written on `master` (`'<!--\\s*xslint-('`,
`'<!ENTITY\\s+'`), the two files this change had to convert. The regression could
have returned in the exact form it originally arrived in, past a selector added to
stop it. One more alternative closes it, `Literal[value=/\\s/]`, verified by
probing all three shapes: caught, and `npx eslint .` over the whole tree still
exits 0.

**And the split regex is built once.** Three converted lines had grown to 90–93
columns, passing only because `ignoreTemplateLiterals` exempts a template, and
each rebuilt `new RegExp(\`${GAP}+\`)` on every call — once per directive inside
a loop, twice per stylesheet for the prefix lists. `src/tokens.js` now exports
`GAPS` beside `GAP`, built once and carrying no `g` flag, so there is no
`lastIndex` for a caller to trip over; all three lines are back under 80.

Not done here: the two remaining mentions of `\s` in `src/` are prose in a
docblock explaining why it is wrong.

