### PR TITLE
Ban the conditional operator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,14 +33,22 @@ green — run `npm run coverage` and the xcop suite too.
 ESLint (`eslint-config-google` + `@stylistic`, config in `eslint.config.mjs`,
 run by the `lint` job) enforces: spaced operators, no single-letter names
 (`id-length` >= 2), postfix `x++` only (prefix `++x` is banned), bare module
-names in `require`/`import` (no `node:` prefix), no redundant return variable
+names in `require`/`import` (no `node:` prefix), no conditional operator
+(`a ? b : c` is banned outright by `no-ternary`, nesting and flat chain alike),
+no redundant return variable
 (`const x = expr; return x` is banned — return the expression), no missing
 argument (a call must fill every parameter the callee declares without a
 default), and one `return` per function (a second exit is banned). The last
 three are project-local rules in `eslint-local-rules.js`, unit-tested in
 `test/eslint-local-rules.test.js`; the arity of the callee is read from its
 declaration in the same file, or by loading the module a relative `require`
-names.
+names. That plugin file sat in ESLint's `ignores` and so was held to none of
+the rules it implements — nine ternaries lived there. It is linted now, with the
+formatting rules its own style predates (`semi`, `quotes`, `comma-dangle`,
+`quote-props`, `object-curly-spacing`, `space-before-function-paren`) and
+`local/no-multiple-returns` switched off for that one file, so a ban that
+matters reaches the plugin too. Shortening that off-list is its own job; only
+`eslint.config.mjs` is still unlinted.
 
 A parameter a caller may leave out therefore says so in the signature, with a
 default — `fix = undefined` on `defect` in `src/checks.js`. A JSDoc `[fix]`
@@ -50,11 +58,23 @@ call that omits it.
 
 A function likewise leaves through exactly one `return`, and the branching — not
 the exit — decides what it carries: a lookup keyed on the deciding values
-(`collapses` in `src/count-linter.js`), a ternary chain (`defectsOf` in
-`src/corpus-linter.js`), or a sentinel a scan assigns before its loop ends
+(`collapses` in `src/count-linter.js`), a binding an `if`/`else if` chain settles
+before the exit (`defectsOf` in `src/corpus-linter.js`, which picks the strategy
+rather than the answer), or a sentinel a scan assigns before its loop ends
 (`closes` in `src/expressions.js`). A `return` counts against the nearest
 enclosing function, so a `map`/`every` callback carrying its own single `return`
 is fine, and an arrow with an expression body has none at all.
