### PR TITLE
bug(#642): see the gap the axis token swallowed

### DIFF
--- a/src/xpath-format-linter.js
+++ b/src/xpath-format-linter.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {tokenized, TOKENS} = require('./tokens')
+const {tokenized, TOKENS, GAP} = require('./tokens')
 const {metaOf, suppressed, defect} = require('./checks')
 const {logger} = require('./logger')
 
@@ -26,6 +26,34 @@ const META = metaOf(CHECK)
 const names = [CHECK]
 
 /**
+ * A run of more than one gap character, for looking inside a token that carries
+ * one.
+ * @type {RegExp}
+ */
+const INTERNAL = new RegExp(`${GAP}{2,}`)
+
+/**
+ * The redundant run a token holds inside itself, or null. Only an axis holds
+ * one: the lexer folds the gap in front of its `::` into the axis token, so
+ * `ancestor  ::` is a single token and a scan reading only `whitespace` tokens
+ * saw the run behind the colons and not the one in front of them — one of the
+ * two runs in `ancestor  ::  b`, with `--fix` leaving the other in the file and
+ * the next run calling it clean (#642). A string or a comment is kept
+ * whole on purpose, so neither is ever looked into, and a run that wraps a line
+ * is left alone here as it is everywhere else.
+ * @param {{type: string, value: string, start: number}} token - The token
+ * @return {?{offset: number, value: string, replacement: string}} - The run
+ */
+const inside = function(token) {
+  const run = token.type === TOKENS.STRING || token.type === TOKENS.COMMENT ?
+    null :
+    INTERNAL.exec(token.value)
+  return run === null || /[\r\n]/.test(run[0]) ?
+    null :
+    {offset: token.start + run.index, value: run[0], replacement: ' '}
+}
+
+/**
  * Redundant whitespace runs in an expression. A run is redundant when it is
  * longer than one space, or leads or trails the expression; a run that wraps a
  * line is left alone, and runs inside string literals or comments are never
@@ -41,6 +69,7 @@ const redundancies = function(expression) {
     const edge =
       token.start === 0 ||
       token.start + token.value.length === expression.length
+    const held = token.type === TOKENS.WHITESPACE ? null : inside(token)
     if (
       token.type === TOKENS.WHITESPACE &&
       !/[\r\n]/.test(token.value) &&
@@ -51,6 +80,8 @@ const redundancies = function(expression) {
         value: token.value,
         replacement: edge ? '' : ' ',
       })
+    } else if (held !== null) {
+      runs.push(held)
     }
   }
   return runs

--- a/test/resources/xpath-format-packs/gap-in-front-of-the-colons.yaml
+++ b/test/resources/xpath-format-packs/gap-in-front-of-the-colons.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: redundant-whitespace
+# Both runs of an axis spaced on each side of its `::` are pinned. The lexer
+# folds the gap in front of the colons into the axis token, so the run in front
+# is found inside that token and the run behind it is a whitespace token of its
+# own (#642).
+found:
+  amount: 2
+  positions: [ [ 4, 35 ], [ 4, 39 ] ]
+  fixes: [ " ", " " ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
+    <xsl:template match="/">
+      <xsl:value-of select="ancestor  ::  b"/>
+    </xsl:template>
+  </xsl:stylesheet>


### PR DESCRIPTION
Closes #642.

`redundant-whitespace` saw one of the two redundant runs in `ancestor  ::  b`,
and `--fix` then left the other in the file:

```text
before                    1 warning
--fix writes              select="ancestor  :: b"
run again                 no whitespace defect at all
```

Two spaces in front of the colons are redundant by the check's own definition, so
the tool pronounced clean a file holding a defect it defines. After:

```text
before                    2 warnings
--fix writes              select="ancestor :: b"
run again                 clean, and correctly so
```

**The roadmap predicted this would fix itself and it did not**, which is worth
recording: #644 had #642 as "falls out of name-aware axis lexing; verify and close
with a pack row" after #249. Verified against the #666 merge — it does not. #666
changed how a *name* is lexed, while `opensAxis` still folds the gap in front of
`::` into the axis token, so `ancestor  ::` remains one token and a scan reading
only `whitespace` tokens cannot see the run inside it. The line in #644 is
corrected.

**I took the ticket's first option, not the second, having changed my mind on
reading what the second costs.** The ticket offers either letting `redundancies`
look inside an axis token, or stopping the fold and letting the lexer emit the
gap as the `whitespace` token it emits everywhere else. I said I would take the
second. It needs a token type for a bare `::` — there is none — and every consumer
that reads an axis token's value and span to build a fix would move with it, on a
lexer merged hours ago. The first option is local to the check that owns
whitespace, and the suite proves the difference: **not one pack position shifted**,
because the token stream is untouched.

The rule is general rather than an axis list: a token that carries a run of more
than one gap character inside itself reports it, with `STRING` and `COMMENT`
excluded because the lexer keeps those whole on purpose, and a line-wrapping run
left alone as it is everywhere else. Only an axis can hold such a run today —
`instance of` is matched with exactly one space — so the rule needs no list to
maintain and gains nothing to drift.

The gap is spelled with `GAP` from `src/tokens.js`, as #643 requires.

New pack `gap-in-front-of-the-colons.yaml` pins both runs, at 4:35 and 4:39, with
the replacement each carries.

`npm test` 1047 passing and 0 failing, `npm run coverage` 100% of statements,
branches, functions and lines, `npx mocha test/xcop.test.js --forbid-pending` 253
passing, `yamllint` clean on the new pack.
