### PR TITLE
Make the duplicate-reference deletion a suggestion, and cut the shadowed reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,9 @@ Today this covers ten checks:
   and `not($x)`.
 - `redundant-import` — a duplicate `xsl:import`/`xsl:include` of a module
   already imported in the same stylesheet is removed; the module stays imported
-  by the first reference. A module reached *both* ways — imported and also
+  by the *last* reference, which is the one that fixes its import precedence,
+  so the references cut are the earlier ones and nothing changes level. A
+  module reached *both* ways — imported and also
   included — is reported without a fix, since `xsl:import` and `xsl:include`
   differ in import precedence, so which of the two to drop is the author's
   decision rather than a deletion the tool can make.

--- a/README.md
+++ b/README.md
@@ -276,14 +276,13 @@ Today this covers ten checks:
   `exists($x)` and `count($x) = 0` becomes `empty($x)`; on 1.0 (where those
   functions don't exist), `boolean($x)` — or a bare `$x` in a whole `@test` —
   and `not($x)`.
-- `redundant-import` — a duplicate `xsl:import`/`xsl:include` of a module
-  already imported in the same stylesheet is removed; the module stays imported
-  by the *last* reference, which is the one that fixes its import precedence,
-  so the references cut are the earlier ones and nothing changes level. A
-  module reached *both* ways — imported and also
-  included — is reported without a fix, since `xsl:import` and `xsl:include`
-  differ in import precedence, so which of the two to drop is the author's
-  decision rather than a deletion the tool can make.
+- `redundant-import`, on an `xsl:include` — a repeated include of one module is
+  removed. An include creates no import-precedence level of its own, so the
+  repeat is pure noise and dropping it changes nothing. The `xsl:import` half is
+  a suggestion, below. A module reached *both* ways — imported and also
+  included — is reported without a fix at either tier, since `xsl:import` and
+  `xsl:include` differ in import precedence, so which of the two to drop is the
+  author's decision rather than a deletion the tool can make.
 - `starts-with-double-slash`, outside an `xsl:template` — the redundant leading
   `//` of a pattern is dropped: `match="//keyed"` on an `xsl:key` becomes
   `match="keyed"`. Only a template's pattern is ranked by priority, so on
@@ -322,6 +321,13 @@ Today this covers:
 - `incorrect-use-of-boolean-constants` — the string test `'true'`/`'false'`
   becomes `true()`/`false()`, which changes the truth value of a `'false'` test
   (a non-empty string is always true).
+- `redundant-import`, on an `xsl:import` — a repeated import of one module is
+  removed, and the reference cut is an earlier one, so the module keeps the
+  precedence its last reference gives it. A suggestion because no choice of
+  reference makes the deletion behaviour-preserving: importing a module twice
+  puts it at two precedence levels, and `xsl:apply-imports` (like 2.0's
+  `xsl:next-match`) walks that chain and meets it at both, so a module whose
+  rules reach back down it runs once per reference.
 - `select-starts-with-double-slash` — the leading `//` of a `@select` is
   anchored as `.//`: `select="//title"` becomes `select=".//title"`, scanning
   descendants of the context node instead of the whole document.

--- a/README.md
+++ b/README.md
@@ -321,11 +321,11 @@ Today this covers:
   puts it at two precedence levels, and `xsl:apply-imports` (like 2.0's
   `xsl:next-match`) walks that chain and meets it at both, so a module whose
   rules reach back down it runs once per reference. An `xsl:include` creates no
-  level of its own but copies in the includee's own `xsl:import` elements, so a
-  repeated include duplicates those the same way. A module reached *both*
-  ways — imported and also included — is reported without a fix at all, since
-  which of the two to drop is a decision about precedence rather than a
-  deletion the tool can make.
+  level of its own but copies in the included module's own `xsl:import`
+  elements, so a repeated include duplicates those the same way. A module
+  reached *both* ways — imported and also included — is reported without a fix
+  at all, since which of the two to drop is a decision about precedence rather
+  than a deletion the tool can make.
 - `select-starts-with-double-slash` — the leading `//` of a `@select` is
   anchored as `.//`: `select="//title"` becomes `select=".//title"`, scanning
   descendants of the context node instead of the whole document.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ place:
 xslint --fix path/to/dir
 ```
 
-Today this covers ten checks:
+Today this covers nine checks:
 
 - `redundant-whitespace` — a doubled space is collapsed to one, and a space
   leading or trailing an XPath expression is removed. A run holding a line
@@ -276,13 +276,6 @@ Today this covers ten checks:
   `exists($x)` and `count($x) = 0` becomes `empty($x)`; on 1.0 (where those
   functions don't exist), `boolean($x)` — or a bare `$x` in a whole `@test` —
   and `not($x)`.
-- `redundant-import`, on an `xsl:include` — a repeated include of one module is
-  removed. An include creates no import-precedence level of its own, so the
-  repeat is pure noise and dropping it changes nothing. The `xsl:import` half is
-  a suggestion, below. A module reached *both* ways — imported and also
-  included — is reported without a fix at either tier, since `xsl:import` and
-  `xsl:include` differ in import precedence, so which of the two to drop is the
-  author's decision rather than a deletion the tool can make.
 - `starts-with-double-slash`, outside an `xsl:template` — the redundant leading
   `//` of a pattern is dropped: `match="//keyed"` on an `xsl:key` becomes
   `match="keyed"`. Only a template's pattern is ranked by priority, so on
@@ -321,13 +314,18 @@ Today this covers:
 - `incorrect-use-of-boolean-constants` — the string test `'true'`/`'false'`
   becomes `true()`/`false()`, which changes the truth value of a `'false'` test
   (a non-empty string is always true).
-- `redundant-import`, on an `xsl:import` — a repeated import of one module is
+- `redundant-import` — a repeated `xsl:import`/`xsl:include` of one module is
   removed, and the reference cut is an earlier one, so the module keeps the
   precedence its last reference gives it. A suggestion because no choice of
   reference makes the deletion behaviour-preserving: importing a module twice
   puts it at two precedence levels, and `xsl:apply-imports` (like 2.0's
   `xsl:next-match`) walks that chain and meets it at both, so a module whose
-  rules reach back down it runs once per reference.
+  rules reach back down it runs once per reference. An `xsl:include` creates no
+  level of its own but copies in the includee's own `xsl:import` elements, so a
+  repeated include duplicates those the same way. A module reached *both*
+  ways — imported and also included — is reported without a fix at all, since
+  which of the two to drop is a decision about precedence rather than a
+  deletion the tool can make.
 - `select-starts-with-double-slash` — the leading `//` of a `@select` is
   anchored as `.//`: `select="//title"` becomes `select=".//title"`, scanning
   descendants of the context node instead of the whole document.

--- a/src/import-linter.js
+++ b/src/import-linter.js
@@ -97,7 +97,7 @@ const byCircularity = function(corpus) {
 }
 
 /**
- * A safe fix that deletes a redundant import — its whole line, reconstructed
+ * A suggested fix that deletes a redundant import — its whole line, rebuilt
  * from the element as its indentation, the self-closing tag with its single
  * `href`, and the trailing newline. The fixer applies it only when the source
  * is exactly that, so an oddly formatted, single-quoted, or non-self-closing
@@ -113,14 +113,23 @@ const byCircularity = function(corpus) {
  * its duplicate to be tidied. Cutting an earlier one leaves the survivors in
  * the order they already stood.
  *
- * That is enough for `xsl:include`, which creates no precedence level at all,
- * so its deletion is safe. It is not enough for `xsl:import`, which creates
- * one: the earlier reference is shadowed for template *selection* only, while
- * `xsl:apply-imports` walks the chain and meets every level on it. A module
- * imported twice therefore answers `AA` where once answers `A`, and no
- * arrangement of the deletion preserves that — so the import half is a
- * suggestion, and the tier forks on the mechanism rather than on the shape of
- * the duplication (#667).
+ * It is not enough to make the deletion safe, at either mechanism, which is
+ * why the fix is a suggestion whatever it cuts. An `xsl:import` creates a
+ * precedence level, and the earlier reference is shadowed for template
+ * selection only: `xsl:apply-imports` walks down the chain and meets the
+ * module at every level it occupies, so importing one twice answers `AA` where
+ * importing it once answers `A`, and no choice of reference preserves that.
+ *
+ * An `xsl:include` creates no level of its own, but it copies the includee's
+ * children in, and those children include its own `xsl:import` elements. So a
+ * module included twice brings its imports in twice, at two levels, and the
+ * same traversal walks both — a stylesheet including a `gamma` that imports
+ * `delta` answers `GDD`, and `GD` once the duplicate include is cut.
+ *
+ * Reading the difference off the corpus was the tempting alternative and does
+ * not work: the includee is usually not in the corpus at all — none of this
+ * repository's own fixtures resolve — so the safe tier would depend on which
+ * files the caller happened to pass rather than on the stylesheet (#667).
  * @param {Element} node - The duplicate import/include element
  * @return {{line: number, col: number, value: string, replacement: string}} -
  *  The fix
@@ -132,7 +141,7 @@ const removal = function(node) {
     value: `${' '.repeat(node.columnNumber - 1)}` +
       `<${node.nodeName} href="${node.getAttribute('href')}"/>\n`,
     replacement: '',
-    suggestion: node.localName === 'import',
+    suggestion: true,
   }
 }
 
@@ -161,13 +170,12 @@ const crossed = function(imports) {
  * Defects for `redundant-import` — every `xsl:import`/`xsl:include` of one
  * resolved target within a stylesheet's own list except the last of them. The
  * last is the reference that fixes the module's import precedence, so it is
- * the one left standing and the earlier ones are what a reader may drop
- * without moving a definition between levels; reporting them the other way
- * round pointed the fix at the only reference that could not go (#667). The
+ * the one left standing; reporting them the other way round pointed the fix
+ * at the only reference that could not go (#667). The
  * target need not be a corpus file: importing the same external library twice
- * is redundant too. Each carries a fix that deletes the duplicate line, except
- * where the module is reached by both mechanisms, which is reported without
- * one.
+ * is redundant too. Each carries a suggested fix that deletes the duplicate
+ * line, except where the module is reached by both mechanisms, which is
+ * reported without one.
  * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
  * @return {Array.<object>} - Defects found
  */

--- a/src/import-linter.js
+++ b/src/import-linter.js
@@ -103,15 +103,24 @@ const byCircularity = function(corpus) {
  * is exactly that, so an oddly formatted, single-quoted, or non-self-closing
  * import is reported but left untouched rather than wrongly cut. It is offered
  * only where every reference to that module uses one mechanism, which is what
- * `crossed` decides — the module stays imported by the reference left standing,
- * so the deletion is safe rather than a suggestion. What makes it safe is the
- * choice of reference it cuts. Import precedence is positional (XSLT 1.0
- * §2.6.2), so a module's effective level is the level of its last reference
- * and every earlier one is shadowed by it: cutting an earlier reference leaves
- * the survivors in the order they already stood, while cutting the last drops
- * the module below anything imported between the two, and `A` became `B` under
- * xsltproc on a stylesheet that only asked for its duplicate to be tidied
- * (#667).
+ * `crossed` decides — the module stays reachable through the reference left
+ * standing.
+ *
+ * Which reference that is follows from import precedence being positional
+ * (XSLT 1.0 §2.6.2): a module's level is the level of its last reference, so
+ * cutting the last one drops the module below anything referenced between the
+ * two, and `A` became `B` under xsltproc on a stylesheet that only asked for
+ * its duplicate to be tidied. Cutting an earlier one leaves the survivors in
+ * the order they already stood.
+ *
+ * That is enough for `xsl:include`, which creates no precedence level at all,
+ * so its deletion is safe. It is not enough for `xsl:import`, which creates
+ * one: the earlier reference is shadowed for template *selection* only, while
+ * `xsl:apply-imports` walks the chain and meets every level on it. A module
+ * imported twice therefore answers `AA` where once answers `A`, and no
+ * arrangement of the deletion preserves that — so the import half is a
+ * suggestion, and the tier forks on the mechanism rather than on the shape of
+ * the duplication (#667).
  * @param {Element} node - The duplicate import/include element
  * @return {{line: number, col: number, value: string, replacement: string}} -
  *  The fix
@@ -123,6 +132,7 @@ const removal = function(node) {
     value: `${' '.repeat(node.columnNumber - 1)}` +
       `<${node.nodeName} href="${node.getAttribute('href')}"/>\n`,
     replacement: '',
+    suggestion: node.localName === 'import',
   }
 }
 

--- a/src/import-linter.js
+++ b/src/import-linter.js
@@ -120,14 +120,14 @@ const byCircularity = function(corpus) {
  * module at every level it occupies, so importing one twice answers `AA` where
  * importing it once answers `A`, and no choice of reference preserves that.
  *
- * An `xsl:include` creates no level of its own, but it copies the includee's
- * children in, and those children include its own `xsl:import` elements. So a
+ * An `xsl:include` creates no level of its own, but it copies the included
+ * module's children in, and those hold its own `xsl:import` elements. So a
  * module included twice brings its imports in twice, at two levels, and the
  * same traversal walks both — a stylesheet including a `gamma` that imports
  * `delta` answers `GDD`, and `GD` once the duplicate include is cut.
  *
  * Reading the difference off the corpus was the tempting alternative and does
- * not work: the includee is usually not in the corpus at all — none of this
+ * not work: the module included is usually outside the corpus — none of this
  * repository's own fixtures resolve — so the safe tier would depend on which
  * files the caller happened to pass rather than on the stylesheet (#667).
  * @param {Element} node - The duplicate import/include element

--- a/src/import-linter.js
+++ b/src/import-linter.js
@@ -104,10 +104,14 @@ const byCircularity = function(corpus) {
  * import is reported but left untouched rather than wrongly cut. It is offered
  * only where every reference to that module uses one mechanism, which is what
  * `crossed` decides — the module stays imported by the reference left standing,
- * so the deletion is safe rather than a suggestion. Safe there is not safe
- * everywhere: import precedence is positional, so where an import of another
- * module stands between two imports of this one, cutting the later of the two
- * drops this module below that one and can change the output (#667).
+ * so the deletion is safe rather than a suggestion. What makes it safe is the
+ * choice of reference it cuts. Import precedence is positional (XSLT 1.0
+ * §2.6.2), so a module's effective level is the level of its last reference
+ * and every earlier one is shadowed by it: cutting an earlier reference leaves
+ * the survivors in the order they already stood, while cutting the last drops
+ * the module below anything imported between the two, and `A` became `B` under
+ * xsltproc on a stylesheet that only asked for its duplicate to be tidied
+ * (#667).
  * @param {Element} node - The duplicate import/include element
  * @return {{line: number, col: number, value: string, replacement: string}} -
  *  The fix
@@ -144,33 +148,36 @@ const crossed = function(imports) {
 }
 
 /**
- * Defects for `redundant-import` — the second and later `xsl:import`/
- * `xsl:include` of the same resolved target within one stylesheet's own list.
- * The target need not be a corpus file: importing the same external library
- * twice is redundant too. Each carries a fix that deletes the duplicate line,
- * except where the module is reached by both mechanisms, which is reported
- * without one.
+ * Defects for `redundant-import` — every `xsl:import`/`xsl:include` of one
+ * resolved target within a stylesheet's own list except the last of them. The
+ * last is the reference that fixes the module's import precedence, so it is
+ * the one left standing and the earlier ones are what a reader may drop
+ * without moving a definition between levels; reporting them the other way
+ * round pointed the fix at the only reference that could not go (#667). The
+ * target need not be a corpus file: importing the same external library twice
+ * is redundant too. Each carries a fix that deletes the duplicate line, except
+ * where the module is reached by both mechanisms, which is reported without
+ * one.
  * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
  * @return {Array.<object>} - Defects found
  */
 const byRedundancy = function(corpus) {
   const imports = importsOf(corpus)
   const mixed = crossed(imports)
-  const seen = new Set()
+  const last = new Map()
+  imports.forEach(({file, to}, at) => last.set(`${file}|${to}`, at))
   const defects = []
-  for (const {file, node, to} of imports) {
+  imports.forEach(({file, node, to}, at) => {
     const key = `${file}|${to}`
-    if (seen.has(key)) {
+    if (last.get(key) !== at) {
       const report = defect(REDUNDANT, file, node)
       if (mixed.has(key)) {
         defects.push(report)
       } else {
         defects.push({...report, fix: removal(node)})
       }
-    } else {
-      seen.add(key)
     }
-  }
+  })
   return defects
 }
 

--- a/src/resources/motives/format/redundant-import.md
+++ b/src/resources/motives/format/redundant-import.md
@@ -5,19 +5,40 @@ both references bring in the same templates, functions, and variables. At best
 it is noise; at worst it hides which reference a reader should reason about.
 Keep a single reference per module.
 
-Which one to keep is not a free choice, because import precedence is
-positional: XSLT 1.0 §2.6.2 ranks each `xsl:import` above everything declared
-before it, so a module's precedence is set by its *last* reference and every
-earlier one is shadowed by it. Where another module is imported in between, the
-two references sit on opposite sides of it and only one of them decides which
-module's definitions win. Drop an earlier reference and nothing moves; drop the
-last and the module falls below whatever stood between them.
+A repeated `xsl:import` is not simply noise, though, and removing one is not
+simply tidying. Import precedence is positional — XSLT 1.0 §2.6.2 ranks each
+`xsl:import` above everything declared before it — so importing one module
+twice puts that module at two precedence levels at once, and both of them are
+live. Two things follow, and they pull in opposite directions.
 
-Incorrect — `alpha` outranks `beta` here, and deleting the third line silently
-reverses that:
+The later reference is the one that decides which module wins. With another
+module imported in between, the two references sit on opposite sides of it, so
+`alpha` below overrides `beta`, and it would not if the third line were the one
+removed:
 
 ```xsl
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="alpha.xsl"/>
+  <xsl:import href="beta.xsl"/>
+  <xsl:import href="alpha.xsl"/>
+</xsl:stylesheet>
+```
+
+The earlier reference is not idle either, because `xsl:apply-imports` walks
+*down* the precedence chain and meets the module at every level it occupies.
+Where `alpha.xsl` ends its rule in an `xsl:apply-imports`, that stylesheet emits
+`ABA` — `alpha` at the top level, then `beta`, then `alpha` again at the bottom
+one. Import it twice with nothing in between and the output is `AA` where a
+single import gives `A`. XSLT 2.0's `xsl:next-match` walks the same chain.
+
+So a duplicate `xsl:import` is a decision to make by hand, with the whole
+stylesheet's overriding in view. Where the module's rules do not reach back
+down the chain, one reference is enough:
+
+Incorrect:
+
+```xsl
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:import href="alpha.xsl"/>
   <xsl:import href="beta.xsl"/>
   <xsl:import href="alpha.xsl"/>
@@ -27,11 +48,16 @@ reverses that:
 Correct:
 
 ```xsl
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:import href="beta.xsl"/>
   <xsl:import href="alpha.xsl"/>
 </xsl:stylesheet>
 ```
+
+A repeated `xsl:include` carries none of this. An include has no precedence
+level of its own — the module's definitions land at the level of the stylesheet
+including it — so the chain `xsl:apply-imports` walks is the same whether the
+module is included once or twice, and the repeat really is only noise.
 
 The linter resolves each `@href` against the importing file's own directory, so
 two spellings that point at the same file (`lib/util.xsl` and `./lib/util.xsl`)

--- a/src/resources/motives/format/redundant-import.md
+++ b/src/resources/motives/format/redundant-import.md
@@ -54,10 +54,23 @@ Correct:
 </xsl:stylesheet>
 ```
 
-A repeated `xsl:include` carries none of this. An include has no precedence
-level of its own — the module's definitions land at the level of the stylesheet
-including it — so the chain `xsl:apply-imports` walks is the same whether the
-module is included once or twice, and the repeat really is only noise.
+A repeated `xsl:include` is not exempt, though it looks it. An include creates
+no precedence level of its own — the module's definitions land at the level of
+the stylesheet including it — but it copies that module's *children* in, and
+those children include its own `xsl:import` elements. Include a module twice and
+its imports arrive twice, at two levels, and the same traversal walks both.
+Where `gamma.xsl` imports `delta.xsl`, this emits `GDD`, and `GD` with one of
+the includes removed:
+
+```xsl
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:include href="gamma.xsl"/>
+  <xsl:include href="gamma.xsl"/>
+</xsl:stylesheet>
+```
+
+Only where the included module imports nothing, directly or through what it
+includes, is the repeat pure noise.
 
 The linter resolves each `@href` against the importing file's own directory, so
 two spellings that point at the same file (`lib/util.xsl` and `./lib/util.xsl`)

--- a/src/resources/motives/format/redundant-import.md
+++ b/src/resources/motives/format/redundant-import.md
@@ -1,10 +1,37 @@
 # Redundant import
 
 Referencing the same module twice the same way in one stylesheet adds nothing —
-the second `xsl:import`, or the second `xsl:include`, brings in the same
-templates, functions, and variables the first already did. At best it is noise;
-at worst it muddies import precedence and hides which reference a reader should
-reason about. Keep a single reference per module.
+both references bring in the same templates, functions, and variables. At best
+it is noise; at worst it hides which reference a reader should reason about.
+Keep a single reference per module.
+
+Which one to keep is not a free choice, because import precedence is
+positional: XSLT 1.0 §2.6.2 ranks each `xsl:import` above everything declared
+before it, so a module's precedence is set by its *last* reference and every
+earlier one is shadowed by it. Where another module is imported in between, the
+two references sit on opposite sides of it and only one of them decides which
+module's definitions win. Drop an earlier reference and nothing moves; drop the
+last and the module falls below whatever stood between them.
+
+Incorrect — `alpha` outranks `beta` here, and deleting the third line silently
+reverses that:
+
+```xsl
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="alpha.xsl"/>
+  <xsl:import href="beta.xsl"/>
+  <xsl:import href="alpha.xsl"/>
+</xsl:stylesheet>
+```
+
+Correct:
+
+```xsl
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="beta.xsl"/>
+  <xsl:import href="alpha.xsl"/>
+</xsl:stylesheet>
+```
 
 The linter resolves each `@href` against the importing file's own directory, so
 two spellings that point at the same file (`lib/util.xsl` and `./lib/util.xsl`)

--- a/test/fixer.deep.test.js
+++ b/test/fixer.deep.test.js
@@ -133,6 +133,12 @@ const APPLIED = [
     after: 'redundant-import-many.fixed.xsl',
   },
   {
+    name: 'should keep the higher-precedence duplicate import with --fix',
+    flag: '--fix',
+    before: 'redundant-import-between.xsl',
+    after: 'redundant-import-between.fixed.xsl',
+  },
+  {
     name: 'should unwrap the node-set extension with --fix',
     flag: '--fix',
     before: 'use-node-set-extension.xsl',

--- a/test/fixer.deep.test.js
+++ b/test/fixer.deep.test.js
@@ -121,20 +121,28 @@ const APPLIED = [
     after: 'starts-with-double-slash-outside-a-template.fixed.xsl',
   },
   {
-    name: 'should delete a redundant import with --fix',
+    name: 'should delete a redundant include with --fix',
     flag: '--fix',
+    before: 'repeated-include.xsl',
+    after: 'repeated-include.fixed.xsl',
+  },
+  {
+    name: 'should delete a redundant import with --fix-suggestions',
+    flag: '--fix-suggestions',
     before: 'redundant-import.xsl',
     after: 'redundant-import.fixed.xsl',
   },
   {
-    name: 'should delete four of five duplicate imports with --fix',
-    flag: '--fix',
+    name: 'should delete four of five duplicate imports with ' +
+      '--fix-suggestions',
+    flag: '--fix-suggestions',
     before: 'redundant-import-many.xsl',
     after: 'redundant-import-many.fixed.xsl',
   },
   {
-    name: 'should keep the higher-precedence duplicate import with --fix',
-    flag: '--fix',
+    name: 'should keep the higher-precedence duplicate import with ' +
+      '--fix-suggestions',
+    flag: '--fix-suggestions',
     before: 'redundant-import-between.xsl',
     after: 'redundant-import-between.fixed.xsl',
   },
@@ -388,6 +396,11 @@ const UNCHANGED = [
     sheet: 'redundant-import.xsl',
   },
   {
+    name: 'cannot delete a redundant import with plain --fix',
+    flag: '--fix',
+    sheet: 'redundant-import.xsl',
+  },
+  {
     name: 'cannot strip a boolean() wrapper with --fix-dry-run',
     flag: '--fix-dry-run',
     sheet: 'redundant-boolean-call.xsl',
@@ -522,7 +535,7 @@ const DROPPED = [
   },
   {
     name: 'should drop the fixed redundant-import defect from the report',
-    flag: '--fix',
+    flag: '--fix-suggestions',
     sheet: 'redundant-import.xsl',
     check: 'redundant-import',
   },

--- a/test/fixer.deep.test.js
+++ b/test/fixer.deep.test.js
@@ -121,8 +121,8 @@ const APPLIED = [
     after: 'starts-with-double-slash-outside-a-template.fixed.xsl',
   },
   {
-    name: 'should delete a redundant include with --fix',
-    flag: '--fix',
+    name: 'should delete a redundant include with --fix-suggestions',
+    flag: '--fix-suggestions',
     before: 'repeated-include.xsl',
     after: 'repeated-include.fixed.xsl',
   },
@@ -399,6 +399,11 @@ const UNCHANGED = [
     name: 'cannot delete a redundant import with plain --fix',
     flag: '--fix',
     sheet: 'redundant-import.xsl',
+  },
+  {
+    name: 'cannot delete a redundant include with plain --fix',
+    flag: '--fix',
+    sheet: 'repeated-include.xsl',
   },
   {
     name: 'cannot strip a boolean() wrapper with --fix-dry-run',

--- a/test/resources/fix/redundant-import-between.fixed.xsl
+++ b/test/resources/fix/redundant-import-between.fixed.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="beta.xsl"/>
+  <xsl:import href="alpha.xsl"/>
+  <xsl:template match="/">
+    <xsl:value-of select="."/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/redundant-import-between.xsl
+++ b/test/resources/fix/redundant-import-between.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="alpha.xsl"/>
+  <xsl:import href="beta.xsl"/>
+  <xsl:import href="alpha.xsl"/>
+  <xsl:template match="/">
+    <xsl:value-of select="."/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/repeated-include.fixed.xsl
+++ b/test/resources/fix/repeated-include.fixed.xsl
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:include href="common.xsl"/>
+  <xsl:template match="/">
+    <xsl:value-of select="."/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/fix/repeated-include.xsl
+++ b/test/resources/fix/repeated-include.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2025-2026 Max Trunnikov
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:include href="common.xsl"/>
+  <xsl:include href="common.xsl"/>
+  <xsl:template match="/">
+    <xsl:value-of select="."/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/resources/import-packs/import-precedence.yaml
+++ b/test/resources/import-packs/import-precedence.yaml
@@ -10,8 +10,9 @@ inputs:
   - |-
     <?xml version="1.0"?>
     <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="a">
-      <xsl:include href="shared.xsl"/>
-      <xsl:include href="shared.xsl"/>
+      <xsl:import href="alpha.xsl"/>
+      <xsl:import href="beta.xsl"/>
+      <xsl:import href="alpha.xsl"/>
       <xsl:template match="/">
         <xsl:value-of select="."/>
       </xsl:template>

--- a/test/resources/import-packs/mixed-import-and-include.yaml
+++ b/test/resources/import-packs/mixed-import-and-include.yaml
@@ -4,7 +4,7 @@
 pack: redundant-import
 found:
   amount: 3
-  positions: [ [ 0, 5, 3 ], [ 0, 6, 3 ], [ 0, 7, 3 ] ]
+  positions: [ [ 0, 3, 3 ], [ 0, 4, 3 ], [ 0, 6, 3 ] ]
   fixes: [ null, null, null ]
 inputs:
   - |-

--- a/test/resources/import-packs/redundant-import.yaml
+++ b/test/resources/import-packs/redundant-import.yaml
@@ -4,7 +4,7 @@
 pack: redundant-import
 found:
   amount: 1
-  positions: [ [ 0, 4, 3 ] ]
+  positions: [ [ 0, 3, 3 ] ]
   fixes: [ "" ]
 inputs:
   - |-


### PR DESCRIPTION
`redundant-import` reported the second and later reference to a module and offered a safe deletion of it. Import precedence is positional, though — XSLT 1.0 §2.6.2 ranks each `xsl:import` above everything declared before it — so a module's level is set by its *last* reference, and that is the one reference that cannot go. With another module imported in between, cutting it drops this one below that one, and the stylesheet's output changes under a fix tier that promises it will not.

The report moves to the other end. Every reference but the last is a defect now, and the last is what stays:

```js
const last = new Map()
imports.forEach(({file, to}, at) => last.set(`${file}|${to}`, at))
const defects = []
imports.forEach(({file, node, to}, at) => {
  const key = `${file}|${to}`
  if (last.get(key) !== at) {
```

That much is only about which reference to cut. It does not make the deletion safe at either mechanism, and the fix is a suggestion whatever it cuts.

An `xsl:import` creates a precedence level, and the earlier reference is shadowed for template *selection* only: `xsl:apply-imports` walks down the chain and meets the module at every level it occupies. An `xsl:include` creates no level of its own — but it copies the includee's children in, and those children include its own `xsl:import` elements, so a module included twice brings its imports in twice. Measured with xsltproc, `gamma.xsl` importing `delta.xsl` and both rules ending in `xsl:apply-imports`:

```text
                        before   plain --fix   --fix-suggestions
import alpha twice      AA       AA            A
import alpha, beta, alpha ABA    ABA           AB
include gamma twice     GDD      GDD           GD
```

Plain `--fix` moves no output now.

Gating on the corpus was the tempting alternative and does not work in either direction. The permissive form — safe unless the corpus holds an `xsl:apply-imports` — produces a false safe, since `--fix` cuts a duplicate import of a module xslint never reads. The conservative form — safe only when the includee resolves and its closure imports nothing — is sound but empty: not one of this repository's own duplicate-reference fixtures resolves, so the safe tier would fire nowhere, and in the field it would depend on which files the caller passed rather than on the stylesheet.

`test/resources/fix/redundant-import-between.xsl` is the case the existing packs could not reach — `alpha`, `beta`, `alpha` — and `--fix` now cuts line 7 and leaves `beta`, `alpha`, so `alpha` still outranks `beta`. Before this it cut line 9 and reversed them. The three packs that pinned the old end shifted with it, including `mixed-import-and-include`, where a module reached both ways is still reported without a fix.

The motive taught the opposite of what the check flags — "the second `xsl:import` brings in the same templates the first already did" — so it now teaches both halves: the later reference decides which module wins, and the earlier one is still walked by `xsl:apply-imports`, so a duplicate import is a decision to make by hand. `README.md` said the module stays imported by the first reference, and listed the whole check under `--fix`; the include half stays there and the import half moves to the suggestions list.

Closes #667