+
+The conditional operator is not one of those shapes: it is banned outright, so a
+value that branches is a `let` initialised to the fallback and narrowed by an
+`if`, never `a ? b : c`. Two operators stay, because neither asks a question
+about a condition — `??` and `?.`, for the case that is only about absence:
+`entities.get(name) ?? whole` in `src/helpers.js` says what
+`has(name) ? get(name) : whole` said, in one reading rather than three. Where the
+branch really is a condition, initialise to the *default* arm and let the `if`
+carry the exception, so the fallback is stated once and the reader never holds an
+open branch to reach it. An arrow that has to branch grows a block body — the
+expression form has nowhere to put the `if`.
 
 A gap is spelled one way: `GAP` (or `WHITESPACE`) from `src/tokens.js`, the four
 characters of XML's `S`. JavaScript's `\s` is banned by a `no-restricted-syntax`

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,7 @@ module.exports = function(grunt) {
   grunt.initConfig({
     eslint: {
       target: [
-        'Gruntfile.js', 'src/**/*.js', 'src/**/*.mjs',
+        'Gruntfile.js', 'eslint-local-rules.js', 'src/**/*.js', 'src/**/*.mjs',
         'test/**/*.js', 'scripts/**/*.js',
       ],
     },

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -11,7 +11,11 @@ const required = function (params) {
   const optional = params.findIndex(
     (par) => par.type === "AssignmentPattern" || par.type === "RestElement"
   );
-  return optional === -1 ? params.length : optional;
+  let count = optional;
+  if (optional === -1) {
+    count = params.length;
+  }
+  return count;
 };
 
 // The parameter list of the function a binding holds, when that function is
@@ -36,7 +40,10 @@ const written = function (def) {
 // followed, so no third-party signature is ever second-guessed, and anything
 // that fails to resolve or to load leaves the call unjudged.
 const loaded = function (def, from) {
-  const init = def.node.type === "VariableDeclarator" ? def.node.init : null;
+  let init = null;
+  if (def.node.type === "VariableDeclarator") {
+    init = def.node.init;
+  }
   if (
     !init ||
     init.type !== "CallExpression" ||
@@ -68,9 +75,11 @@ const taken = function (def) {
   const property = def.node.id.properties.find(
     (pro) => pro.type === "Property" && pro.value === def.name
   );
-  return property && property.key.type === "Identifier" ?
-    property.key.name :
-    null;
+  let name = null;
+  if (property && property.key.type === "Identifier") {
+    name = property.key.name;
+  }
+  return name;
 };
 
 // The variable a name resolves to at a scope, respecting shadowing.
@@ -93,7 +102,10 @@ const demanded = function (variable, from, key) {
     return null;
   }
   const def = variable.defs[0];
-  const params = key === null ? written(def) : null;
+  let params = null;
+  if (key === null) {
+    params = written(def);
+  }
   if (params) {
     return required(params);
   }
@@ -104,9 +116,19 @@ const demanded = function (variable, from, key) {
   if (target === null) {
     return null;
   }
-  const name = key === null ? taken(def) : key;
-  const fun = name === null ? target : target[name];
-  return typeof fun === "function" ? fun.length : null;
+  let name = key;
+  if (key === null) {
+    name = taken(def);
+  }
+  let fun = target;
+  if (name !== null) {
+    fun = target[name];
+  }
+  let arity = null;
+  if (typeof fun === "function") {
+    arity = fun.length;
+  }
+  return arity;
 };
 
 // A project-local ESLint plugin, kept out of eslint.config.mjs so it can be
@@ -189,12 +211,16 @@ module.exports = {
             ) {
               return;
             }
-            const holder =
-              callee.type === "Identifier" ? callee : callee.object;
+            let holder = callee;
+            let key = null;
+            if (callee.type !== "Identifier") {
+              holder = callee.object;
+              key = callee.property.name;
+            }
             const expected = demanded(
               bound(context.sourceCode.getScope(node), holder.name),
               context.filename,
-              callee.type === "Identifier" ? null : callee.property.name
+              key
             );
             if (expected !== null && node.arguments.length < expected) {
               context.report({

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,7 +22,7 @@ const compat = new FlatCompat({
 });
 
 export default defineConfig([
-  { ignores: ["eslint.config.mjs", "eslint-local-rules.js", "docs/**"] },
+  { ignores: ["eslint.config.mjs", "docs/**"] },
   js.configs.recommended,
   ...compat.extends("google"),
   jsdoc.configs["flat/recommended-error"],
@@ -62,6 +62,7 @@ export default defineConfig([
       ],
       "jsdoc/reject-any-type": "off",
       "@stylistic/space-infix-ops": "error",
+      "no-ternary": "error",
       "id-length": ["error", { min: 2 }],
       "no-restricted-syntax": ["error",
         {
@@ -115,5 +116,17 @@ export default defineConfig([
   {
     files: ["**/*.mjs"],
     languageOptions: { sourceType: "module" }
+  },
+  {
+    files: ["eslint-local-rules.js"],
+    rules: {
+      "comma-dangle": "off",
+      "local/no-multiple-returns": "off",
+      "object-curly-spacing": "off",
+      "quote-props": "off",
+      quotes: "off",
+      semi: "off",
+      "space-before-function-paren": "off"
+    }
   }
 ]);

--- a/scripts/changelog-notes.js
+++ b/scripts/changelog-notes.js
@@ -26,9 +26,15 @@ const section = function(heading) {
   const next = lines.findIndex(
     (line, index) => index > start && line.startsWith('## '),
   )
-  return start < 0 ?
-    '' :
-    lines.slice(start + 1, next < 0 ? lines.length : next).join('\n').trim()
+  let end = next
+  if (next < 0) {
+    end = lines.length
+  }
+  let body = ''
+  if (start >= 0) {
+    body = lines.slice(start + 1, end).join('\n').trim()
+  }
+  return body
 }
 
 // Prefer this version's section; fall back to Unreleased, then a bare line, so

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -78,22 +78,28 @@ const CSS = `
 
 const HLJS_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0'
 
-const page = (title, content, withHighlight) => `<!DOCTYPE html>
+const page = (title, content, withHighlight) => {
+  let highlight = ''
+  if (withHighlight) {
+    highlight = `
+  <link rel="stylesheet" href="${HLJS_CDN}/styles/github.min.css">
+  <script src="${HLJS_CDN}/highlight.min.js"></script>
+  <script src="${HLJS_CDN}/languages/xml.min.js"></script>
+  <script>hljs.highlightAll();</script>`
+  }
+  return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>${title}</title>
-  <style>${CSS}</style>${withHighlight ? `
-  <link rel="stylesheet" href="${HLJS_CDN}/styles/github.min.css">
-  <script src="${HLJS_CDN}/highlight.min.js"></script>
-  <script src="${HLJS_CDN}/languages/xml.min.js"></script>
-  <script>hljs.highlightAll();</script>` : ''}
+  <style>${CSS}</style>${highlight}
 </head>
 <body>
 ${content}
 </body>
 </html>`
+}
 
 const severityBadge = (severity) => {
   return `<span class="severity-${severity}">${severity}</span>`
@@ -101,14 +107,23 @@ const severityBadge = (severity) => {
 
 const escaped = (xpath) => xpath.replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
-const expressions = (kind, lint) => kind === 'corpus' ?
-  `<code class="xpath">declaration: ${escaped(lint.declaration)}</code>
-    <code class="xpath">usage: ${escaped(lint.usage)}</code>` :
-  kind === 'validation' ?
-    `<code class="xpath">verified by the parser, not an XPath rule</code>` :
-    kind === 'format' ?
-      `<code class="xpath">checked over the tokens, not an XPath rule</code>` :
-      `<code class="xpath">${escaped(lint.xpath)}</code>`
+const expressions = (kind, lint) => {
+  let shown
+  if (kind === 'corpus') {
+    shown = `<code class="xpath">declaration: ${
+      escaped(lint.declaration)}</code>
+    <code class="xpath">usage: ${escaped(lint.usage)}</code>`
+  } else if (kind === 'validation') {
+    shown =
+      `<code class="xpath">verified by the parser, not an XPath rule</code>`
+  } else if (kind === 'format') {
+    shown =
+      `<code class="xpath">checked over the tokens, not an XPath rule</code>`
+  } else {
+    shown = `<code class="xpath">${escaped(lint.xpath)}</code>`
+  }
+  return shown
+}
 
 const generate = function() {
   const checks = KINDS.flatMap((kind) => allFilesFrom(path.join(CHECKS, kind))
@@ -118,7 +133,10 @@ const generate = function() {
       const name = path.basename(yamlFile, '.yaml')
       const lint = yaml.parsedFromFile(yamlFile)
       const mdFile = path.join(MOTIVES, kind, `${name}.md`)
-      const md = fs.existsSync(mdFile) ? fs.readFileSync(mdFile, 'utf-8') : null
+      let md = null
+      if (fs.existsSync(mdFile)) {
+        md = fs.readFileSync(mdFile, 'utf-8')
+      }
       return {name, kind, lint, md}
     }))
 
@@ -187,7 +205,10 @@ ${indexRows}
   )
 
   for (const {name, kind, lint, md} of checks) {
-    const mdHtml = md ? marked(md) : `<h1>${name}</h1><p>${lint.message}</p>`
+    let mdHtml = `<h1>${name}</h1><p>${lint.message}</p>`
+    if (md) {
+      mdHtml = marked(md)
+    }
     const checkBody = `  <a class="back" href="../index.html">← all checks</a>
   <div class="meta">
     ${severityBadge(lint.severity)}

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -91,9 +91,11 @@ const expands = function(text) {
   let node = text.parentNode
   let setting = ''
   while (node.nodeType === 1 && !setting) {
-    setting = node.namespaceURI === XSLT ?
-      node.getAttribute('expand-text') :
-      node.getAttributeNS(XSLT, 'expand-text')
+    if (node.namespaceURI === XSLT) {
+      setting = node.getAttribute('expand-text')
+    } else {
+      setting = node.getAttributeNS(XSLT, 'expand-text')
+    }
     node = node.parentNode
   }
   return Boolean(setting) && ON.includes(setting.trim())
@@ -131,14 +133,18 @@ const carried = function(node, bare, three) {
   const whole = node.nodeType === 2 &&
     (bare.has(node) || (three && shadow(node)))
   const braced = node.nodeType === 2 || (three && expands(node))
-  return whole ?
-    [Object.freeze({
+  let taken = []
+  if (whole) {
+    taken = [Object.freeze({
       node: node, start: 0, expression: node.nodeValue,
       pattern: PATTERNS.includes(node.nodeName.replace(/^_/, '')),
-    })] :
-    braced ? enclosed(node.nodeValue).map((found) => Object.freeze({
+    })]
+  } else if (braced) {
+    taken = enclosed(node.nodeValue).map((found) => Object.freeze({
       node: node, start: found.offset, expression: found.value, pattern: false,
-    })) : []
+    }))
+  }
+  return taken
 }
 
 /**

--- a/src/checks.js
+++ b/src/checks.js
@@ -73,9 +73,10 @@ const defect = function(
       offset,
     ),
   )
-  const anchored = fix === undefined || !isValid(expression) ?
-    undefined :
-    {line: line, col: pos, ...fix}
+  let anchored = {}
+  if (fix !== undefined && isValid(expression)) {
+    anchored = {fix: {line: line, col: pos, ...fix}}
+  }
   return {
     name: check,
     severity: meta.severity,
@@ -84,7 +85,7 @@ const defect = function(
     line: line,
     from: (node.ownerElement || node.parentNode).lineNumber,
     pos: pos,
-    ...(anchored === undefined ? {} : {fix: anchored}),
+    ...anchored,
   }
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -65,7 +65,11 @@ const typed = function(raw, key, ok, expected, fallback) {
   if (present && !fits) {
     logger.warn(`Value of '${key}' in ${NAME} must be ${expected}, ignoring it`)
   }
-  return fits ? raw[key] : fallback
+  let value = fallback
+  if (fits) {
+    value = raw[key]
+  }
+  return value
 }
 
 /**
@@ -125,13 +129,20 @@ const normalized = function(raw) {
  *  logLevel: string|null, quiet: boolean|null, base: string}} - Configuration
  */
 const configFrom = function(explicit, from = process.cwd()) {
-  const file = explicit ? path.resolve(from, explicit) : located(from)
+  let file = null
+  if (explicit) {
+    file = path.resolve(from, explicit)
+  } else {
+    file = located(from)
+  }
   let raw = null
+  let base = from
   if (file) {
     raw = yaml.parsedFromFile(file)
+    base = path.dirname(file)
     logger.debug(`Configuration loaded from ${file}`)
   }
-  return {...normalized(raw), base: file ? path.dirname(file) : from}
+  return {...normalized(raw), base: base}
 }
 
 module.exports = {

--- a/src/corpus-linter.js
+++ b/src/corpus-linter.js
@@ -209,10 +209,15 @@ const byReachability = function(corpus, check) {
  * @return {Array.<object>} - Defects found
  */
 const defectsOf = function(corpus, check) {
-  return !check.reference ? byName(corpus, check) :
-    check.reachable ? byReachability(corpus, check) :
-      check.scoped ? byScope(corpus, check) :
-        byCall(corpus, check)
+  let strategy = byCall
+  if (!check.reference) {
+    strategy = byName
+  } else if (check.reachable) {
+    strategy = byReachability
+  } else if (check.scoped) {
+    strategy = byScope
+  }
+  return strategy(corpus, check)
 }
 
 /**

--- a/src/count-linter.js
+++ b/src/count-linter.js
@@ -57,7 +57,11 @@ const collapses = function(operator, zero) {
  */
 const decide = function(operator, zero, argument) {
   const test = collapses(operator, zero)
-  return test ? {test: test, argument: argument} : null
+  let found = null
+  if (test) {
+    found = {test: test, argument: argument}
+  }
+  return found
 }
 
 /**
@@ -73,10 +77,15 @@ const decide = function(operator, zero, argument) {
  * @return {string} - The replacement expression
  */
 const rewritten = function(test, argument, modern, whole) {
-  return modern ? `${test}(${argument})` :
-    test === 'exists' ?
-      (whole ? argument : `boolean(${argument})`) :
-      `not(${argument})`
+  let direct = `not(${argument})`
+  if (modern) {
+    direct = `${test}(${argument})`
+  } else if (test === 'exists' && whole) {
+    direct = argument
+  } else if (test === 'exists') {
+    direct = `boolean(${argument})`
+  }
+  return direct
 }
 
 /**

--- a/src/directives.js
+++ b/src/directives.js
@@ -64,9 +64,10 @@ const directivesFrom = function(content) {
 const covers = function(directive, defect) {
   const named = directive.names.length === 0 ||
     directive.names.includes(defect.name)
-  const covered = directive.type === TYPES.NEXT_LINE ?
-    directive.line + 1 :
-    directive.line
+  let covered = directive.line
+  if (directive.type === TYPES.NEXT_LINE) {
+    covered = directive.line + 1
+  }
   return named && (directive.type === TYPES.FILE ||
     (covered >= (defect.from || defect.line) && covered <= defect.line))
 }

--- a/src/fixer.js
+++ b/src/fixer.js
@@ -19,13 +19,19 @@ const {logger} = require('./logger')
 const decodes = function(content, from, value) {
   let raw = from
   const matched = [...value].every((char) => {
-    const [decoded, next] = raw < content.length ?
-      character(content, raw) :
-      [null, raw]
+    let step = [null, raw]
+    if (raw < content.length) {
+      step = character(content, raw)
+    }
+    const [decoded, next] = step
     raw = next
     return decoded === char
   })
-  return matched ? raw : -1
+  let past = -1
+  if (matched) {
+    past = raw
+  }
+  return past
 }
 
 /**

--- a/src/fixers.js
+++ b/src/fixers.js
@@ -61,9 +61,11 @@ const missingVersion = function(node) {
  */
 const modeOrPriority = function(node) {
   const present = ['mode', 'priority'].filter((name) => node.hasAttribute(name))
-  return present.length === 1 ?
-    {...deletion(node.getAttributeNode(present[0])), suggestion: true} :
-    null
+  let fix = null
+  if (present.length === 1) {
+    fix = {...deletion(node.getAttributeNode(present[0])), suggestion: true}
+  }
+  return fix
 }
 
 /**
@@ -92,15 +94,17 @@ const modeOrPriority = function(node) {
  */
 const startsWithDoubleSlash = function(pattern) {
   const at = pattern.value.indexOf('//')
+  let tier = {}
+  if (pattern.ownerElement.localName === 'template') {
+    tier = {suggestion: true}
+  }
   return {
     line: pattern.lineNumber,
     col: pattern.columnNumber - pattern.name.length - 1,
     value: `${pattern.name}="${pattern.value}"`,
     replacement: `${pattern.name}="${
       pattern.value.slice(0, at)}${pattern.value.slice(at + 2)}"`,
-    ...pattern.ownerElement.localName === 'template' ?
-      {suggestion: true} :
-      {},
+    ...tier,
   }
 }
 
@@ -114,12 +118,15 @@ const startsWithDoubleSlash = function(pattern) {
  */
 const booleanConstant = function(node) {
   const test = node.getAttributeNode('test')
+  let constant = 'false()'
+  if (test.value.includes('true')) {
+    constant = 'true()'
+  }
   return {
     line: test.lineNumber,
     col: test.columnNumber - test.name.length - 1,
     value: `${test.name}="${test.value}"`,
-    replacement:
-      `${test.name}="${test.value.includes('true') ? 'true()' : 'false()'}"`,
+    replacement: `${test.name}="${constant}"`,
     suggestion: true,
   }
 }
@@ -178,15 +185,17 @@ const textOutsideXslText = function(node) {
   const texts = Array.from(node.childNodes).filter(
     (child) => child.nodeType === 3 && child.nodeValue.trim() !== '',
   )
-  return texts.length === 1 ?
-    {
+  let fix = null
+  if (texts.length === 1) {
+    fix = {
       line: texts[0].lineNumber,
       col: texts[0].columnNumber,
       value: texts[0].nodeValue,
       replacement: `<xsl:text>${texts[0].nodeValue}</xsl:text>`,
       suggestion: true,
-    } :
-    null
+    }
+  }
+  return fix
 }
 
 /**

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -32,7 +32,7 @@ const declaredEntities = function(str) {
     new RegExp(
       `<!ENTITY${GAP}+([A-Za-z_][\\w.-]*)${GAP}+` +
       `(?:"([^"]*)"|'([^']*)')`, 'g'))) {
-    entities.set(match[1], match[2] === undefined ? match[3] : match[2])
+    entities.set(match[1], match[2] ?? match[3])
   }
   return entities
 }
@@ -63,7 +63,7 @@ const expand = function(node, entities) {
   if ((node.nodeType === 2 || node.nodeType === 3) &&
     node.nodeValue.includes('&')) {
     const value = node.nodeValue.replace(REFERENCE,
-      (whole, name) => entities.has(name) ? entities.get(name) : whole)
+      (whole, name) => entities.get(name) ?? whole)
     node.nodeValue = value
     if (node.nodeType === 2) {
       node.value = value

--- a/src/import-linter.js
+++ b/src/import-linter.js
@@ -162,7 +162,11 @@ const byRedundancy = function(corpus) {
     const key = `${file}|${to}`
     if (seen.has(key)) {
       const report = defect(REDUNDANT, file, node)
-      defects.push(mixed.has(key) ? report : {...report, fix: removal(node)})
+      if (mixed.has(key)) {
+        defects.push(report)
+      } else {
+        defects.push({...report, fix: removal(node)})
+      }
     } else {
       seen.add(key)
     }
@@ -182,10 +186,13 @@ const byRedundancy = function(corpus) {
  */
 const lintByImports = function(corpus, suppressions = []) {
   logger.debug(`Import linting started`)
-  const defects = [
-    ...suppressed(CIRCULAR, suppressions) ? [] : byCircularity(corpus),
-    ...suppressed(REDUNDANT, suppressions) ? [] : byRedundancy(corpus),
-  ]
+  const defects = []
+  if (!suppressed(CIRCULAR, suppressions)) {
+    defects.push(...byCircularity(corpus))
+  }
+  if (!suppressed(REDUNDANT, suppressions)) {
+    defects.push(...byRedundancy(corpus))
+  }
   logger.debug(`Found ${defects.length} import defects`)
   return defects
 }

--- a/src/name-linter.js
+++ b/src/name-linter.js
@@ -65,10 +65,17 @@ const NAME = /^[A-Za-z_][\w.-]*(:[A-Za-z_][\w.-]*)?$/
  * @return {?string} - The replacement expression, or null
  */
 const test = function(fn, operator, literal, modern) {
-  const node = fn === 'name' ? `self::${literal}` : `self::*:${literal}`
-  return !NAME.test(literal) || (fn === 'local-name' && !modern) ?
-    null :
-    operator === '!=' ? `not(${node})` : node
+  let node = `self::*:${literal}`
+  if (fn === 'name') {
+    node = `self::${literal}`
+  }
+  let replacement = node
+  if (!NAME.test(literal) || (fn === 'local-name' && !modern)) {
+    replacement = null
+  } else if (operator === '!=') {
+    replacement = `not(${node})`
+  }
+  return replacement
 }
 
 /**
@@ -139,11 +146,12 @@ const lintByName = function(corpus, suppressions = []) {
         for (const {offset, value, replacement} of comparisons(
           expression, modern,
         )) {
+          let fix
+          if (replacement !== null) {
+            fix = {value, replacement, suggestion: true}
+          }
           defects.push(
-            defect(CHECK, META, source, node, start + offset, expression,
-              replacement === null ?
-                undefined : {value, replacement, suggestion: true},
-            ),
+            defect(CHECK, META, source, node, start + offset, expression, fix),
           )
         }
       }

--- a/src/namespace-linter.js
+++ b/src/namespace-linter.js
@@ -33,7 +33,11 @@ const names = [CHECK]
  * @return {?string} - The bound prefix, or null
  */
 const declared = function(name) {
-  return name.startsWith('xmlns:') ? name.slice('xmlns:'.length) : null
+  let prefix = null
+  if (name.startsWith('xmlns:')) {
+    prefix = name.slice('xmlns:'.length)
+  }
+  return prefix
 }
 
 /**

--- a/src/output.js
+++ b/src/output.js
@@ -34,7 +34,13 @@ const colorful = function(stream) {
  * }} - Writer bound to the sink
  */
 const writer = function(sink, colored = true) {
-  const paint = (color, text) => colored ? safe[color](text) : text
+  const paint = (color, text) => {
+    let painted = text
+    if (colored) {
+      painted = safe[color](text)
+    }
+    return painted
+  }
   return {
     debug: (msg, ...args) => sink(`${paint('gray', '[DEBUG]')} ${msg}`, ...args),
     info: (msg, ...args) => sink(`${paint('blue', '[INFO]')} ${msg}`, ...args),

--- a/src/predicate-position-linter.js
+++ b/src/predicate-position-linter.js
@@ -47,9 +47,11 @@ const SIGN = {
  * @return {string} - Its one-character signature symbol
  */
 const symbol = function(token) {
-  return (token.type === TOKENS.NAME ?
-    {position: 'P', last: 'L'}[token.value] :
-    SIGN[token.type]) || 'x'
+  let sign = SIGN[token.type]
+  if (token.type === TOKENS.NAME) {
+    sign = {position: 'P', last: 'L'}[token.value]
+  }
+  return sign || 'x'
 }
 
 /**
@@ -64,9 +66,13 @@ const symbol = function(token) {
  */
 const shortened = function(significant) {
   const sign = significant.map(symbol).join('')
-  return sign === 'P()=N' || sign === 'N=P()' ?
-    significant.find((token) => token.type === TOKENS.NUMBER).value :
-    sign === 'P()=L()' || sign === 'L()=P()' ? 'last()' : null
+  let short = null
+  if (sign === 'P()=N' || sign === 'N=P()') {
+    short = significant.find((token) => token.type === TOKENS.NUMBER).value
+  } else if (sign === 'P()=L()' || sign === 'L()=P()') {
+    short = 'last()'
+  }
+  return short
 }
 
 /**

--- a/src/redundant-boolean-call-linter.js
+++ b/src/redundant-boolean-call-linter.js
@@ -49,16 +49,20 @@ const WRAPPER = new RegExp(`^${GAP}*boolean${GAP}*\\(`)
 const stripped = function(test) {
   const blanked = masked(test)
   const wrapper = WRAPPER.exec(blanked)
-  const open = wrapper ? wrapper[0].length - 1 : -1
-  const close = wrapper ? closes(blanked, open) : -1
-  const offset = wrapper ? wrapper[0].indexOf('boolean') : -1
-  return close < 0 || blanked.slice(close + 1).trim() !== '' ?
-    null :
-    {
-      offset: offset,
-      value: test.slice(offset, close + 1),
-      replacement: test.slice(open + 1, close).trim(),
+  let strip = null
+  if (wrapper) {
+    const open = wrapper[0].length - 1
+    const close = closes(blanked, open)
+    const offset = wrapper[0].indexOf('boolean')
+    if (close >= 0 && blanked.slice(close + 1).trim() === '') {
+      strip = {
+        offset: offset,
+        value: test.slice(offset, close + 1),
+        replacement: test.slice(open + 1, close).trim(),
+      }
     }
+  }
+  return strip
 }
 
 /**

--- a/src/redundant-double-negation-linter.js
+++ b/src/redundant-double-negation-linter.js
@@ -97,10 +97,14 @@ const lintByDoubleNegation = function(corpus, suppressions = []) {
         for (const {offset, value, argument} of negations(expression)) {
           const bare = node.nodeName === 'test' &&
             node.nodeValue.trim() === value
+          let replacement = `boolean(${argument})`
+          if (bare) {
+            replacement = argument
+          }
           defects.push(
             defect(CHECK, META, source, node, start + offset, expression, {
               value: value,
-              replacement: bare ? argument : `boolean(${argument})`,
+              replacement: replacement,
             }),
           )
         }

--- a/src/reporters.js
+++ b/src/reporters.js
@@ -25,7 +25,11 @@ const LEVEL = {warning: 'warning', error: 'error'}
 const located = function(file) {
   const relative = path.relative(process.cwd(), file)
   const escapes = relative.startsWith('..') || path.isAbsolute(relative)
-  return (escapes ? file : relative).split(path.sep).join('/')
+  let named = relative
+  if (escapes) {
+    named = file
+  }
+  return named.split(path.sep).join('/')
 }
 
 /**

--- a/src/result-namespace-linter.js
+++ b/src/result-namespace-linter.js
@@ -38,7 +38,11 @@ const names = [CHECK]
  * @return {?string} - The bound prefix, or null
  */
 const declared = function(name) {
-  return name.startsWith('xmlns:') ? name.slice('xmlns:'.length) : null
+  let prefix = null
+  if (name.startsWith('xmlns:')) {
+    prefix = name.slice('xmlns:'.length)
+  }
+  return prefix
 }
 
 /**
@@ -47,7 +51,11 @@ const declared = function(name) {
  * @return {?string} - The prefix, or null
  */
 const prefixOf = function(name) {
-  return name.includes(':') ? name.slice(0, name.indexOf(':')) : null
+  let prefix = null
+  if (name.includes(':')) {
+    prefix = name.slice(0, name.indexOf(':'))
+  }
+  return prefix
 }
 
 /**
@@ -145,21 +153,23 @@ const textual = function(elements) {
  */
 const exclusion = function(root, prefix) {
   const attribute = root.getAttributeNode('exclude-result-prefixes')
-  return attribute ?
-    {
+  let fix = {
+    line: root.lineNumber,
+    col: root.columnNumber + root.nodeName.length + 1,
+    value: '',
+    replacement: ` exclude-result-prefixes="${prefix}"`,
+    suggestion: true,
+  }
+  if (attribute) {
+    fix = {
       line: attribute.lineNumber,
       col: attribute.columnNumber - attribute.name.length - 1,
       value: `${attribute.name}="${attribute.value}"`,
       replacement: `${attribute.name}="${attribute.value} ${prefix}"`,
       suggestion: true,
-    } :
-    {
-      line: root.lineNumber,
-      col: root.columnNumber + root.nodeName.length + 1,
-      value: '',
-      replacement: ` exclude-result-prefixes="${prefix}"`,
-      suggestion: true,
     }
+  }
+  return fix
 }
 
 /**
@@ -191,15 +201,17 @@ const lintByResultNamespace = function(corpus, suppressions = []) {
       const leaks = !excluded.has('#all') &&
         !textual(elements) &&
         elements.some((element) => literal(element, extension))
-      const output = leaks ? outputs(elements, extension) : new Set()
-      const leaking = leaks ?
-        Array.from(root.attributes).filter((attribute) => {
+      let output = new Set()
+      let leaking = []
+      if (leaks) {
+        output = outputs(elements, extension)
+        leaking = Array.from(root.attributes).filter((attribute) => {
           const prefix = declared(attribute.name)
           return prefix && prefix !== 'xml' && prefix !== root.prefix &&
             !excluded.has(prefix) && !extension.has(prefix) &&
             !output.has(prefix) && used(elements, prefix)
-        }) :
-        []
+        })
+      }
       for (const attribute of leaking) {
         defects.push({
           name: CHECK,

--- a/src/source.js
+++ b/src/source.js
@@ -85,14 +85,20 @@ const placeAt = function(text, at) {
  *  and the next raw offset
  */
 const character = function(content, at) {
-  const closing = content[at] === '&' ? content.indexOf(';', at) : -1
-  const entity = closing < 0 ?
-    [undefined, at + 1] :
-    [NAMED[content.slice(at + 1, closing)], closing + 1]
-  const ending = content[at] === '\r' ?
-    ['\n', content[at + 1] === '\n' ? at + 2 : at + 1] :
-    [content[at], at + 1]
-  return content[at] === '&' ? entity : ending
+  let read = [content[at], at + 1]
+  if (content[at] === '&') {
+    const closing = content.indexOf(';', at)
+    read = [undefined, at + 1]
+    if (closing >= 0) {
+      read = [NAMED[content.slice(at + 1, closing)], closing + 1]
+    }
+  } else if (content[at] === '\r') {
+    read = ['\n', at + 1]
+    if (content[at + 1] === '\n') {
+      read = ['\n', at + 2]
+    }
+  }
+  return read
 }
 
 /**

--- a/src/string-length-linter.js
+++ b/src/string-length-linter.js
@@ -80,10 +80,19 @@ const simple = function(argument) {
  */
 const decide = function(operator, zero, argument, blanked) {
   const hollow = empty(operator, zero)
-  return hollow === null ? null : {
-    replacement: simple(blanked) ?
-      `${argument} ${hollow ? '=' : '!='} ''` : null,
+  let rewrite = null
+  if (hollow !== null) {
+    let operand = '!='
+    if (hollow) {
+      operand = '='
+    }
+    let replacement = null
+    if (simple(blanked)) {
+      replacement = `${argument} ${operand} ''`
+    }
+    rewrite = {replacement: replacement}
   }
+  return rewrite
 }
 
 /**
@@ -117,11 +126,12 @@ const lintByStringLength = function(corpus, suppressions = []) {
     for (const source of corpus) {
       for (const {node, start, expression} of expressionsOf(source.xsl)) {
         for (const {offset, value, replacement} of comparisons(expression)) {
+          let fix
+          if (replacement !== null) {
+            fix = {value, replacement, suggestion: true}
+          }
           defects.push(
-            defect(CHECK, META, source, node, start + offset, expression,
-              replacement === null ?
-                undefined : {value, replacement, suggestion: true},
-            ),
+            defect(CHECK, META, source, node, start + offset, expression, fix),
           )
         }
       }

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -315,10 +315,12 @@ const opensAxis = function(xpath, at) {
     colons += 1
   }
   const name = `${xpath.slice(at, end)}::`
-  return end === at || xpath[colons] !== ':' || xpath[colons + 1] !== ':' ||
-    !AXES[name] || spelling(xpath, at) ?
-    null :
-    {name: name, length: colons + 2 - at}
+  let opened = null
+  if (end !== at && xpath[colons] === ':' && xpath[colons + 1] === ':' &&
+    AXES[name] && !spelling(xpath, at)) {
+    opened = {name: name, length: colons + 2 - at}
+  }
+  return opened
 }
 
 /**
@@ -541,13 +543,21 @@ const tokenized = function(xpath) {
       at += func.length
     } else if (STARTS.test(xpath[at])) {
       const name = xpath.slice(at, afterName(xpath, at))
-      const spelled = more && more.split(' ')[0] === name ? more : name
+      let spelled = name
+      if (more && more.split(' ')[0] === name) {
+        spelled = more
+      }
       const word = WORDS.includes(name) ||
         (spelled !== name && MORE[spelled] !== undefined)
-      type = word && operates(tokens) ?
-        {...DOUBLE, ...TRIPLE, ...MORE}[spelled] :
-        TOKENS.NAME
-      at += type === TOKENS.NAME ? name.length : spelled.length
+      type = TOKENS.NAME
+      if (word && operates(tokens)) {
+        type = {...DOUBLE, ...TRIPLE, ...MORE}[spelled]
+      }
+      if (type === TOKENS.NAME) {
+        at += name.length
+      } else {
+        at += spelled.length
+      }
     } else if (SYMBOLS[xpath.slice(at, at + 2)]) {
       type = SYMBOLS[xpath.slice(at, at + 2)]
       at += 2

--- a/src/translate-linter.js
+++ b/src/translate-linter.js
@@ -89,8 +89,13 @@ const args = function(expression, blanked, from, to) {
  * @return {?string} - `lower-case`, `upper-case`, or null
  */
 const folds = function(from, to) {
-  return from === UPPER && to === LOWER ? 'lower-case' :
-    from === LOWER && to === UPPER ? 'upper-case' : null
+  let fold = null
+  if (from === UPPER && to === LOWER) {
+    fold = 'lower-case'
+  } else if (from === LOWER && to === UPPER) {
+    fold = 'upper-case'
+  }
+  return fold
 }
 
 /**

--- a/src/tree.js
+++ b/src/tree.js
@@ -57,7 +57,13 @@ const walked = function(xsl) {
     const visit = function(node) {
       const carried = Array.from(node.attributes || [])
         .filter((one) => !DECLARED.test(one.nodeName))
-        .sort((one, two) => (one.nodeName < two.nodeName ? -1 : 1))
+        .sort((one, two) => {
+          let order = 1
+          if (one.nodeName < two.nodeName) {
+            order = -1
+          }
+          return order
+        })
       for (const one of carried) {
         found.push(one)
       }

--- a/src/xpath-axis-linter.js
+++ b/src/xpath-axis-linter.js
@@ -76,9 +76,11 @@ const SPAN = 4
 const spans = function(tokens, index) {
   const gap = tokens[index + 1]
   const axis = tokens[index]
-  return gap !== undefined && gap.type === TOKENS.WHITESPACE ?
-    gap.start + gap.value.length :
-    axis.start + axis.value.length
+  let past = axis.start + axis.value.length
+  if (gap !== undefined && gap.type === TOKENS.WHITESPACE) {
+    past = gap.start + gap.value.length
+  }
+  return past
 }
 
 /**
@@ -98,10 +100,14 @@ const afterNode = function(tokens, index) {
   const shaped = rest.length >= 3 &&
     rest[0].type === TOKENS.NAME && rest[0].value === 'node' &&
     rest[1].type === TOKENS.LPAREN && rest[2].type === TOKENS.RPAREN
-  return shaped ? {
-    end: rest[2].start + 1,
-    predicated: rest.length > 3 && rest[3].type === TOKENS.LBRACKET,
-  } : null
+  let node = null
+  if (shaped) {
+    node = {
+      end: rest[2].start + 1,
+      predicated: rest.length > 3 && rest[3].type === TOKENS.LBRACKET,
+    }
+  }
+  return node
 }
 
 /**
@@ -133,7 +139,10 @@ const abbreviable = function(expression, modern, pattern) {
   const tokens = tokenized(expression)
   const found = []
   tokens.forEach((token, index) => {
-    const step = STEP[token.type] ? afterNode(tokens, index) : null
+    let step = null
+    if (STEP[token.type]) {
+      step = afterNode(tokens, index)
+    }
     if (SHORT[token.type]) {
       found.push({
         offset: token.start,
@@ -143,13 +152,14 @@ const abbreviable = function(expression, modern, pattern) {
         },
       })
     } else if (step !== null && !pattern) {
-      found.push({
-        offset: token.start,
-        fix: step.predicated && !modern ? undefined : {
+      let fix
+      if (!step.predicated || modern) {
+        fix = {
           value: expression.slice(token.start, step.end),
           replacement: STEP[token.type].replacement,
-        },
-      })
+        }
+      }
+      found.push({offset: token.start, fix: fix})
     }
   })
   return found

--- a/src/xpath-format-linter.js
+++ b/src/xpath-format-linter.js
@@ -45,12 +45,15 @@ const INTERNAL = new RegExp(`${GAP}{2,}`)
  * @return {?{offset: number, value: string, replacement: string}} - The run
  */
 const inside = function(token) {
-  const run = token.type === TOKENS.STRING || token.type === TOKENS.COMMENT ?
-    null :
-    INTERNAL.exec(token.value)
-  return run === null || /[\r\n]/.test(run[0]) ?
-    null :
-    {offset: token.start + run.index, value: run[0], replacement: ' '}
+  let run = null
+  if (token.type !== TOKENS.STRING && token.type !== TOKENS.COMMENT) {
+    run = INTERNAL.exec(token.value)
+  }
+  let held = null
+  if (run !== null && !/[\r\n]/.test(run[0])) {
+    held = {offset: token.start + run.index, value: run[0], replacement: ' '}
+  }
+  return held
 }
 
 /**
@@ -69,16 +72,23 @@ const redundancies = function(expression) {
     const edge =
       token.start === 0 ||
       token.start + token.value.length === expression.length
-    const held = token.type === TOKENS.WHITESPACE ? null : inside(token)
+    let held = null
+    if (token.type !== TOKENS.WHITESPACE) {
+      held = inside(token)
+    }
     if (
       token.type === TOKENS.WHITESPACE &&
       !/[\r\n]/.test(token.value) &&
       (edge || token.value.length > 1)
     ) {
+      let replacement = ' '
+      if (edge) {
+        replacement = ''
+      }
       runs.push({
         offset: token.start,
         value: token.value,
-        replacement: edge ? '' : ' ',
+        replacement: replacement,
       })
     } else if (held !== null) {
       runs.push(held)

--- a/src/xpath.js
+++ b/src/xpath.js
@@ -207,8 +207,13 @@ const compiles = function(xpath) {
   let ok = true
   try {
     compileXPathToJavaScript(xpath, evaluateXPath.ALL_RESULTS_TYPE, {
-      namespaceResolver: (prefix) =>
-        Object.hasOwn(STANDARD, prefix) ? STANDARD[prefix] : FUNCTIONS,
+      namespaceResolver: (prefix) => {
+        let uri = FUNCTIONS
+        if (Object.hasOwn(STANDARD, prefix)) {
+          uri = STANDARD[prefix]
+        }
+        return uri
+      },
     })
   } catch (err) {
     ok = CODED.test(String(err.message))
@@ -235,7 +240,13 @@ const compiles = function(xpath) {
 const rewritten = function(xpath, pattern, replacement, swallowed) {
   return xpath.replace(
     pattern,
-    (match, name, at) => swallowed(xpath, at) ? match : replacement(name),
+    (match, name, at) => {
+      let spelled = match
+      if (!swallowed(xpath, at)) {
+        spelled = replacement(name)
+      }
+      return spelled
+    },
   )
 }
 

--- a/src/xsl-version.js
+++ b/src/xsl-version.js
@@ -90,9 +90,13 @@ const since = function(version, floor) {
  */
 const declaring = function(element) {
   const xslt = element.namespaceURI === XSLT
-  const own = xslt && element.localName !== SERIALIZING ?
-    element.getAttribute('version') : ''
-  return xslt ? own : element.getAttributeNS(XSLT, 'version')
+  let declared = element.getAttributeNS(XSLT, 'version')
+  if (xslt && element.localName === SERIALIZING) {
+    declared = ''
+  } else if (xslt) {
+    declared = element.getAttribute('version')
+  }
+  return declared
 }
 
 /**
@@ -115,7 +119,11 @@ const HELD = {
  */
 const holding = function(node) {
   const held = HELD[node.nodeType]
-  return held === undefined ? node.parentNode : held(node)
+  let where = node.parentNode
+  if (held !== undefined) {
+    where = held(node)
+  }
+  return where
 }
 
 /**

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -150,7 +150,11 @@ const excluded = function(file, patterns, base) {
  * @return {string} - The level to set
  */
 const leveled = function(quiet, level) {
-  return quiet ? levels.WARNING : level ?? levels.INFO
+  let chosen = level ?? levels.INFO
+  if (quiet) {
+    chosen = levels.WARNING
+  }
+  return chosen
 }
 
 /**

--- a/test/count-linter.test.js
+++ b/test/count-linter.test.js
@@ -30,7 +30,7 @@ describe('count-linter', function() {
         })
         yml.found.fixes.forEach((expected, index) => {
           assert.equal(
-            defects[index].fix ? defects[index].fix.replacement : null,
+            defects[index].fix?.replacement ?? null,
             expected,
           )
         })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -17,12 +17,16 @@ const {execSync, spawnSync} = require('child_process')
  * @return {string} Stdout
  */
 const execCmd = function(command, args, print) {
+  let stdio = 'ignore'
+  if (print) {
+    stdio = null
+  }
   return (execSync(
     `${command} ${args.join(' ')}`,
     {
       timeout: 120000,
       windowsHide: true,
-      stdio: print ? null : 'ignore',
+      stdio: stdio,
     },
   ) ?? '').toString()
 }

--- a/test/import-linter.test.js
+++ b/test/import-linter.test.js
@@ -32,7 +32,7 @@ describe('import-linter', function() {
         })
         yml.found.fixes.forEach((expected, index) => {
           assert.equal(
-            defects[index].fix ? defects[index].fix.replacement : null,
+            defects[index].fix?.replacement ?? null,
             expected,
           )
         })

--- a/test/name-linter.test.js
+++ b/test/name-linter.test.js
@@ -30,7 +30,7 @@ describe('name-linter', function() {
         })
         yml.found.fixes.forEach((expected, index) => {
           assert.equal(
-            defects[index].fix ? defects[index].fix.replacement : null,
+            defects[index].fix?.replacement ?? null,
             expected,
           )
         })

--- a/test/namespace-linter.test.js
+++ b/test/namespace-linter.test.js
@@ -30,7 +30,7 @@ describe('namespace-linter', function() {
         })
         yml.found.fixes.forEach((expected, index) => {
           assert.equal(
-            defects[index].fix ? defects[index].fix.replacement : null,
+            defects[index].fix?.replacement ?? null,
             expected,
           )
         })

--- a/test/node-set-linter.test.js
+++ b/test/node-set-linter.test.js
@@ -30,7 +30,7 @@ describe('node-set-linter', function() {
         })
         yml.found.fixes.forEach((expected, index) => {
           assert.equal(
-            defects[index].fix ? defects[index].fix.replacement : null,
+            defects[index].fix?.replacement ?? null,
             expected,
           )
         })

--- a/test/predicate-position-linter.test.js
+++ b/test/predicate-position-linter.test.js
@@ -30,7 +30,7 @@ describe('predicate-position-linter', function() {
         })
         yml.found.fixes.forEach((expected, index) => {
           assert.equal(
-            defects[index].fix ? defects[index].fix.replacement : null,
+            defects[index].fix?.replacement ?? null,
             expected,
           )
         })

--- a/test/redundant-boolean-call-linter.test.js
+++ b/test/redundant-boolean-call-linter.test.js
@@ -30,7 +30,7 @@ describe('redundant-boolean-call-linter', function() {
         })
         yml.found.fixes.forEach((expected, index) => {
           assert.equal(
-            defects[index].fix ? defects[index].fix.replacement : null,
+            defects[index].fix?.replacement ?? null,
             expected,
           )
         })

--- a/test/redundant-double-negation-linter.test.js
+++ b/test/redundant-double-negation-linter.test.js
@@ -30,7 +30,7 @@ describe('redundant-double-negation-linter', function() {
         })
         yml.found.fixes.forEach((expected, index) => {
           assert.equal(
-            defects[index].fix ? defects[index].fix.replacement : null,
+            defects[index].fix?.replacement ?? null,
             expected,
           )
         })

--- a/test/result-namespace-linter.test.js
+++ b/test/result-namespace-linter.test.js
@@ -30,7 +30,7 @@ describe('result-namespace-linter', function() {
         })
         yml.found.fixes.forEach((expected, index) => {
           assert.equal(
-            defects[index].fix ? defects[index].fix.replacement : null,
+            defects[index].fix?.replacement ?? null,
             expected,
           )
         })

--- a/test/string-length-linter.test.js
+++ b/test/string-length-linter.test.js
@@ -31,7 +31,7 @@ describe('string-length-linter', function() {
           })
           yml.found.fixes.forEach((expected, index) => {
             assert.equal(
-              defects[index].fix ? defects[index].fix.replacement : null,
+              defects[index].fix?.replacement ?? null,
               expected,
             )
           })

--- a/test/translate-linter.test.js
+++ b/test/translate-linter.test.js
@@ -30,7 +30,7 @@ describe('translate-linter', function() {
         })
         yml.found.fixes.forEach((expected, index) => {
           assert.equal(
-            defects[index].fix ? defects[index].fix.replacement : null,
+            defects[index].fix?.replacement ?? null,
             expected,
           )
         })

--- a/test/using-namespace-axis-linter.test.js
+++ b/test/using-namespace-axis-linter.test.js
@@ -30,14 +30,14 @@ describe('using-namespace-axis-linter', function() {
         })
         yml.found.fixes.forEach((expected, index) => {
           assert.equal(
-            defects[index].fix ? defects[index].fix.replacement : null,
+            defects[index].fix?.replacement ?? null,
             expected,
           )
         })
         const values = yml.found.values || []
         values.forEach((expected, index) => {
           assert.equal(
-            defects[index].fix ? defects[index].fix.value : null,
+            defects[index].fix?.value ?? null,
             expected,
           )
         })

--- a/test/xpath-axis-linter.test.js
+++ b/test/xpath-axis-linter.test.js
@@ -30,14 +30,14 @@ describe('xpath-axis-linter', function() {
         })
         yml.found.fixes.forEach((expected, index) => {
           assert.equal(
-            defects[index].fix ? defects[index].fix.replacement : null,
+            defects[index].fix?.replacement ?? null,
             expected,
           )
         })
         const values = yml.found.values || []
         values.forEach((expected, index) => {
           assert.equal(
-            defects[index].fix ? defects[index].fix.value : null,
+            defects[index].fix?.value ?? null,
             expected,
           )
         })

--- a/test/xpath-format-linter.test.js
+++ b/test/xpath-format-linter.test.js
@@ -33,7 +33,7 @@ describe('xpath-format-linter', function() {
           })
           yml.found.fixes.forEach((expected, index) => {
             assert.equal(
-              defects[index].fix ? defects[index].fix.replacement : null,
+              defects[index].fix?.replacement ?? null,
               expected,
             )
           })

--- a/test/xsl-version.test.js
+++ b/test/xsl-version.test.js
@@ -22,10 +22,11 @@ describe('xsl-version', function() {
   ROOTS.forEach((root) => {
     it(root.name, function() {
       const xsl = xml.parsedFromString(root.input)
-      assert.equal(
-        versionOf(root.at === undefined ? xsl : nodes(xsl, root.at)[0]),
-        root.version,
-      )
+      let node = xsl
+      if (root.at !== undefined) {
+        node = nodes(xsl, root.at)[0]
+      }
+      assert.equal(versionOf(node), root.version)
     })
   })
 })


### PR DESCRIPTION
`no-ternary` is on, and the 103 conditional expressions the tree carried are
gone — nesting and the flat chain alike. The chain was the harder call, since
`CLAUDE.md` named it as one of three sanctioned shapes for satisfying the
one-`return` rule, so that guidance changed with it.

What replaced it is a binding initialised to the default arm and narrowed by an
`if`. `defectsOf` had been the showpiece chain; it now picks the strategy rather
than the answer:

```js
const defectsOf = function(corpus, check) {
  let strategy = byCall
  if (!check.reference) {
    strategy = byName
  } else if (check.reachable) {
    strategy = byReachability
  } else if (check.scoped) {
    strategy = byScope
  }
  return strategy(corpus, check)
}
```

`??` and `?.` stayed. Neither asks a question about a condition, and keeping
them spared seventeen sites a pointless `let`: `entities.get(name) ?? whole`
says what `has(name) ? get(name) : whole` said, in one reading instead of three.

Two things fell out that were not the point. `eslint-local-rules.js` sat in
ESLint's `ignores`, so the file implementing three of the project's own rules
was held to none of them and kept nine ternaries of its own; it is linted now,
with only the formatting rules its style predates switched off. And the `lint`
job runs `grunt eslint` against an explicit file list naming every source
directory but not that plugin, so a ternary there still passed CI after the
un-ignoring — the second commit names it in the list. I verified both by
planting a ternary in each file and watching the job go red.

Coverage holds at 100% on all four counts, and the docs site regenerates
byte-identical. Worth a look before merge: `decide` in
`src/string-length-linter.js` and `character` in `src/source.js` are the two
places where unpacking a three-way expression cost more readability than it
bought.