### PR TITLE
Let one word name one thing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,17 @@ the exit — decides what it carries: a lookup keyed on the deciding values
 enclosing function, so a `map`/`every` callback carrying its own single `return`
 is fine, and an arrow with an expression body has none at all.
 
+One word names one thing. **`expression` is the text of an expression, never the
+node carrying it** — a node is an `attribute`, and the record pairing the two is
+`found` (`{node, start, expression, pattern}`, what `expressionsOf` yields).
+`no-restricted-syntax` selectors enforce both halves: reading a node's property
+off an `expression` is an error, and so is handing `defect` a node and its text as
+two arguments. The word named the node in `src/xpath-validator.js` and the text in
+`src/attributes.js` until #648, which is how one call came to spell both from one
+identifier and how a JSDoc drifted to a key (`file`) the validator never pushed.
+Pass the record, not its pieces: a mismatched pair reported at the wrong place and
+lost its fix silently, because a node read as text parses for nobody.
+
 A gap is spelled one way: `GAP` (or `WHITESPACE`) from `src/tokens.js`, the four
 characters of XML's `S`. JavaScript's `\s` is banned by a `no-restricted-syntax`
 selector in every regex literal and template, because it also matches a no-break
@@ -193,7 +204,9 @@ motive, or ships untested fails the build.
   template, or a shadow attribute carries, each flagged `pattern` or not) unless
   it has a documented reason to
   narrow — then it narrows through `selectorOf`, never a hand-written `//@name`,
-  which an ESLint `no-restricted-syntax` selector bans.
+  which an ESLint `no-restricted-syntax` selector bans, and wraps what it narrowed
+  to in `wholeOf` so `defect` still receives one expression rather than a node and
+  a string paired up by hand.
 
 Then run `npm test`, `npm run coverage`, and `npx grunt docs`.
 
