### PR TITLE
Ask xcop once instead of 257 times

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,14 +32,26 @@ green — run `npm run coverage` and the xcop suite too.
 The suite comes in two halves, and the line between them is a child process. A
 **deep** test starts one — it runs `xslint` or `xcop` the way a user does — and
 is named `*.deep.test.js`; every other test stays in this process. Three files
-are deep, and they cost what the suite costs: 431 of the 1070 tests, 52 of the
-53 seconds. The other 639 finish inside a second, which is why `npm run fast` is
-the loop to work in and `npm test` the one to finish on. `grunt mochacli` runs
-both targets, so nothing in CI narrows. The naming is not a convention anybody
-has to remember either: `test/conformance.test.js` reads every `.test.js` for
-the `require('./helpers')` that is the only door to a child process, and fails
-when a file holding it is not named `.deep.test.js` — or when one that spawns
-nothing is.
+are deep, and they still cost most of what the suite costs: 431 of the 1071
+tests, 15 of the 18 seconds. The other 640 finish inside a second, which is why
+`npm run fast` is the loop to work in and `npm test` the one to finish on. The
+deep target runs under `mocha --parallel`, so those three files run at once and
+the slowest of them sets the clock. `grunt mochacli` runs both targets, so
+nothing in CI narrows. The naming is not a convention anybody has to remember
+either: `test/conformance.test.js` reads every `.test.js` for the
+`require('./helpers')` that is the only door to a child process, and fails when
+a file holding it is not named `.deep.test.js` — or when one that spawns nothing
+is.
+
+What a deep test must not do is spend a process per assertion. The xcop suite
+did, 257 of them, and 25 of the suite's 26 seconds were ruby interpreters
+booting; it asks once over a directory now and reads each fixture's line out of
+the one report (#687). Nor may it write into the working tree: its scratch files
+go under `mkdtempSync`, because `should test default directory` lints the
+repository and a file appearing and vanishing under `test/` takes that walk's
+count with it — a race parallel mode turns from theory into one failure in four.
+`conformance.test.js` fails any test file that writes without asking for a
+temporary directory.
 
 ## Code style
 
@@ -140,6 +152,15 @@ it — resolves config, reads the `.xsl` files, calls `lint`, applies `--fix`,
 reports, and sets the exit code. The package `main` re-exports `lint` and
 `fixed` so an embedder (the planned LSP server, #336) can lint a buffer without
 shelling out; the bin stays `src/index.mjs`.
+
+`src/index.mjs` reaches `xslint.js` through a dynamic `import` inside the
+command action, not a top-level one, and so runs `program.parseAsync`. Importing
+it eagerly loaded fontoxpath, xmldom, `yaml`, and all 67 check YAMLs — 137 ms
+before a byte of XSL was read, charged to `--version` and `--help` and every
+rejected argument as much as to a real run. Behind the action that work happens
+only where it is used, and the invocations that never lint answer in 72 ms
+(#687). Whatever the action throws still reaches the one `try` around the parse,
+which is what `parseAsync` buys over letting an async action reject unheard.
 
 A check is one entry with **four kinds**, each a YAML file plus a motive plus a
 test pack:
@@ -393,10 +414,14 @@ accidentally attached fix turns red.
   fixtures go in `test/resources/malformed/` (excluded from the xcop workflow,
   since malformed XML cannot pass a formatting check).
 - **xcop.** `test/xcop.deep.test.js` re-serializes the inline XSL of every
-  `*-packs` directory and runs [xcop](https://github.com/yegor256/xcop) over it;
-  the CI `xcop` job runs it too. The `redundant-namespace-declarations` pack is
-  listed in `UNFORMATTED` because its fixture must carry the unused namespace
-  the check flags, which xcop would canonicalize away. The repo-wide sweep in
+  `*-packs` directory into one `mkdtempSync` directory and runs
+  [xcop](https://github.com/yegor256/xcop) over that directory once, then reads
+  each fixture's own line out of the single report — `helpers.js`'s `xcopped`,
+  which takes the report off the failure when xcop exits non-zero rather than
+  losing it with the throw. The CI `xcop` job runs it too. The
+  `redundant-namespace-declarations` pack is listed in `UNFORMATTED` because its
+  fixture must carry the unused namespace the check flags, which xcop would
+  canonicalize away. The repo-wide sweep in
   the workflow excludes `test/resources/directives/wrapped*.xsl` for the same
   reason: they must keep the wrapped attribute value #611 is about, which xcop
   joins onto one line.
@@ -476,5 +501,6 @@ accidentally attached fix turns red.
 | `src/helpers.js` | XML parsing (expands internal-subset entities), YAML parsing, file recursion |
 | `src/logger.js` | 4-level logger |
 | `scripts/generate-docs.js` | Builds the `docs/` site from checks + motives |
-| `test/conformance.test.js` | Enforces naming, motives, selector hygiene, pack/test coverage, the `mature` freeze across all kinds, and the fast/deep split of the suite itself |
-| `test/xcop.deep.test.js` | Runs xcop over the inline XSL of every `*-packs` directory; pending, never absent, where the tool does not run |
+| `test/conformance.test.js` | Enforces naming, motives, selector hygiene, pack/test coverage, the `mature` freeze across all kinds, the fast/deep split of the suite itself, and that no test writes a scratch file outside a temporary directory |
+| `test/helpers.js` | The only door to a child process in the suite: `runXslint`/`xslintStatus`/`xslintStreams` run the CLI, `xcopped` runs xcop once over a directory, `cmdAvailable` answers whether a tool is there by running it |
+| `test/xcop.deep.test.js` | Writes every pack's inline XSL to one `mkdtempSync` directory and runs xcop over it once; pending, never absent, where the tool does not run |

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,6 +36,7 @@ module.exports = function(grunt) {
         options: {
           files: ['test/**/*.deep.test.js', '!test/resources/**'],
           timeout: TIMEOUT,
+          parallel: true,
         },
       },
     },

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ before sending us your pull request please make sure all your tests pass:
 npm test
 ```
 
-Most of that minute goes to the three `*.deep.test.js` files, which run the
+Most of those seconds go to the three `*.deep.test.js` files, which run the
 command-line tool in a child process. While you are still working, run the rest
 of the suite on its own — it finishes in about a second:
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -6,7 +6,6 @@
 
 import {program, Option} from 'commander'
 import version from './version.js'
-import xslint from './xslint.js'
 
 program
   .name('xslint')
@@ -45,12 +44,13 @@ program
     (check, suppressions) => [...suppressions, check], [],
   )
   .argument('[paths...]', 'paths to file or directory to process', ['.'])
-  .action((path) => {
+  .action(async (path) => {
+    const {default: xslint} = await import('./xslint.js')
     xslint(path, program.opts())
   })
 
 try {
-  program.parse(process.argv)
+  await program.parseAsync(process.argv)
 } catch (error) {
   console.error(error.message)
   console.error(error.stack)

--- a/test/conformance.test.js
+++ b/test/conformance.test.js
@@ -226,6 +226,22 @@ describe('conformance', function() {
         'that starts none is, so the fast half of the suite runs the wrong files',
     )
   })
+  it('writes every scratch file of a test into a temporary directory', function() {
+    assert.deepEqual(
+      allFilesFrom(__dirname)
+        .filter((file) => file.endsWith('.test.js'))
+        .filter((file) => {
+          const suite = fs.readFileSync(file, 'utf-8')
+          return suite.includes('writeFileSync') &&
+            !suite.includes('mkdtempSync')
+        })
+        .map((file) => path.basename(file)),
+      [],
+      'a test that writes a file without asking for a temporary directory ' +
+        'leaves it in the working tree, where the run that lints the ' +
+        'repository walks over it and loses its count (#687)',
+    )
+  })
   it('tests every validation check by name in a test file', function() {
     const suite = allFilesFrom(path.resolve(__dirname))
       .filter((file) => file.endsWith('.test.js'))

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -89,6 +89,27 @@ const runXcop = function(arg, print = true) {
 }
 
 /**
+ * What xcop says about every stylesheet in a directory, in one run. It reports
+ * a line per file, so a caller asking about 257 of them learns the same from
+ * one interpreter as from 257 — which is the difference between 0.1 seconds and
+ * 25 of them (#687). A file it rejects makes the whole process exit non-zero
+ * and `execSync` announces that by throwing, so the report is read off the
+ * failure rather than lost with it; a tool that is not there throws too, with
+ * nothing to read, and `cmdAvailable` is what tells those two apart.
+ * @param {string} dir - Directory holding the stylesheets
+ * @return {string} Stdout, one line per file
+ */
+const xcopped = function(dir) {
+  let printed
+  try {
+    printed = runXcop(dir, true)
+  } catch (refusal) {
+    printed = (refusal.stdout ?? '').toString()
+  }
+  return printed
+}
+
+/**
  * Whether the tool runs here, asked by running it with the argument that proves
  * it does. Looking the name up in `PATH` was a proxy for that question, and the
  * two disagree: `which` walks `PATH` literally while the shell that starts the
@@ -116,5 +137,6 @@ module.exports = {
   xslintStatus,
   xslintStreams,
   runXcop,
+  xcopped,
   cmdAvailable,
 }

--- a/test/xcop.deep.test.js
+++ b/test/xcop.deep.test.js
@@ -7,7 +7,8 @@ const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')
 const fs = require('fs')
-const {runXcop, cmdAvailable} = require('./helpers')
+const os = require('os')
+const {xcopped, cmdAvailable} = require('./helpers')
 
 /**
  * Directory holding every test pack.
@@ -56,29 +57,56 @@ const CHECKED = PACKS.filter(
   (pack) => !UNFORMATTED.includes(path.basename(pack)),
 )
 
+/**
+ * Where the fixtures are written. It is a temporary directory, not the suite's
+ * own, because a scratch file inside the working tree is a hazard and not only
+ * a mess: `should test default directory` lints the repository, so a file this
+ * suite creates and deletes under `test/` can vanish from beneath that walk and
+ * take its file count with it (#687).
+ * @type {string}
+ */
+const SCRATCH = fs.mkdtempSync(path.join(os.tmpdir(), 'xslint-xcop-'))
+
+/**
+ * Every fixture, written out before the first assertion: the pack it came from,
+ * its index inside that pack, and the file now holding it. They are all on disk
+ * up front so that xcop can be asked about the whole set at once.
+ * @type {Array.<{pack: string, index: number, file: string}>}
+ */
+const FIXTURES = CHECKED.flatMap((pack) => {
+  const yml = yaml.parsedFromFile(pack)
+  return (yml.inputs || [yml.input]).map((input, index) => {
+    const file = path.join(
+      SCRATCH, `${path.basename(pack, '.yaml')}-${index}.xsl`,
+    )
+    fs.writeFileSync(file, `${xml.parsedFromString(input)}\n`)
+    return {pack: path.basename(pack), index: index, file: file}
+  })
+})
+
 if (!available) {
   console.warn(
     'xcop does not run here, so its fixtures are pending, not passing',
   )
 }
 
+/**
+ * What xcop made of all of them, from the single run every assertion below
+ * reads its own line out of.
+ * @type {string}
+ */
+let verdict = ''
+if (available) {
+  verdict = xcopped(SCRATCH)
+}
+
 describe('xcop', function() {
-  CHECKED.forEach((pack) => {
-    const yml = yaml.parsedFromFile(pack)
-    const inputs = yml.inputs || [yml.input]
-    inputs.forEach((input, index) => {
-      it(`should find 0 xcop errors in xsl #${index} of ${path.basename(pack)}`, function() {
-        if (!available) {
-          this.skip()
-        }
-        const xsl = path.resolve(
-          __dirname, `temp-${path.basename(pack, '.yaml')}-${index}.xsl`,
-        )
-        fs.writeFileSync(xsl, `${xml.parsedFromString(input)}\n`)
-        const stdout = runXcop(xsl)
-        fs.unlinkSync(xsl)
-        assert.ok(stdout.includes(`${xsl} looks good`))
-      })
+  FIXTURES.forEach((fixture) => {
+    it(`should find 0 xcop errors in xsl #${fixture.index} of ${fixture.pack}`, function() {
+      if (!available) {
+        this.skip()
+      }
+      assert.ok(verdict.includes(`${fixture.file} looks good`))
     })
   })
 })


