### PR TITLE
Count a prefix list as usage of the prefixes it names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,7 +421,13 @@ accidentally attached fix turns red.
   losing it with the throw. The CI `xcop` job runs it too. The
   `redundant-namespace-declarations` pack is listed in `UNFORMATTED` because its
   fixture must carry the unused namespace the check flags, which xcop would
-  canonicalize away. The repo-wide sweep in
+  canonicalize away, and its four prefix-list packs for the same reason one step
+  in: xcop counts a namespace used only by a QName, so a declaration named only
+  by an `exclude-result-prefixes` is canonicalized away exactly as a dead one is
+  (#553). A pack's *basename* is what that list matches and what names its
+  fixture file, so two packs sharing one across directories exclude and overwrite
+  each other silently — name a new pack so it collides with none. The repo-wide
+  sweep in
   the workflow excludes `test/resources/directives/wrapped*.xsl` for the same
   reason: they must keep the wrapped attribute value #611 is about, which xcop
   joins onto one line.

--- a/README.md
+++ b/README.md
@@ -263,7 +263,10 @@ Today this covers ten checks:
   `self::node()` becomes `.`. On a 1.0 stylesheet a predicated step keeps its
   longhand, since `.` and `..` took no predicate before XPath 2.0.
 - `redundant-namespace-declarations` — a namespace prefix declared on the
-  stylesheet but never used is deleted.
+  stylesheet but never used is deleted. A prefix named in an
+  `exclude-result-prefixes` or `extension-element-prefixes` list counts as
+  used, `#all` naming every one of them at once, since cutting a declaration
+  one of those refers to leaves the reference unbound.
 - `use-node-set-extension` — the redundant `node-set()` extension is unwrapped
   in XSLT 2.0 and later: `exsl:node-set($x)` becomes `$x`.
 - `count-compared-to-zero` — an existence test spelled as a count is

--- a/src/namespace-linter.js
+++ b/src/namespace-linter.js
@@ -6,6 +6,8 @@
 const {metaOf, suppressed} = require('./checks')
 const {deletion} = require('./fixes')
 const {logger} = require('./logger')
+const {GAPS} = require('./tokens')
+const {XSLT} = require('./xsl-version')
 
 /**
  * Name of the check this linter owns.
@@ -41,26 +43,76 @@ const declared = function(name) {
 }
 
 /**
+ * The two standard attributes that name namespace prefixes as bare tokens
+ * rather than inside a qualified name, so a scan looking for `prefix:` cannot
+ * see them.
+ * @type {Array.<string>}
+ */
+const LISTS = ['exclude-result-prefixes', 'extension-element-prefixes']
+
+/**
+ * The prefixes an element names in a prefix list. The spelling depends on what
+ * the element is: on an XSLT element the attribute stands unprefixed, while on
+ * a literal result element it is a standard attribute in the XSLT namespace
+ * (`xsl:exclude-result-prefixes`) — an unprefixed one there is text bound for
+ * the result tree, naming no prefix at all, the same distinction
+ * `src/attributes.js` draws for a `select`. The split is on `GAPS` because that
+ * is the one spelling of a gap this repository allows, not because a tab can
+ * reach here: attribute-value normalization turned every `S` into a space
+ * before the value was read, and only a run of them survives. `#default` names
+ * the default namespace, which binds no prefix and so matches nothing here.
+ * @param {Element} element - The element to read
+ * @return {Array.<string>} - The tokens its prefix lists hold
+ */
+const listed = function(element) {
+  const prefixes = []
+  for (const name of LISTS) {
+    let value = element.getAttributeNS(XSLT, name)
+    if (element.namespaceURI === XSLT) {
+      value = element.getAttribute(name)
+    }
+    if (value) {
+      prefixes.push(...value.split(GAPS))
+    }
+  }
+  return prefixes
+}
+
+/**
  * Whether a prefix is used anywhere in the document — by an element name, an
- * attribute name, or a qualified name inside an attribute value. Namespace
- * declarations themselves are not usage, so they are skipped.
+ * attribute name, a qualified name inside an attribute value, or a prefix list
+ * naming it. Namespace declarations themselves are not usage, so they are
+ * skipped.
+ *
+ * A prefix list is usage even though nothing in it is qualified: a declaration
+ * `exclude-result-prefixes` names is what tells the processor to keep that
+ * namespace out of the output, and deleting the declaration leaves the
+ * reference bound to nothing, which a conformant processor rejects (XTSE0808).
+ * The check reported such a prefix as never used and its safe fix then cut the
+ * declaration, so `--fix` turned a stylesheet that compiled into one that does
+ * not (#553). `#all` says every namespace in scope is excluded, so it is usage
+ * of every prefix at once — read at any version, as `leaking-result-namespace`
+ * reads it, since `#all` is no NCName and can never be the prefix under
+ * judgement.
  * @param {Array.<Element>} elements - Every element of the document
  * @param {string} prefix - Prefix to look for
  * @return {boolean} - True when the prefix is used
  */
 const used = function(elements, prefix) {
   const qualifier = `${prefix}:`
-  return elements.some(
-    (element) =>
-      element.nodeName.startsWith(qualifier) ||
+  return elements.some((element) => {
+    const prefixes = listed(element)
+    return element.nodeName.startsWith(qualifier) ||
+      prefixes.includes(prefix) ||
+      prefixes.includes('#all') ||
       Array.from(element.attributes).some(
         (attribute) =>
           !declared(attribute.name) &&
           attribute.name !== 'xmlns' &&
           (attribute.name.startsWith(qualifier) ||
             attribute.value.includes(qualifier)),
-      ),
-  )
+      )
+  })
 }
 
 /**

--- a/src/resources/motives/format/redundant-namespace-declarations.md
+++ b/src/resources/motives/format/redundant-namespace-declarations.md
@@ -4,6 +4,15 @@ A namespace prefix declared on the `xsl:stylesheet` element but never used by
 any element name, attribute name, or qualified name inside an attribute value
 is dead weight that misleads the reader and should be removed.
 
+Two attributes use a prefix without qualifying anything with it, and a prefix
+either of them names is in use:
+`exclude-result-prefixes` keeps the namespace out of the result tree, and
+`extension-element-prefixes` marks it as holding extension instructions. Both
+hold bare prefixes, separated by whitespace, and `exclude-result-prefixes="#all"`
+names every prefix in scope at once. Removing a declaration one of them names
+leaves the reference bound to nothing, and a conformant processor refuses to
+compile the stylesheet.
+
 Incorrect:
 
 ```xsl
@@ -17,5 +26,14 @@ Correct:
 ```xsl
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
   <!-- only namespaces that are actually used are declared -->
+</xsl:stylesheet>
+```
+
+A prefix whose only mention is a prefix list is used, and its declaration stays:
+
+```xsl
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:foo="urn:foo"
+  exclude-result-prefixes="foo" version="2.0">
+  <!-- foo is declared so that exclude-result-prefixes can name it -->
 </xsl:stylesheet>
 ```

--- a/test/fixer.deep.test.js
+++ b/test/fixer.deep.test.js
@@ -445,6 +445,12 @@ const UNCHANGED = [
     flag: '--fix-suggestions',
     sheet: 'variable-with-select-holding-a-numeric-entity.xsl',
   },
+  {
+    name: 'cannot delete a declaration exclude-result-prefixes names with ' +
+      '--fix',
+    flag: '--fix',
+    sheet: 'an-excluded-result-prefix.xsl',
+  },
 ]
 
 /**

--- a/test/resources/fix/an-excluded-result-prefix.xsl
+++ b/test/resources/fix/an-excluded-result-prefix.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:foo="urn:foo" exclude-result-prefixes="foo" version="2.0">
+  <xsl:output method="xml"/>
+  <xsl:template match="/">
+    <zz>
+      <xsl:value-of select="count(o)"/>
+    </zz>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/namespace-packs/all-prefixes-excluded-at-once.yaml
+++ b/test/resources/namespace-packs/all-prefixes-excluded-at-once.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: redundant-namespace-declarations
+found:
+  amount: 0
+  positions: [ ]
+  fixes: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:one="urn:one"
+    xmlns:two="urn:two"
+    xmlns:three="urn:three"
+    exclude-result-prefixes="#all"
+    version="2.0">
+    <xsl:template match="/">
+      <zz/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/namespace-packs/excluded-result-prefixes.yaml
+++ b/test/resources/namespace-packs/excluded-result-prefixes.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: redundant-namespace-declarations
+found:
+  amount: 2
+  positions: [ [ 6, 3 ], [ 7, 3 ] ]
+  fixes: [ "", "" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:foo="urn:foo"
+    xmlns:bar="urn:bar"
+    xmlns:fo="urn:fo"
+    xmlns:dead="urn:dead"
+    exclude-result-prefixes="foo	 bar"
+    version="2.0">
+    <xsl:template match="/">
+      <zz/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/namespace-packs/excluded-result-prefixes.yaml
+++ b/test/resources/namespace-packs/excluded-result-prefixes.yaml
@@ -10,11 +10,11 @@ input: |-
   <?xml version="1.0"?>
   <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:foo="urn:foo"
-    xmlns:bar="urn:bar"
-    xmlns:fo="urn:fo"
+    xmlns:alphabet="urn:alphabet"
+    xmlns:beta="urn:beta"
+    xmlns:alpha="urn:alpha"
     xmlns:dead="urn:dead"
-    exclude-result-prefixes="foo	 bar"
+    exclude-result-prefixes="alphabet	 beta"
     version="2.0">
     <xsl:template match="/">
       <zz/>

--- a/test/resources/namespace-packs/extension-element-prefixes.yaml
+++ b/test/resources/namespace-packs/extension-element-prefixes.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: redundant-namespace-declarations
+found:
+  amount: 0
+  positions: [ ]
+  fixes: [ ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:ext="urn:ext"
+    xmlns:deep="urn:deep"
+    xmlns:lit="urn:lit"
+    extension-element-prefixes="ext"
+    version="2.0">
+    <xsl:template match="/" exclude-result-prefixes="deep">
+      <zz xsl:exclude-result-prefixes="lit"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/resources/namespace-packs/prefix-list-on-a-literal-element.yaml
+++ b/test/resources/namespace-packs/prefix-list-on-a-literal-element.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+# SPDX-License-Identifier: MIT
+---
+pack: redundant-namespace-declarations
+found:
+  amount: 1
+  positions: [ [ 4, 3 ] ]
+  fixes: [ "" ]
+input: |-
+  <?xml version="1.0"?>
+  <xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:out="urn:out"
+    exclude-result-prefixes="#default"
+    version="2.0">
+    <xsl:template match="/">
+      <zz exclude-result-prefixes="out"/>
+    </xsl:template>
+  </xsl:stylesheet>

--- a/test/xcop.deep.test.js
+++ b/test/xcop.deep.test.js
@@ -42,11 +42,20 @@ const available = cmdAvailable('xcop', ['--version'], false)
  * and xmldom emits the raw character. One name covers all six such packs, one
  * per linter. Excluded from the formatting check, as the fix fixtures are in
  * the xcop workflow.
+ *
+ * The four prefix-list packs are here for the same reason, one step further in:
+ * xcop counts a namespace used only by a QName, so a declaration whose sole
+ * mention is an `exclude-result-prefixes` is canonicalized away exactly as a
+ * dead one is — which is the reading #553 is about, in another tool.
  * @type {Array.<string>}
  */
 const UNFORMATTED = [
   'redundant-namespace-declarations.yaml',
   'no-break-space-before-the-bracket.yaml',
+  'excluded-result-prefixes.yaml',
+  'extension-element-prefixes.yaml',
+  'all-prefixes-excluded-at-once.yaml',
+  'prefix-list-on-a-literal-element.yaml',
 ]
 
 /**


### PR DESCRIPTION
`used` looked for `prefix:` — a prefix inside a qualified name — and two XSLT attributes name a prefix without qualifying anything with it. So a declaration whose only reference was `exclude-result-prefixes="foo"` read as dead, and the safe-tier fix cut it. xsltproc on the result:

```text
compilation error: element stylesheet
xsl:exclude-result-prefixes : undefined namespace foo
```

A valid stylesheet turned invalid by plain `--fix`, which is the worst thing this tool can do. `test/resources/fix/an-excluded-result-prefix.xsl` is that sheet, and an `UNCHANGED` row now holds `--fix` to leaving it alone.

Both list attributes count now, and `#all` names every prefix at once:

```js
let value = element.getAttributeNS(XSLT, name)
if (element.namespaceURI === XSLT) {
  value = element.getAttribute(name)
}
```

Which spelling to read is not a detail. On an XSLT element the attribute stands unprefixed; on a literal result element only `xsl:exclude-result-prefixes` is the standard attribute, and a bare one there is text bound for the result tree that names no prefix at all — the distinction `src/attributes.js` already draws for a `select`. A pack pins each direction, and dropping the namespace test fails two of them.

`#all` is honoured at every version rather than gated at 2.0, matching what `leaking-result-namespace` already does with the same token two files away: `#all` is no NCName, so it can never be the prefix under judgement, and reading it as one would license deleting a declaration on the strength of a token the check chose not to understand. If that deserves a version gate it deserves one in both places, as its own change.

Four packs cover the list attributes, `#all`, a list on a nested `xsl:template`, an `xsl:`-prefixed one on a literal result element, and the negatives that must keep firing — an unlisted prefix, and `alpha` declared beside a listed `alphabet`, since a prefix list is matched token-wise and not by substring. Three mutations, three caught.

Two things found on the way, neither fixed here. The xcop harness keys both its `UNFORMATTED` list and each fixture's filename on a pack's *basename*, so a new pack sharing a name with one in another directory silently unchecks and overwrites it — `all-result-prefixes-excluded.yaml` already existed under `result-namespace-packs`, and my pack of that name cost that fixture its check until I renamed mine. And when one fixture is not canonical, xcop stops there and every later fixture loses its line from the shared verdict, so one bad file failed 204 unrelated tests and a different 204 on the next run. Both are filed: #693 and #694.

Closes #553
