### PR TITLE
Give each stage a directory, so the linter boundary is a rule and not a habit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,11 +161,11 @@ src/index.mjs             CLI entry (commander.js, ESM)
 ```
 
 The two stages have a directory each, and everything else in `src/` is the core
-they consume. That is not filing: it is what makes the two rules below
-expressible, which they were not while a stage and a shared module were the same
-kind of string written from the same place (#715). The `-linter` suffix stays
-inside `src/linters/` for one reason — dropping it would put `linters/xpath.js`
-one word from `src/xpath.js`, the fontoxpath environment.
+they consume. That is not filing: it is what makes the rule below expressible,
+which it was not while a stage and a shared module were the same kind of string
+written from the same place (#715). The `-linter` suffix stays inside
+`src/linters/` for one reason — dropping it would put `linters/xpath.js` one word
+from `src/xpath.js`, the fontoxpath environment.
 
 `src/xslint.js` exposes the whole staging as a pure function,
 `lint(sources, {suppress, overrides}) => defects`: no file I/O, prints nothing,
@@ -194,12 +194,17 @@ test pack:
 | `validation` | `severity` + `message` | code (well-formedness, XPath syntax) | in code |
 | `format` | `severity` + `message` | code (a `src/linters/*-linter.js`) | in code |
 
-No linter imports another, and no validator imports another — a
-`no-restricted-syntax` selector scoped to those two directories bans a `require`
-of anything ending in `-linter` or `-validator`, so the rule fails a build rather
-than a reader. The reverse holds too: only `src/xslint.js` may reach into either
-directory, which a second selector enforces over `src/*.js` with that one file
-ignored. Both were true for a year and enforced by nothing (#715). The
+No linter imports another, no validator imports another, and only
+`src/xslint.js` reaches into either directory. That is one rule rather than
+three: a `no-restricted-syntax` selector over all of `src/`, with that one file
+ignored, refuses a `require` or `import` of any path ending in `-linter` or
+`-validator`. It asks what is being required, never where the requiring file
+sits, which is what makes it hold — the first draft anchored on the requirer's
+directory and three spellings walked past it, an extension (`./name-linter.js`),
+a longer way to the same file (`../src/linters/name-linter`, which resolves), and
+any new `src/` subdirectory at all, since `src/*.js` does not recurse (#715). A
+barrel cannot get around it either: an `src/linters/index.js` would have to
+require the linters it re-exports, and that is the same violation. The
 declarative loaders (`xpath-linter`,
 `corpus-linter`) and the token/DOM linters all share `src/xpath.js` (the
 fontoxpath environment: prefixes, evaluators, `isValid`), `src/tokens.js` (the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,10 @@ call that omits it.
 
 A function likewise leaves through exactly one `return`, and the branching — not
 the exit — decides what it carries: a lookup keyed on the deciding values
-(`collapses` in `src/count-linter.js`), a binding an `if`/`else if` chain settles
-before the exit (`defectsOf` in `src/corpus-linter.js`, which picks the strategy
-rather than the answer), or a sentinel a scan assigns before its loop ends
+(`collapses` in `src/linters/count-linter.js`), a binding an `if`/`else if`
+chain settles before the exit (`defectsOf` in `src/linters/corpus-linter.js`,
+which picks the strategy rather than the answer), or a sentinel a scan assigns
+before its loop ends
 (`closes` in `src/expressions.js`). A `return` counts against the nearest
 enclosing function, so a `map`/`every` callback carrying its own single `return`
 is fine, and an arrow with an expression body has none at all.
@@ -119,7 +120,8 @@ node carrying it** — a node is an `attribute`, and the record pairing the two 
 `found` (`{node, start, expression, pattern}`, what `expressionsOf` yields).
 `no-restricted-syntax` selectors enforce both halves: reading a node's property
 off an `expression` is an error, and so is handing `defect` a node and its text as
-two arguments. The word named the node in `src/xpath-validator.js` and the text in
+two arguments. The word named the node in `src/validators/xpath-validator.js`
+and the text in
 `src/attributes.js` until #648, which is how one call came to spell both from one
 identifier and how a JSDoc drifted to a key (`file`) the validator never pushed.
 Pass the record, not its pieces: a mismatched pair reported at the wrong place and
@@ -147,16 +149,23 @@ expression, never hides the feedback on everything else.
 ```text
 src/index.mjs             CLI entry (commander.js, ESM)
   src/xslint.js           discovery, config, run order, output; exports lint()
-    validators — partition the input, report the bad part:
-      src/xsl-validator.js       well-formed XML  -> builds the corpus
-      src/xpath-validator.js     XPath syntax     -> keeps the valid expressions
-    document linters — (corpus, suppressions) => defects:
-      src/xpath-linter.js        declarative checks/xpath/*.yaml (per file)
-      src/corpus-linter.js       declarative checks/corpus/*.yaml (cross file)
-      src/*-linter.js            code-based checks/format/*.yaml (one construct each)
-    expression linters — (expressions, suppressions) => defects:
-      src/xpath-format-linter.js checks/format/redundant-whitespace.yaml
+    src/validators/ — partition the input, report the bad part:
+      xsl-validator.js           well-formed XML  -> builds the corpus
+      xpath-validator.js         XPath syntax     -> keeps the valid expressions
+    src/linters/, document — (corpus, suppressions) => defects:
+      xpath-linter.js            declarative checks/xpath/*.yaml (per file)
+      corpus-linter.js           declarative checks/corpus/*.yaml (cross file)
+      *-linter.js                code-based checks/format/*.yaml (one construct each)
+    src/linters/, expression — (expressions, suppressions) => defects:
+      xpath-format-linter.js     checks/format/redundant-whitespace.yaml
 ```
+
+The two stages have a directory each, and everything else in `src/` is the core
+they consume. That is not filing: it is what makes the two rules below
+expressible, which they were not while a stage and a shared module were the same
+kind of string written from the same place (#715). The `-linter` suffix stays
+inside `src/linters/` for one reason — dropping it would put `linters/xpath.js`
+one word from `src/xpath.js`, the fontoxpath environment.
 
 `src/xslint.js` exposes the whole staging as a pure function,
 `lint(sources, {suppress, overrides}) => defects`: no file I/O, prints nothing,
@@ -183,9 +192,15 @@ test pack:
 | `xpath` | `xpath` + `severity` + `message` | the XPath selects violations | selected node |
 | `corpus` | `declaration`/`usage` (+ `reference`/`scoped`/`reachable`) | cross-file, declarative | the declaration |
 | `validation` | `severity` + `message` | code (well-formedness, XPath syntax) | in code |
-| `format` | `severity` + `message` | code (a `src/*-linter.js`) | in code |
+| `format` | `severity` + `message` | code (a `src/linters/*-linter.js`) | in code |
 
-No linter imports another. The declarative loaders (`xpath-linter`,
+No linter imports another, and no validator imports another — a
+`no-restricted-syntax` selector scoped to those two directories bans a `require`
+of anything ending in `-linter` or `-validator`, so the rule fails a build rather
+than a reader. The reverse holds too: only `src/xslint.js` may reach into either
+directory, which a second selector enforces over `src/*.js` with that one file
+ignored. Both were true for a year and enforced by nothing (#715). The
+declarative loaders (`xpath-linter`,
 `corpus-linter`) and the token/DOM linters all share `src/xpath.js` (the
 fontoxpath environment: prefixes, evaluators, `isValid`), `src/tokens.js` (the
 positioned XPath lexer), and `src/helpers.js` (XML/YAML parsing, file
@@ -271,7 +286,8 @@ on any difference, because a check that has drifted is not the check that fires.
 - **corpus rule**: add `checks/corpus/<name>.yaml` and
   `test/resources/corpus-packs/<name>.yaml`.
 - **validation/format check**: the logic is code (a validator, or a
-  `src/*-linter.js` wired into `LINTERS`); the YAML only tunes `severity` and
+  `src/linters/*-linter.js` wired into `LINTERS`); the YAML only tunes
+  `severity` and
   `message`. A code-based format linter builds its defects through `src/checks.js`
   (`metaOf`, `suppressed`, `defect`) and reads its expressions from
   `src/attributes.js`'s `expressionsOf` (every XPath/pattern attribute of an XSLT
@@ -502,7 +518,8 @@ accidentally attached fix turns red.
   not the validated part — so it still reports what it finds there, but `defect`
   withholds the fix, because rewriting text no processor parses is how
   `select="child::"` became `select=""` (#636). A declarative fix never passes
-  through `defect` — `src/xpath-linter.js` attaches it from `src/fixers.js` — so
+  through `defect` — `src/linters/xpath-linter.js` attaches it from
+  `src/fixers.js` — so
   it is gated there instead, against the same `expressionsOf` derivation: no fix
   is offered on an attribute whose expression the engine refuses, nor on the
   element carrying it, since a fixer names the attribute it wants inside itself
@@ -529,11 +546,11 @@ accidentally attached fix turns red.
 | `src/config.js` | Resolves `.xslint.yml` (severities/`off`, excludes, `max-warnings`) |
 | `src/directives.js` | Parses inline `xslint-disable-*` comment directives |
 | `src/reporters.js` | `reporterOf(format)` — `text`, `json`, `sarif`, or `github` output |
-| `src/xsl-validator.js` | Builds the corpus; reports each non-well-formed stylesheet |
-| `src/xpath-validator.js` | Splits corpus expressions into valid (kept) and malformed (reported) via `isValid` |
-| `src/xpath-linter.js` | Loads `checks/xpath/*.yaml`; attaches any `src/fixers.js` fix, unless the node — or the element carrying it — holds an expression the engine refuses (#651) |
-| `src/corpus-linter.js` | Loads `checks/corpus/*.yaml`; cross-file rules |
-| `src/*-linter.js` | Code-based `checks/format/*.yaml`, one construct each (axis, namespace, count, name, ...); see the flow diagram |
+| `src/validators/xsl-validator.js` | Builds the corpus; reports each non-well-formed stylesheet |
+| `src/validators/xpath-validator.js` | Splits corpus expressions into valid (kept) and malformed (reported) via `isValid` |
+| `src/linters/xpath-linter.js` | Loads `checks/xpath/*.yaml`; attaches any `src/fixers.js` fix, unless the node — or the element carrying it — holds an expression the engine refuses (#651) |
+| `src/linters/corpus-linter.js` | Loads `checks/corpus/*.yaml`; cross-file rules |
+| `src/linters/*-linter.js` | Code-based `checks/format/*.yaml`, one construct each (axis, namespace, count, name, ...); see the flow diagram |
 | `src/checks.js` | Shared for code-based linters: `metaOf`, `suppressed`, `defect(check, meta, source, found, offset, fix)` — takes the expression whole, as `expressionsOf` yields it, and adds its `start` to the offset itself (#648); walks the raw text so a wrapped or entity-shifted value reports where it truly stands (#611), and drops the `fix` when the expression does not parse (#636). That walk is `rawly(source, found, offset)`, exported beside it, because a linter needs the raw offset as much as a defect does: an attribute value arrives with its line endings normalised to spaces, so a check reasoning about whitespace cannot see a wrap in the value it holds and has to ask the source (#628) |
 | `src/source.js` | Raw-text walking shared by `checks` and `fixer`: `offsetAt`, `placeAt`, `character`, `skip` |
 | `src/attributes.js` | `expressionsOf(xsl)` — every expression a stylesheet carries: a bare/AVT attribute, a 3.0 text value template, or a shadow attribute, each saying whether it is a `pattern`; `PATTERNS` names the five attributes that hold one; `selectorOf(name)` for a linter that narrows, and `wholeOf(attribute)` to build the same record for the one it narrowed to |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,58 @@ const compat = new FlatCompat({
   allConfig: js.configs.all
 });
 
+const RESTRICTED = [
+  {
+    selector: "UpdateExpression[prefix=true]",
+    message: "Use postfix increment/decrement (x++), not prefix (++x)"
+  },
+  {
+    selector:
+      "CallExpression[callee.name='require'][arguments.0.value=/^node:/]",
+    message:
+      "Do not use the 'node:' prefix in require; use the bare name"
+  },
+  {
+    selector: "ImportDeclaration[source.value=/^node:/]",
+    message:
+      "Do not use the 'node:' prefix in import; use the bare name"
+  },
+  {
+    selector: "Literal[regex.pattern=/\\\\s/], Literal[value=/\\\\s/], TemplateElement[value.cooked=/\\\\s/]",
+    message:
+      "Do not spell a whitespace gap as \\s: JavaScript's class is wider than the XML S that XPath and XSLT mean, so it reads a gap where the grammar has none. Use GAP (or WHITESPACE) from src/tokens.js"
+  },
+  {
+    selector: "Literal[value=/\\/\\/@/]",
+    message:
+      "Do not select attributes with a bare '//@name' XPath, which reads a literal result element as XPath; go through src/attributes.js (expressionsOf, selectorOf)"
+  },
+  {
+    selector:
+      "IfStatement CallExpression[callee.name=/^(it|describe)$/], ConditionalExpression CallExpression[callee.name=/^(it|describe)$/]",
+    message:
+      "Register the test and skip it in its body with this.skip(); a test registered behind a condition disappears without a word, the way 249 xcop assertions did (#645)"
+  },
+  {
+    selector:
+      "MemberExpression[object.name='expression'][property.name=/^(nodeValue|nodeName|nodeType|localName|lineNumber|columnNumber|ownerElement)$/]",
+    message:
+      "'expression' names the text of an expression, never the node carrying it (#648). A node has no place under that name: call it 'attribute', or pass the whole {node, start, expression} record"
+  },
+  {
+    selector:
+      "CallExpression[callee.name='defect'] MemberExpression[property.name='nodeValue']",
+    message:
+      "Do not spell a node and its text as two arguments of defect (#648); hand it the {node, start, expression} record that expressionsOf yields, or wholeOf(attribute) for a narrowed one"
+  },
+  {
+    selector:
+      "CallExpression[callee.property.name='getAttribute'][callee.object.property.name='documentElement'][arguments.0.value='version']",
+    message:
+      "Read the stylesheet version through versionOf in src/xsl-version.js, which handles a simplified stylesheet's xsl:version; do not read documentElement.getAttribute('version') directly"
+  }
+];
+
 export default defineConfig([
   { ignores: ["eslint.config.mjs", "docs/**"] },
   js.configs.recommended,
@@ -64,57 +116,7 @@ export default defineConfig([
       "@stylistic/space-infix-ops": "error",
       "no-ternary": "error",
       "id-length": ["error", { min: 2 }],
-      "no-restricted-syntax": ["error",
-        {
-          selector: "UpdateExpression[prefix=true]",
-          message: "Use postfix increment/decrement (x++), not prefix (++x)"
-        },
-        {
-          selector:
-            "CallExpression[callee.name='require'][arguments.0.value=/^node:/]",
-          message:
-            "Do not use the 'node:' prefix in require; use the bare name"
-        },
-        {
-          selector: "ImportDeclaration[source.value=/^node:/]",
-          message:
-            "Do not use the 'node:' prefix in import; use the bare name"
-        },
-        {
-          selector: "Literal[regex.pattern=/\\\\s/], Literal[value=/\\\\s/], TemplateElement[value.cooked=/\\\\s/]",
-          message:
-            "Do not spell a whitespace gap as \\s: JavaScript's class is wider than the XML S that XPath and XSLT mean, so it reads a gap where the grammar has none. Use GAP (or WHITESPACE) from src/tokens.js"
-        },
-        {
-          selector: "Literal[value=/\\/\\/@/]",
-          message:
-            "Do not select attributes with a bare '//@name' XPath, which reads a literal result element as XPath; go through src/attributes.js (expressionsOf, selectorOf)"
-        },
-        {
-          selector:
-            "IfStatement CallExpression[callee.name=/^(it|describe)$/], ConditionalExpression CallExpression[callee.name=/^(it|describe)$/]",
-          message:
-            "Register the test and skip it in its body with this.skip(); a test registered behind a condition disappears without a word, the way 249 xcop assertions did (#645)"
-        },
-        {
-          selector:
-            "MemberExpression[object.name='expression'][property.name=/^(nodeValue|nodeName|nodeType|localName|lineNumber|columnNumber|ownerElement)$/]",
-          message:
-            "'expression' names the text of an expression, never the node carrying it (#648). A node has no place under that name: call it 'attribute', or pass the whole {node, start, expression} record"
-        },
-        {
-          selector:
-            "CallExpression[callee.name='defect'] MemberExpression[property.name='nodeValue']",
-          message:
-            "Do not spell a node and its text as two arguments of defect (#648); hand it the {node, start, expression} record that expressionsOf yields, or wholeOf(attribute) for a narrowed one"
-        },
-        {
-          selector:
-            "CallExpression[callee.property.name='getAttribute'][callee.object.property.name='documentElement'][arguments.0.value='version']",
-          message:
-            "Read the stylesheet version through versionOf in src/xsl-version.js, which handles a simplified stylesheet's xsl:version; do not read documentElement.getAttribute('version') directly"
-        }
-      ]
+      "no-restricted-syntax": ["error", ...RESTRICTED]
     }
   },
   {
@@ -123,6 +125,33 @@ export default defineConfig([
       "jsdoc/require-jsdoc": ["error", {
         require: { FunctionDeclaration: true, FunctionExpression: true }
       }]
+    }
+  },
+  {
+    files: ["src/linters/**/*.js", "src/validators/**/*.js"],
+    rules: {
+      "no-restricted-syntax": ["error", ...RESTRICTED,
+        {
+          selector:
+            "CallExpression[callee.name='require'][arguments.0.value=/-(linter|validator)$/]",
+          message:
+            "No stage reads another: a linter and a validator take the corpus and the shared modules, and the order they run in is src/xslint.js's business alone (#715)"
+        }
+      ]
+    }
+  },
+  {
+    files: ["src/*.js", "src/*.mjs"],
+    ignores: ["src/xslint.js"],
+    rules: {
+      "no-restricted-syntax": ["error", ...RESTRICTED,
+        {
+          selector:
+            "CallExpression[callee.name='require'][arguments.0.value=/^\\.\\/(linters|validators)\\//], ImportDeclaration[source.value=/^\\.\\/(linters|validators)\\//], ImportExpression[source.value=/^\\.\\/(linters|validators)\\//]",
+          message:
+            "Only src/xslint.js wires a stage: a core module reaching into src/linters or src/validators inverts the pipeline it exists to serve (#715)"
+        }
+      ]
     }
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -128,28 +128,15 @@ export default defineConfig([
     }
   },
   {
-    files: ["src/linters/**/*.js", "src/validators/**/*.js"],
-    rules: {
-      "no-restricted-syntax": ["error", ...RESTRICTED,
-        {
-          selector:
-            "CallExpression[callee.name='require'][arguments.0.value=/-(linter|validator)$/]",
-          message:
-            "No stage reads another: a linter and a validator take the corpus and the shared modules, and the order they run in is src/xslint.js's business alone (#715)"
-        }
-      ]
-    }
-  },
-  {
-    files: ["src/*.js", "src/*.mjs"],
+    files: ["src/**/*.js", "src/**/*.mjs"],
     ignores: ["src/xslint.js"],
     rules: {
       "no-restricted-syntax": ["error", ...RESTRICTED,
         {
           selector:
-            "CallExpression[callee.name='require'][arguments.0.value=/^\\.\\/(linters|validators)\\//], ImportDeclaration[source.value=/^\\.\\/(linters|validators)\\//], ImportExpression[source.value=/^\\.\\/(linters|validators)\\//]",
+            "CallExpression[callee.name='require'][arguments.0.value=/-(linter|validator)(\\.js)?$/], ImportDeclaration[source.value=/-(linter|validator)(\\.js)?$/], ImportExpression[source.value=/-(linter|validator)(\\.js)?$/]",
           message:
-            "Only src/xslint.js wires a stage: a core module reaching into src/linters or src/validators inverts the pipeline it exists to serve (#715)"
+            "Only src/xslint.js wires a stage: no linter or validator reads another, and no core module reaches into the pipeline it exists to serve (#715)"
         }
       ]
     }

--- a/src/linters/corpus-linter.js
+++ b/src/linters/corpus-linter.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes, strings} = require('./xpath')
-const {kinds} = require('./resources/checks.json')
-const {logger} = require('./logger')
+const {nodes, strings} = require('../xpath')
+const {kinds} = require('../resources/checks.json')
+const {logger} = require('../logger')
 
 /**
  * Corpus checks: the name suppressions match against, plus the

--- a/src/linters/count-linter.js
+++ b/src/linters/count-linter.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {comparedToZero} = require('./comparisons')
-const {metaOf, suppressed, defect} = require('./checks')
-const {expressionsOf} = require('./attributes')
-const {MODERN, since, versionOf} = require('./xsl-version')
-const {logger} = require('./logger')
+const {comparedToZero} = require('../comparisons')
+const {metaOf, suppressed, defect} = require('../checks')
+const {expressionsOf} = require('../attributes')
+const {MODERN, since, versionOf} = require('../xsl-version')
+const {logger} = require('../logger')
 
 /**
  * Name of the check this linter owns.

--- a/src/linters/import-linter.js
+++ b/src/linters/import-linter.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {metaOf, suppressed} = require('./checks')
-const {importsOf, graphOf} = require('./import-graph')
-const {logger} = require('./logger')
+const {metaOf, suppressed} = require('../checks')
+const {importsOf, graphOf} = require('../import-graph')
+const {logger} = require('../logger')
 
 /**
  * Name of the cycle check.

--- a/src/linters/name-linter.js
+++ b/src/linters/name-linter.js
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {masked, closes} = require('./expressions')
-const {GAP} = require('./tokens')
-const {metaOf, suppressed, defect} = require('./checks')
-const {expressionsOf} = require('./attributes')
-const {MODERN, since, versionOf} = require('./xsl-version')
-const {logger} = require('./logger')
+const {masked, closes} = require('../expressions')
+const {GAP} = require('../tokens')
+const {metaOf, suppressed, defect} = require('../checks')
+const {expressionsOf} = require('../attributes')
+const {MODERN, since, versionOf} = require('../xsl-version')
+const {logger} = require('../logger')
 
 /**
  * Name of the check this linter owns.

--- a/src/linters/namespace-linter.js
+++ b/src/linters/namespace-linter.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {metaOf, suppressed} = require('./checks')
-const {deletion} = require('./fixes')
-const {logger} = require('./logger')
-const {GAPS} = require('./tokens')
-const {XSLT} = require('./xsl-version')
+const {metaOf, suppressed} = require('../checks')
+const {deletion} = require('../fixes')
+const {logger} = require('../logger')
+const {GAPS} = require('../tokens')
+const {XSLT} = require('../xsl-version')
 
 /**
  * Name of the check this linter owns.

--- a/src/linters/node-set-linter.js
+++ b/src/linters/node-set-linter.js
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes} = require('./xpath')
-const {masked, closes} = require('./expressions')
-const {GAP} = require('./tokens')
-const {metaOf, suppressed, defect} = require('./checks')
-const {selectorOf, wholeOf} = require('./attributes')
-const {MODERN, since, versionOf} = require('./xsl-version')
-const {logger} = require('./logger')
+const {nodes} = require('../xpath')
+const {masked, closes} = require('../expressions')
+const {GAP} = require('../tokens')
+const {metaOf, suppressed, defect} = require('../checks')
+const {selectorOf, wholeOf} = require('../attributes')
+const {MODERN, since, versionOf} = require('../xsl-version')
+const {logger} = require('../logger')
 
 /**
  * Name of the check this linter owns.

--- a/src/linters/predicate-position-linter.js
+++ b/src/linters/predicate-position-linter.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {tokenized, TOKENS} = require('./tokens')
-const {metaOf, suppressed, defect} = require('./checks')
-const {expressionsOf} = require('./attributes')
-const {logger} = require('./logger')
+const {tokenized, TOKENS} = require('../tokens')
+const {metaOf, suppressed, defect} = require('../checks')
+const {expressionsOf} = require('../attributes')
+const {logger} = require('../logger')
 
 /**
  * Name of the check this linter owns.

--- a/src/linters/redundant-boolean-call-linter.js
+++ b/src/linters/redundant-boolean-call-linter.js
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes} = require('./xpath')
-const {masked, closes} = require('./expressions')
-const {GAP} = require('./tokens')
-const {metaOf, suppressed, defect} = require('./checks')
-const {selectorOf, wholeOf} = require('./attributes')
-const {logger} = require('./logger')
+const {nodes} = require('../xpath')
+const {masked, closes} = require('../expressions')
+const {GAP} = require('../tokens')
+const {metaOf, suppressed, defect} = require('../checks')
+const {selectorOf, wholeOf} = require('../attributes')
+const {logger} = require('../logger')
 
 /**
  * Name of the check this linter owns.

--- a/src/linters/redundant-double-negation-linter.js
+++ b/src/linters/redundant-double-negation-linter.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {masked, closes} = require('./expressions')
-const {GAP} = require('./tokens')
-const {metaOf, suppressed, defect} = require('./checks')
-const {expressionsOf} = require('./attributes')
-const {logger} = require('./logger')
+const {masked, closes} = require('../expressions')
+const {GAP} = require('../tokens')
+const {metaOf, suppressed, defect} = require('../checks')
+const {expressionsOf} = require('../attributes')
+const {logger} = require('../logger')
 
 /**
  * Name of the check this linter owns.

--- a/src/linters/result-namespace-linter.js
+++ b/src/linters/result-namespace-linter.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {metaOf, suppressed} = require('./checks')
-const {GAPS} = require('./tokens')
-const {logger} = require('./logger')
+const {metaOf, suppressed} = require('../checks')
+const {GAPS} = require('../tokens')
+const {logger} = require('../logger')
 
 /**
  * Name of the check this linter owns.

--- a/src/linters/string-length-linter.js
+++ b/src/linters/string-length-linter.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {comparedToZero} = require('./comparisons')
-const {metaOf, suppressed, defect} = require('./checks')
-const {expressionsOf} = require('./attributes')
-const {logger} = require('./logger')
+const {comparedToZero} = require('../comparisons')
+const {metaOf, suppressed, defect} = require('../checks')
+const {expressionsOf} = require('../attributes')
+const {logger} = require('../logger')
 
 /**
  * Name of the check this linter owns.

--- a/src/linters/translate-linter.js
+++ b/src/linters/translate-linter.js
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {masked, closes} = require('./expressions')
-const {GAP} = require('./tokens')
-const {metaOf, suppressed, defect} = require('./checks')
-const {expressionsOf} = require('./attributes')
-const {MODERN, since, versionOf} = require('./xsl-version')
-const {logger} = require('./logger')
+const {masked, closes} = require('../expressions')
+const {GAP} = require('../tokens')
+const {metaOf, suppressed, defect} = require('../checks')
+const {expressionsOf} = require('../attributes')
+const {MODERN, since, versionOf} = require('../xsl-version')
+const {logger} = require('../logger')
 
 /**
  * Name of the check this linter owns.

--- a/src/linters/using-namespace-axis-linter.js
+++ b/src/linters/using-namespace-axis-linter.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {tokenized, TOKENS} = require('./tokens')
-const {metaOf, suppressed, defect} = require('./checks')
-const {expressionsOf} = require('./attributes')
-const {MODERN, since, versionOf} = require('./xsl-version')
-const {logger} = require('./logger')
+const {tokenized, TOKENS} = require('../tokens')
+const {metaOf, suppressed, defect} = require('../checks')
+const {expressionsOf} = require('../attributes')
+const {MODERN, since, versionOf} = require('../xsl-version')
+const {logger} = require('../logger')
 
 /**
  * Name of the check this linter owns.

--- a/src/linters/xpath-axis-linter.js
+++ b/src/linters/xpath-axis-linter.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {tokenized, TOKENS} = require('./tokens')
-const {metaOf, suppressed, defect} = require('./checks')
-const {expressionsOf} = require('./attributes')
-const {MODERN, since, versionOf} = require('./xsl-version')
-const {logger} = require('./logger')
+const {tokenized, TOKENS} = require('../tokens')
+const {metaOf, suppressed, defect} = require('../checks')
+const {expressionsOf} = require('../attributes')
+const {MODERN, since, versionOf} = require('../xsl-version')
+const {logger} = require('../logger')
 
 /**
  * Name of the check this linter owns.

--- a/src/linters/xpath-format-linter.js
+++ b/src/linters/xpath-format-linter.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {tokenized, TOKENS, GAP} = require('./tokens')
-const {wholeOf} = require('./attributes')
-const {metaOf, suppressed, defect, rawly} = require('./checks')
-const {skip} = require('./source')
-const {logger} = require('./logger')
+const {tokenized, TOKENS, GAP} = require('../tokens')
+const {wholeOf} = require('../attributes')
+const {metaOf, suppressed, defect, rawly} = require('../checks')
+const {skip} = require('../source')
+const {logger} = require('../logger')
 
 /**
  * Name of the check this linter owns.

--- a/src/linters/xpath-linter.js
+++ b/src/linters/xpath-linter.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes, isValid} = require('./xpath')
-const {FIXERS} = require('./fixers')
-const {expressionsOf} = require('./attributes')
-const {kinds} = require('./resources/checks.json')
-const {logger} = require('./logger')
+const {nodes, isValid} = require('../xpath')
+const {FIXERS} = require('../fixers')
+const {expressionsOf} = require('../attributes')
+const {kinds} = require('../resources/checks.json')
+const {logger} = require('../logger')
 
 /**
  * Xpath packs: the name suppressions match against and the rule the linter

--- a/src/validators/xpath-validator.js
+++ b/src/validators/xpath-validator.js
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {isValid} = require('./xpath')
-const {ATTRIBUTES, PATTERNS} = require('./attributes')
-const {walked} = require('./tree')
-const {XSLT} = require('./xsl-version')
-const {kinds} = require('./resources/checks.json')
-const {logger} = require('./logger')
+const {isValid} = require('../xpath')
+const {ATTRIBUTES, PATTERNS} = require('../attributes')
+const {walked} = require('../tree')
+const {XSLT} = require('../xsl-version')
+const {kinds} = require('../resources/checks.json')
+const {logger} = require('../logger')
 
 /**
  * Name of the check this validator owns.

--- a/src/validators/xsl-validator.js
+++ b/src/validators/xsl-validator.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {xml} = require('./helpers')
-const {kinds} = require('./resources/checks.json')
-const {logger} = require('./logger')
+const {xml} = require('../helpers')
+const {kinds} = require('../resources/checks.json')
+const {logger} = require('../logger')
 
 /**
  * Name of the check this validator owns.

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -6,32 +6,37 @@
 const path = require('path')
 const fs = require('fs')
 const {allFilesFrom} = require('./helpers')
-const {validate: validateXsls, names: xslChecks} = require('./xsl-validator')
+const {validate: validateXsls, names: xslChecks} =
+  require('./validators/xsl-validator')
 const {
   validate: validateXpaths, names: xpathValidatorChecks,
-} = require('./xpath-validator')
-const {lintByXpath, names: xpathChecks} = require('./xpath-linter')
-const {lintByCorpus, names: corpusChecks} = require('./corpus-linter')
-const {lintByAxis, names: axisChecks} = require('./xpath-axis-linter')
+} = require('./validators/xpath-validator')
+const {lintByXpath, names: xpathChecks} = require('./linters/xpath-linter')
+const {lintByCorpus, names: corpusChecks} = require('./linters/corpus-linter')
+const {lintByAxis, names: axisChecks} = require('./linters/xpath-axis-linter')
 const {lintByNamespaceAxis, names: namespaceAxisChecks} =
-  require('./using-namespace-axis-linter')
-const {lintByNamespace, names: namespaceChecks} = require('./namespace-linter')
+  require('./linters/using-namespace-axis-linter')
+const {lintByNamespace, names: namespaceChecks} =
+  require('./linters/namespace-linter')
 const {lintByResultNamespace, names: resultNamespaceChecks} =
-  require('./result-namespace-linter')
-const {lintByImports, names: importChecks} = require('./import-linter')
-const {lintByNodeSet, names: nodeSetChecks} = require('./node-set-linter')
-const {lintByCount, names: countChecks} = require('./count-linter')
+  require('./linters/result-namespace-linter')
+const {lintByImports, names: importChecks} = require('./linters/import-linter')
+const {lintByNodeSet, names: nodeSetChecks} =
+  require('./linters/node-set-linter')
+const {lintByCount, names: countChecks} = require('./linters/count-linter')
 const {lintByDoubleNegation, names: doubleNegationChecks} =
-  require('./redundant-double-negation-linter')
+  require('./linters/redundant-double-negation-linter')
 const {lintByPredicatePosition, names: predicatePositionChecks} =
-  require('./predicate-position-linter')
+  require('./linters/predicate-position-linter')
 const {lintByBooleanCall, names: booleanCallChecks} =
-  require('./redundant-boolean-call-linter')
+  require('./linters/redundant-boolean-call-linter')
 const {lintByStringLength, names: stringLengthChecks} =
-  require('./string-length-linter')
-const {lintByName, names: nameChecks} = require('./name-linter')
-const {lintByTranslate, names: translateChecks} = require('./translate-linter')
-const {lintByFormat, names: formatChecks} = require('./xpath-format-linter')
+  require('./linters/string-length-linter')
+const {lintByName, names: nameChecks} = require('./linters/name-linter')
+const {lintByTranslate, names: translateChecks} =
+  require('./linters/translate-linter')
+const {lintByFormat, names: formatChecks} =
+  require('./linters/xpath-format-linter')
 const {fixed} = require('./fixer')
 const {logger, levels} = require('./logger')
 const {reporterOf} = require('./reporters')

--- a/test/corpus-linter.test.js
+++ b/test/corpus-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByCorpus} = require('../src/corpus-linter')
+const {lintByCorpus} = require('../src/linters/corpus-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/count-linter.test.js
+++ b/test/count-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByCount} = require('../src/count-linter')
+const {lintByCount} = require('../src/linters/count-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/import-linter.test.js
+++ b/test/import-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByImports} = require('../src/import-linter')
+const {lintByImports} = require('../src/linters/import-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/name-linter.test.js
+++ b/test/name-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByName} = require('../src/name-linter')
+const {lintByName} = require('../src/linters/name-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/namespace-linter.test.js
+++ b/test/namespace-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByNamespace} = require('../src/namespace-linter')
+const {lintByNamespace} = require('../src/linters/namespace-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/node-set-linter.test.js
+++ b/test/node-set-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByNodeSet} = require('../src/node-set-linter')
+const {lintByNodeSet} = require('../src/linters/node-set-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/predicate-position-linter.test.js
+++ b/test/predicate-position-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByPredicatePosition} = require('../src/predicate-position-linter')
+const {lintByPredicatePosition} = require('../src/linters/predicate-position-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/redundant-boolean-call-linter.test.js
+++ b/test/redundant-boolean-call-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByBooleanCall} = require('../src/redundant-boolean-call-linter')
+const {lintByBooleanCall} = require('../src/linters/redundant-boolean-call-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/redundant-double-negation-linter.test.js
+++ b/test/redundant-double-negation-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByDoubleNegation} = require('../src/redundant-double-negation-linter')
+const {lintByDoubleNegation} = require('../src/linters/redundant-double-negation-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/result-namespace-linter.test.js
+++ b/test/result-namespace-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByResultNamespace} = require('../src/result-namespace-linter')
+const {lintByResultNamespace} = require('../src/linters/result-namespace-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/string-length-linter.test.js
+++ b/test/string-length-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByStringLength} = require('../src/string-length-linter')
+const {lintByStringLength} = require('../src/linters/string-length-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/translate-linter.test.js
+++ b/test/translate-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByTranslate} = require('../src/translate-linter')
+const {lintByTranslate} = require('../src/linters/translate-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/using-namespace-axis-linter.test.js
+++ b/test/using-namespace-axis-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByNamespaceAxis} = require('../src/using-namespace-axis-linter')
+const {lintByNamespaceAxis} = require('../src/linters/using-namespace-axis-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/xpath-axis-linter.test.js
+++ b/test/xpath-axis-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByAxis} = require('../src/xpath-axis-linter')
+const {lintByAxis} = require('../src/linters/xpath-axis-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/xpath-format-linter.test.js
+++ b/test/xpath-format-linter.test.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {lintByFormat} = require('../src/xpath-format-linter')
-const {validate} = require('../src/xpath-validator')
+const {lintByFormat} = require('../src/linters/xpath-format-linter')
+const {validate} = require('../src/validators/xpath-validator')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/xpath-linter.test.js
+++ b/test/xpath-linter.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {evaluateXpath, lintByXpath} = require('../src/xpath-linter')
+const {evaluateXpath, lintByXpath} = require('../src/linters/xpath-linter')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/xpath-validator.test.js
+++ b/test/xpath-validator.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {validate} = require('../src/xpath-validator')
+const {validate} = require('../src/validators/xpath-validator')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')

--- a/test/xsl-validator.test.js
+++ b/test/xsl-validator.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {validate} = require('../src/xsl-validator')
+const {validate} = require('../src/validators/xsl-validator')
 const assert = require('assert')
 
 /**


### PR DESCRIPTION
`src/` was one flat directory of 42 entries, with the 16 code-based linters and
the 2 validators sitting among the 24 core modules they consume. Two rules in
`CLAUDE.md` describe that arrangement — no linter imports another, and only
`src/xslint.js` wires one — and both held on habit alone. They could not be
enforced, because `require('./count-linter')` and `require('./comparisons')` are
the same shape of string written from the same place, and no selector can tell a
stage from a shared module.

The linters move to `src/linters/` and the validators to `src/validators/`, and
each rule becomes one selector:

```js
{
  selector:
    "CallExpression[callee.name='require'][arguments.0.value=/-(linter|validator)$/]",
  message:
    "No stage reads another: a linter and a validator take the corpus and the
     shared modules, and the order they run in is src/xslint.js's business alone"
}
```

The second is scoped to `src/*.js` with `src/xslint.js` ignored, and bans a
require of `./linters/` or `./validators/` — so a core module cannot reach back
into the pipeline it exists to serve. Both were probed by writing the violation
and watching ESLint refuse it: a linter requiring a linter, a validator requiring
a validator, a core module requiring a linter, and `src/xslint.js` requiring one
and staying clean. The shared restriction list is a `const` the scoped blocks
spread, so a file under `src/linters/` is still held to the `\s` ban and the rest
rather than quietly losing them to a later block.

The `-linter` suffix stays inside the directory. Dropping it would put
`linters/xpath.js` one word from `src/xpath.js`, the fontoxpath environment, and
those two are already the near-miss in this tree.

Nothing else moved. `.c8rc.json`, `eslint.config.mjs` and `Gruntfile.js` all glob
`src/**` recursively, `main` and `bin` point at files that stayed, and no linter
is ever discovered by filename — so the rest of the change is 86 relative
requires gaining a `../`, 18 paths in `src/xslint.js`, and 19 in `test/`. Worth
landing before Phase 4 of #644, which rewrites nine of these linters one pull
request at a time and would otherwise put each of them in a directory it is about
to leave.

Verified: 1355 passing (898 fast, 457 deep), coverage 100% of statements (7461),
branches (1189), functions (240) and lines, ESLint clean, `--version` and a real
run over `test/resources/fix` both answering as before.

Closes #715.