@@ -414,9 +427,9 @@ accidentally attached fix turns red.
 | `src/xpath-linter.js` | Loads `checks/xpath/*.yaml`; attaches any `src/fixers.js` fix, unless the node — or the element carrying it — holds an expression the engine refuses (#651) |
 | `src/corpus-linter.js` | Loads `checks/corpus/*.yaml`; cross-file rules |
 | `src/*-linter.js` | Code-based `checks/format/*.yaml`, one construct each (axis, namespace, count, name, ...); see the flow diagram |
-| `src/checks.js` | Shared for code-based linters: `metaOf`, `suppressed`, `defect(check, meta, source, node, offset, expression, fix)` — walks the raw text so a wrapped or entity-shifted value reports where it truly stands (#611), and drops the `fix` when `expression` does not parse (#636) |
+| `src/checks.js` | Shared for code-based linters: `metaOf`, `suppressed`, `defect(check, meta, source, found, offset, fix)` — takes the expression whole, as `expressionsOf` yields it, and adds its `start` to the offset itself (#648); walks the raw text so a wrapped or entity-shifted value reports where it truly stands (#611), and drops the `fix` when the expression does not parse (#636) |
 | `src/source.js` | Raw-text walking shared by `checks` and `fixer`: `offsetAt`, `placeAt`, `character`, `skip` |
-| `src/attributes.js` | `expressionsOf(xsl)` — every expression a stylesheet carries: a bare/AVT attribute, a 3.0 text value template, or a shadow attribute, each saying whether it is a `pattern`; `PATTERNS` names the five attributes that hold one; `selectorOf(name)` for a linter that narrows |
+| `src/attributes.js` | `expressionsOf(xsl)` — every expression a stylesheet carries: a bare/AVT attribute, a 3.0 text value template, or a shadow attribute, each saying whether it is a `pattern`; `PATTERNS` names the five attributes that hold one; `selectorOf(name)` for a linter that narrows, and `wholeOf(attribute)` to build the same record for the one it narrowed to |
 | `src/xsl-version.js` | `versionOf(node)` — the version in force at a node, from the nearest ancestor's `@version` (XSLT element) or `@xsl:version` (literal result element), canonicalised as a decimal; `since(version, floor)` for a lower-bound gate; shared `MODERN`/`KNOWN`/`DECIMAL` |
 | `src/comparisons.js` | `comparedToZero` — shared scan for a call compared with `0`/`1` (count, string-length) |
 | `src/expressions.js` | `masked`/`closes` lexer helpers (node-set, double-negation, boolean-call); `enclosed` — the expressions an AVT holds in its braces |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -97,6 +97,18 @@ export default defineConfig([
         },
         {
           selector:
+            "MemberExpression[object.name='expression'][property.name=/^(nodeValue|nodeName|nodeType|localName|lineNumber|columnNumber|ownerElement)$/]",
+          message:
+            "'expression' names the text of an expression, never the node carrying it (#648). A node has no place under that name: call it 'attribute', or pass the whole {node, start, expression} record"
+        },
+        {
+          selector:
+            "CallExpression[callee.name='defect'] MemberExpression[property.name='nodeValue']",
+          message:
+            "Do not spell a node and its text as two arguments of defect (#648); hand it the {node, start, expression} record that expressionsOf yields, or wholeOf(attribute) for a narrowed one"
+        },
+        {
+          selector:
             "CallExpression[callee.property.name='getAttribute'][callee.object.property.name='documentElement'][arguments.0.value='version']",
           message:
             "Read the stylesheet version through versionOf in src/xsl-version.js, which handles a simplified stylesheet's xsl:version; do not read documentElement.getAttribute('version') directly"

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -115,6 +115,24 @@ const shadow = function(attribute) {
 }
 
 /**
+ * The whole value of an attribute as one expression, standing where the value
+ * itself starts. Every expression this module yields is such a record — the
+ * node carrying it, the offset it begins at inside that node's value, its own
+ * text, and whether it is a pattern — and a linter that narrows to one
+ * attribute of its own builds the record here rather than handing a node and
+ * its text on separately, which is how one word came to name both (#648).
+ * @param {Node} attribute - The attribute node
+ * @return {{node: Node, start: number, expression: string,
+ *  pattern: boolean}} - The expression it holds whole
+ */
+const wholeOf = function(attribute) {
+  return Object.freeze({
+    node: attribute, start: 0, expression: attribute.nodeValue,
+    pattern: PATTERNS.includes(attribute.nodeName.replace(/^_/, '')),
+  })
+}
+
+/**
  * The expressions a node contributes: a whole value when it is a bare-XPath (or
  * shadow) attribute, otherwise each expression its braces enclose — an
  * attribute value template, or a text value template in a text node (a CDATA
@@ -132,12 +150,9 @@ const carried = function(node, bare, three) {
     (bare.has(node) || (three && shadow(node)))
   const braced = node.nodeType === 2 || (three && expands(node))
   return whole ?
-    [Object.freeze({
-      node: node, start: 0, expression: node.nodeValue,
-      pattern: PATTERNS.includes(node.nodeName.replace(/^_/, '')),
-    })] :
-    braced ? enclosed(node.nodeValue).map((found) => Object.freeze({
-      node: node, start: found.offset, expression: found.value, pattern: false,
+    [wholeOf(node)] :
+    braced ? enclosed(node.nodeValue).map((brace) => Object.freeze({
+      node: node, start: brace.offset, expression: brace.value, pattern: false,
     })) : []
 }
 
@@ -171,4 +186,5 @@ module.exports = {
   PATTERNS,
   selectorOf,
   expressionsOf,
+  wholeOf,
 }

--- a/src/checks.js
+++ b/src/checks.js
@@ -48,29 +48,40 @@ const LEAD = {2: 1, 4: '<![CDATA['.length}
  * holding the value opens on, because nothing inside a start tag can be
  * silenced from within it — no comment fits there — so a directive has to reach
  * the whole way down from above the element. Omit `fix` for report-only.
+ *
+ * The expression arrives whole — the node carrying it, where it starts inside
+ * that node's value, and its text — as `src/attributes.js` yields it, rather
+ * than as a node and a string a caller pairs up itself. Two things came of the
+ * old shape (#648): the word `expression` named the node in one module and the
+ * text in another, so one call had to spell both from one identifier, and every
+ * caller added `start` to its own offset, nine chances to forget an addition
+ * that belongs here. A mismatched pair reported at the wrong place and lost its
+ * fix in silence, because a node read as text is valid XPath to nobody.
  * @param {string} check - Check name
  * @param {{severity: string, message: string}} meta - The check metadata
  * @param {{file: string, content: string}} source - The file the node sits
  *  in, with its raw text, which is the only place the line breaks a parser
  *  normalised away are still visible
- * @param {Node} node - The attribute, text, or CDATA node
- * @param {number} offset - Offset of the defect within the node value
- * @param {string} expression - The expression the defect stands in, whose own
- *  text decides whether a fix may be offered at all
+ * @param {{node: Node, start: number, expression: string}} found - The
+ *  expression the defect stands in: its attribute, text or CDATA node, where it
+ *  starts in that node's value, and its own text, which decides whether a fix
+ *  may be offered at all
+ * @param {number} offset - Offset of the defect within the expression
  * @param {?{value: string, replacement: string, suggestion?: boolean}} [fix] -
  *  The fix, or undefined for a report-only defect
  * @return {object} - Defect
  */
 const defect = function(
-  check, meta, source, node, offset, expression, fix = undefined,
+  check, meta, source, found, offset, fix = undefined,
 ) {
+  const {node, start, expression} = found
   const {line, pos} = placeAt(
     source.content,
     skip(
       source.content,
       offsetAt(source.content, node.lineNumber, node.columnNumber) +
         (LEAD[node.nodeType] || 0),
-      offset,
+      start + offset,
     ),
   )
   const anchored = fix === undefined || !isValid(expression) ?

--- a/src/count-linter.js
+++ b/src/count-linter.js
@@ -106,13 +106,14 @@ const lintByCount = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const source of corpus) {
-      for (const {node, start, expression} of expressionsOf(source.xsl)) {
+      for (const found of expressionsOf(source.xsl)) {
+        const {node, expression} = found
         const modern = since(versionOf(node), MODERN)
         for (const {offset, value, test, argument} of comparisons(expression)) {
           const whole = node.nodeName === 'test' &&
             node.nodeValue.trim() === value
           defects.push(
-            defect(CHECK, META, source, node, start + offset, expression, {
+            defect(CHECK, META, source, found, offset, {
               value: value,
               replacement: rewritten(test, argument, modern, whole),
             }),

--- a/src/name-linter.js
+++ b/src/name-linter.js
@@ -134,13 +134,14 @@ const lintByName = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const source of corpus) {
-      for (const {node, start, expression} of expressionsOf(source.xsl)) {
+      for (const found of expressionsOf(source.xsl)) {
+        const {node, expression} = found
         const modern = since(versionOf(node), MODERN)
         for (const {offset, value, replacement} of comparisons(
           expression, modern,
         )) {
           defects.push(
-            defect(CHECK, META, source, node, start + offset, expression,
+            defect(CHECK, META, source, found, offset,
               replacement === null ?
                 undefined : {value, replacement, suggestion: true},
             ),

--- a/src/node-set-linter.js
+++ b/src/node-set-linter.js
@@ -7,7 +7,7 @@ const {nodes} = require('./xpath')
 const {masked, closes} = require('./expressions')
 const {GAP} = require('./tokens')
 const {metaOf, suppressed, defect} = require('./checks')
-const {selectorOf} = require('./attributes')
+const {selectorOf, wholeOf} = require('./attributes')
 const {MODERN, since, versionOf} = require('./xsl-version')
 const {logger} = require('./logger')
 
@@ -84,7 +84,7 @@ const lintByNodeSet = function(corpus, suppressions = []) {
           )) {
             defects.push(
               defect(
-                CHECK, META, source, attribute, offset, attribute.nodeValue,
+                CHECK, META, source, wholeOf(attribute), offset,
                 {value, replacement},
               ),
             )

--- a/src/predicate-position-linter.js
+++ b/src/predicate-position-linter.js
@@ -123,11 +123,12 @@ const lintByPredicatePosition = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const source of corpus) {
-      for (const {node, start, expression} of expressionsOf(source.xsl)) {
+      for (const found of expressionsOf(source.xsl)) {
+        const {expression} = found
         for (const {offset, value, replacement} of literals(expression)) {
           defects.push(
             defect(
-              CHECK, META, source, node, start + offset, expression,
+              CHECK, META, source, found, offset,
               {value, replacement},
             ),
           )

--- a/src/redundant-boolean-call-linter.js
+++ b/src/redundant-boolean-call-linter.js
@@ -7,7 +7,7 @@ const {nodes} = require('./xpath')
 const {masked, closes} = require('./expressions')
 const {GAP} = require('./tokens')
 const {metaOf, suppressed, defect} = require('./checks')
-const {selectorOf} = require('./attributes')
+const {selectorOf, wholeOf} = require('./attributes')
 const {logger} = require('./logger')
 
 /**
@@ -83,8 +83,7 @@ const lintByBooleanCall = function(corpus, suppressions = []) {
         if (strip) {
           defects.push(
             defect(
-              CHECK, META, source, attribute, strip.offset,
-              attribute.nodeValue,
+              CHECK, META, source, wholeOf(attribute), strip.offset,
               {value: strip.value, replacement: strip.replacement},
             ),
           )

--- a/src/redundant-double-negation-linter.js
+++ b/src/redundant-double-negation-linter.js
@@ -93,12 +93,13 @@ const lintByDoubleNegation = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const source of corpus) {
-      for (const {node, start, expression} of expressionsOf(source.xsl)) {
+      for (const found of expressionsOf(source.xsl)) {
+        const {node, expression} = found
         for (const {offset, value, argument} of negations(expression)) {
           const bare = node.nodeName === 'test' &&
             node.nodeValue.trim() === value
           defects.push(
-            defect(CHECK, META, source, node, start + offset, expression, {
+            defect(CHECK, META, source, found, offset, {
               value: value,
               replacement: bare ? argument : `boolean(${argument})`,
             }),

--- a/src/string-length-linter.js
+++ b/src/string-length-linter.js
@@ -115,10 +115,11 @@ const lintByStringLength = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const source of corpus) {
-      for (const {node, start, expression} of expressionsOf(source.xsl)) {
+      for (const found of expressionsOf(source.xsl)) {
+        const {expression} = found
         for (const {offset, value, replacement} of comparisons(expression)) {
           defects.push(
-            defect(CHECK, META, source, node, start + offset, expression,
+            defect(CHECK, META, source, found, offset,
               replacement === null ?
                 undefined : {value, replacement, suggestion: true},
             ),

--- a/src/translate-linter.js
+++ b/src/translate-linter.js
@@ -142,11 +142,12 @@ const lintByTranslate = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const source of corpus) {
-      for (const {node, start, expression} of expressionsOf(source.xsl)) {
+      for (const found of expressionsOf(source.xsl)) {
+        const {node, expression} = found
         if (since(versionOf(node), MODERN)) {
           for (const {offset, value, replacement} of folded(expression)) {
             defects.push(
-              defect(CHECK, META, source, node, start + offset, expression,
+              defect(CHECK, META, source, found, offset,
                 {value, replacement, suggestion: true},
               ),
             )

--- a/src/using-namespace-axis-linter.js
+++ b/src/using-namespace-axis-linter.js
@@ -55,11 +55,12 @@ const lintByNamespaceAxis = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const source of corpus) {
-      for (const {node, start, expression} of expressionsOf(source.xsl)) {
+      for (const found of expressionsOf(source.xsl)) {
+        const {node, expression} = found
         if (since(versionOf(node), MODERN)) {
           for (const offset of axes(expression)) {
             defects.push(
-              defect(CHECK, META, source, node, start + offset, expression),
+              defect(CHECK, META, source, found, offset),
             )
           }
         }

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -168,14 +168,14 @@ const lintByAxis = function(corpus, suppressions = []) {
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
     for (const source of corpus) {
-      for (const held of expressionsOf(source.xsl)) {
-        const {node, start, expression} = held
+      for (const found of expressionsOf(source.xsl)) {
+        const {node, expression} = found
         for (const {offset, fix} of abbreviable(
-          expression, since(versionOf(node), MODERN), held.pattern,
+          expression, since(versionOf(node), MODERN), found.pattern,
         )) {
           defects.push(
             defect(
-              CHECK, META, source, node, start + offset, expression, fix,
+              CHECK, META, source, found, offset, fix,
             ),
           )
         }

--- a/src/xpath-format-linter.js
+++ b/src/xpath-format-linter.js
@@ -4,6 +4,7 @@
  */
 
 const {tokenized, TOKENS, GAP} = require('./tokens')
+const {wholeOf} = require('./attributes')
 const {metaOf, suppressed, defect} = require('./checks')
 const {logger} = require('./logger')
 
@@ -69,7 +70,7 @@ const redundancies = function(expression) {
     const edge =
       token.start === 0 ||
       token.start + token.value.length === expression.length
-    const held = token.type === TOKENS.WHITESPACE ? null : inside(token)
+    const run = token.type === TOKENS.WHITESPACE ? null : inside(token)
     if (
       token.type === TOKENS.WHITESPACE &&
       !/[\r\n]/.test(token.value) &&
@@ -80,8 +81,8 @@ const redundancies = function(expression) {
         value: token.value,
         replacement: edge ? '' : ' ',
       })
-    } else if (held !== null) {
-      runs.push(held)
+    } else if (run !== null) {
+      runs.push(run)
     }
   }
   return runs
@@ -91,8 +92,9 @@ const redundancies = function(expression) {
  * Lint the valid Xpath expressions for redundant whitespace. The expressions
  * are already known to parse — the validator dropped the malformed ones — so
  * this linter never re-checks validity, it only reasons over their tokens.
- * @param {Array.<{file: string, expression: Node}>} expressions - Valid
- *  expressions paired with the file they came from
+ * @param {Array.<{source: object, attribute: Node}>} expressions - Valid
+ *  expressions, each the attribute holding one paired with the file it came
+ *  from
  * @param {Array.<string>} suppressions - Array of suppressed checks
  * @return {{name: string, severity: string, message: string, file: string,
  *  line: number, pos: number}[]} - Defects found
@@ -101,15 +103,13 @@ const lintByFormat = function(expressions, suppressions = []) {
   logger.debug(`Format linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const {source, expression} of expressions) {
+    for (const {source, attribute} of expressions) {
+      const found = wholeOf(attribute)
       for (const {offset, value, replacement} of redundancies(
-        expression.nodeValue,
+        found.expression,
       )) {
         defects.push(
-          defect(
-            CHECK, META, source, expression, offset, expression.nodeValue,
-            {value, replacement},
-          ),
+          defect(CHECK, META, source, found, offset, {value, replacement}),
         )
       }
     }

--- a/src/xpath-validator.js
+++ b/src/xpath-validator.js
@@ -49,14 +49,15 @@ const names = [CHECK]
 const EXPRESSIONS = ATTRIBUTES.filter((name) => !PATTERNS.includes(name))
 
 /**
- * Whether the walked node is one of those attributes on an XSLT element. The
- * walk answers the same set a descendant scan did and answers it linearly
- * (#635), so the name test that was a predicate inside the XPath is a filter
- * here.
+ * Whether the walked node is one of those attributes on an XSLT element,
+ * holding its expression bare — the same word `src/attributes.js` uses for the
+ * set it builds, so the two modules name one thing one way (#648). The walk
+ * answers the same set a descendant scan did and answers it linearly (#635), so
+ * the name test that was a predicate inside the XPath is a filter here.
  * @param {Node} node - A node of the walk
  * @return {boolean} - True when it holds an expression to validate
  */
-const held = function(node) {
+const bare = function(node) {
   return node.nodeType === 2 && EXPRESSIONS.includes(node.localName) &&
     node.ownerElement.namespaceURI === XSLT
 }
@@ -83,7 +84,7 @@ const UNRESOLVED = /&[A-Za-z_][\w.-]*;/
  * @param {Array.<{file: string, content: string, xsl: Document}>} corpus -
  *  Parsed stylesheets
  * @param {Array.<string>} suppressions - Array of suppressed checks
- * @return {{expressions: Array.<{source: object, expression: Node}>, defects:
+ * @return {{expressions: Array.<{source: object, attribute: Node}>, defects:
  *  {name: string, severity: string, message: string, file: string,
  *  line: number, pos: number}[]}} - Valid expressions and defects found
  */
@@ -93,10 +94,10 @@ const validate = function(corpus, suppressions = []) {
   const defects = []
   const suppressed = suppressions.some((sup) => CHECK.includes(sup))
   for (const source of corpus) {
-    for (const expression of walked(source.xsl).filter(held)) {
-      if (isValid(expression.nodeValue)) {
-        expressions.push({source: source, expression: expression})
-      } else if (UNRESOLVED.test(expression.nodeValue)) {
+    for (const attribute of walked(source.xsl).filter(bare)) {
+      if (isValid(attribute.nodeValue)) {
+        expressions.push({source: source, attribute: attribute})
+      } else if (UNRESOLVED.test(attribute.nodeValue)) {
         logger.debug(`Skipping expression with an unresolved entity`)
       } else if (!suppressed) {
         defects.push({
@@ -104,8 +105,8 @@ const validate = function(corpus, suppressions = []) {
           severity: META.severity,
           message: META.message,
           file: source.file,
-          line: expression.lineNumber,
-          pos: expression.columnNumber,
+          line: attribute.lineNumber,
+          pos: attribute.columnNumber,
         })
       }
     }

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -66,7 +66,7 @@ const LINTERS = [
 /**
  * Expression linters paired with their checks, each given the valid Xpath
  * expressions the validator kept so they never reason over malformed input.
- * @type {Array.<{run: function(Array.<{file: string, expression: Node}>,
+ * @type {Array.<{run: function(Array.<{source: object, attribute: Node}>,
  *  Array.<string>): Array.<object>, checks: Array.<string>}>}
  */
 const EXPRESSION_LINTERS = [

--- a/test/attributes.test.js
+++ b/test/attributes.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {expressionsOf} = require('../src/attributes')
+const {expressionsOf, wholeOf} = require('../src/attributes')
 const {xml} = require('../src/helpers')
 const path = require('path')
 const fs = require('fs')
@@ -50,6 +50,14 @@ describe('attributes', function() {
         ['select', 0, '@x'],
       ],
       'cannot read the expressions of the stylesheet',
+    )
+  })
+  it('reads a narrowed attribute as the walk reads the same one', function() {
+    const whole = expressionsOf(SHEET).find((found) => found.start === 0)
+    assert.deepEqual(
+      wholeOf(whole.node),
+      whole,
+      'builds a different record for an attribute a linter narrowed to',
     )
   })
   it('cannot read a literal result attribute as an expression', function() {


### PR DESCRIPTION
Closes #648.

The word `expression` named the **text** in `src/attributes.js` and the **node**
in `src/xpath-validator.js`, and the two met in one call, which had to spell both
from one identifier:

```js
defect(CHECK, META, source, expression, offset, expression.nodeValue, {…})
```

**The convention is enforced before it is followed**, since a naming rule nothing
checks is a wish. Two `no-restricted-syntax` selectors, and they reproduce the
ticket on `master` — 9 errors across **four** files, not the two the ticket named:

```text
src/xpath-validator.js         4   'expression' naming a node
src/xpath-format-linter.js     3   both senses, in one call
src/node-set-linter.js         1   a node and its text as two arguments
src/redundant-boolean-call.js  1   the same
```

The first selector bans reading a node's property (`nodeValue`, `lineNumber`,
`ownerElement`, …) off anything called `expression`: a node is an `attribute`, and
the word means text. The second bans handing `defect` a node and a `.nodeValue`
separately. Both verified by reintroducing a violation of each shape and watching
it fail, tree clean again after restoring.

**The seven-parameter signature was the same defect**, as #644 says, so it goes in
the same pass. `defect` took a node, an offset, *and* the text — three parameters
describing one expression, which is precisely what let a caller pair the wrong two:

```js
defect(check, meta, source, node, offset, expression, fix)   // before
defect(check, meta, source, found, offset, fix)              // after
```

`found` is the record `expressionsOf` already yields (`{node, start, expression,
pattern}`), so the trio travels as one thing and a mismatch is not expressible.
Two further wins fall out. Every caller was adding `start` to its own offset —
nine chances to forget an addition that belongs in one place; that arithmetic is
now inside `defect`. And the two linters that narrow through `selectorOf` had been
building the pair by hand from a raw attribute, so `src/attributes.js` grows
`wholeOf(attribute)`, the one definition of the record, which `carried` now uses
too rather than spelling the same object literal twice.

**A JSDoc had already drifted where nobody could see it.** `EXPRESSION_LINTERS` in
`src/xslint.js` and `lintByFormat` both documented their input as
`{file: string, expression: Node}` — wrong in the key (the validator pushes
`source`, never `file`) as well as the type. That is what the ambiguity costs: the
contract between two stages was written down incorrectly and neither side noticed,
because neither name meant anything definite. Both now read
`{source: object, attribute: Node}`.

The validator's predicate `held` becomes `bare` — the word `src/attributes.js`
already uses for the same set — so the two modules name one concept one way. That
also frees `held`, which had been three different things in this tree: a predicate
here, the walked node list in `expressionsOf`, and a token's internal gap in
`xpath-format-linter`. The record is `found`, which `test/attributes.test.js` was
already calling it.

**No behavior changes**, which is the ticket's claim and the risk: 1069 tests and a
100% branch gate are what stand behind it, with not one pack position shifted. One
test is added, and it pins the property that matters rather than restating the
fields — `wholeOf(node)` must build exactly what the walk builds for the same node,
so a narrowing linter cannot be handed a different record from a walking one. It
fails if the two drift, verified by drifting one.

Not done here, and deliberate: `defect` does not check the shape it is handed.
Failing fast on a bad record would mean asking a value what type it is, which this
repository bans, and the selectors close the hole at the only place it ever opened
— the call site. The third sense the ticket raises, `isValid(xpath)` being handed
patterns and template sub-expressions as well as expressions, is not a rename but
the missing pattern grammar, and stays with #589.

`npm test` 1069 passing and 0 failing, `npm run coverage` the same at 100% of
statements, branches, functions and lines, `npx mocha test/xcop.test.js
--forbid-pending` 257 passing, `npx eslint .` clean, markdownlint clean, `npx grunt
docs` regenerated.