### PR DESCRIPTION
The xcop suite asked its question 257 times, once per fixture, and each answer
cost a ruby interpreter starting up. That was 25 of the suite's 26 seconds. xcop
takes a directory and prints a line per file, so it is asked once now and each
assertion reads its own line:

```js
let verdict = ''
if (available) {
  verdict = xcopped(SCRATCH)
}
```

Same 257 tests, 28ms instead of 25 seconds.

The directory those fixtures go in is a `mkdtempSync` one, which is the other
half of this. They used to be written into `test/`, and `should test default
directory` lints the repository — so a file appearing and vanishing under the
walk took its file count with it. Serially the two never met; under
`mocha --parallel` it failed once in four runs. `conformance.test.js` now fails
any test file that writes without asking for a temporary directory, since one
grep was all that separated the convention from the bug.

With xcop no longer setting the clock, the deep target runs parallel, and
`src/index.mjs` reaches the pipeline through a dynamic `import` inside the
command action instead of a top-level one. Loading it eagerly cost 137ms of
fontoxpath, xmldom and 67 check YAMLs before a byte of XSL was read, charged to
`--version` as much as to a real run; it answers in 72ms now. The parse became
`parseAsync` so an async action's throw still lands in the one `try` around it.

`npm test` goes from 54 seconds to 18, `npm run coverage` from a minute to 33
seconds, and coverage stays at 100% on all four counters. Six consecutive
parallel runs of the deep half were green.

Closes #687
