### PR TITLE
Cap a source file at 1000 lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ run by the `lint` job) enforces: spaced operators, no single-letter names
 (`id-length` >= 2), postfix `x++` only (prefix `++x` is banned), bare module
 names in `require`/`import` (no `node:` prefix), no conditional operator
 (`a ? b : c` is banned outright by `no-ternary`, nesting and flat chain alike),
+no file longer than 1000 lines (`max-lines`),
 no redundant return variable
 (`const x = expr; return x` is banned — return the expression), no missing
 argument (a call must fill every parameter the callee declares without a
@@ -95,6 +96,19 @@ formatting rules its own style predates (`semi`, `quotes`, `comma-dangle`,
 `local/no-multiple-returns` switched off for that one file, so a ban that
 matters reaches the plugin too. Shortening that off-list is its own job; only
 `eslint.config.mjs` is still unlinted.
+
+A file stops at 1000 lines, counting the blank ones and the comments, since a
+reader scrolls past those as well. One file stands above it and is named in
+`SPRAWLING` in the config — `src/grammar.js`, 1828 lines of one function per
+production of XPath 3.1 — rather than carrying a disable comment of its own, so
+what is exempted is one list a reviewer reads in the place the cap is set, not a
+mark to be found by opening every file. Neither half can rot in silence.
+`conformance.test.js` asks the rule itself whether each name on that list is
+still reported, so a file that shrinks back under the cap, or is renamed, or is
+deleted, turns its own exemption red instead of quietly un-capping whatever
+takes the name next; and it fails when *nothing* in the config caps a file at
+all, because a rule deleted takes its enforcement with it and leaves the
+exemption list reading like a limit that is still in force.
 
 A parameter a caller may leave out therefore says so in the signature, with a
 default — `fix = undefined` on `defect` in `src/checks.js`. A JSDoc `[fix]`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -100,6 +100,8 @@ const TRIVIA = {
     "Which kinds carry no meaning to a grammar and every meaning to the source is TRIVIA in src/tokens.js and nowhere else: it was spelled three times over — as TRIVIA in src/grammar.js, as a && chain inside tokenized, and once more in lone — which is how OPAQUE came to be missing a kind (#576, #708)"
 };
 
+const SPRAWLING = ["src/grammar.js"];
+
 export default defineConfig([
   { ignores: ["eslint.config.mjs", "docs/**"] },
   js.configs.recommended,
@@ -136,6 +138,11 @@ export default defineConfig([
         ignoreTemplateLiterals: true,
         ignoreRegExpLiterals: true
       }],
+      "max-lines": ["error", {
+        max: 1000,
+        skipBlankLines: false,
+        skipComments: false
+      }],
       "jsdoc/no-undefined-types": [
         "error",
         { definedTypes: ["Document", "Node", "Element"] }
@@ -171,6 +178,12 @@ export default defineConfig([
   {
     files: ["**/*.mjs"],
     languageOptions: { sourceType: "module" }
+  },
+  {
+    files: SPRAWLING,
+    rules: {
+      "max-lines": "off"
+    }
   },
   {
     files: ["eslint-local-rules.js"],

--- a/test/conformance.test.js
+++ b/test/conformance.test.js
@@ -8,6 +8,7 @@ const {GAP} = require('../src/tokens')
 const {FIXERS} = require('../src/fixers')
 const {DECIMAL} = require('../src/xsl-version')
 const {authored, rendered, PLACE} = require('../scripts/generate-checks')
+const {Linter} = require('eslint')
 const path = require('path')
 const fs = require('fs')
 const assert = require('assert')
@@ -90,6 +91,27 @@ const SPAWNS = /require\('\.\/helpers'\)/
  * @type {string}
  */
 const DEEP = '.deep.test.js'
+
+/**
+ * Whether the line cap reports a file. The rule itself is asked, rather than
+ * the lines counted a second time here, so the guard cannot come to measure
+ * something other than what ESLint measures; a file that is gone answers no,
+ * since an exemption naming nothing is as stale as one naming a short file.
+ * @param {string} named - Path of the file from the repository root
+ * @param {Array} rule - The max-lines rule as eslint.config.mjs sets it
+ * @return {boolean} - TRUE when the rule reports the file
+ */
+const sprawls = function(named, rule) {
+  const whole = path.resolve(__dirname, '..', named)
+  let found = []
+  if (fs.existsSync(whole)) {
+    found = new Linter().verify(
+      fs.readFileSync(whole, 'utf-8'),
+      {rules: {'max-lines': rule}},
+    )
+  }
+  return found.some((one) => one.ruleId === 'max-lines')
+}
 
 /**
  * Names of the checks of a kind.
@@ -250,6 +272,31 @@ describe('conformance', function() {
       'a test that writes a file without asking for a temporary directory ' +
         'leaves it in the working tree, where the run that lints the ' +
         'repository walks over it and loses its count (#687)',
+    )
+  })
+  it('caps how far a source file may grow', async function() {
+    assert.ok(
+      (await import('../eslint.config.mjs')).default
+        .some((entry) => Array.isArray(entry.rules?.['max-lines'])),
+      'nothing in eslint.config.mjs caps the length of a source file, so the ' +
+        'next one to sprawl past what a reader can hold passes lint',
+    )
+  })
+  it('lifts that cap off no file standing under it', async function() {
+    const config = (await import('../eslint.config.mjs')).default
+    const cap = config
+      .map((entry) => entry.rules?.['max-lines'])
+      .filter((rule) => Array.isArray(rule))
+      .pop()
+    assert.deepEqual(
+      config
+        .filter((entry) => entry.rules?.['max-lines'] === 'off')
+        .flatMap((entry) => entry.files)
+        .filter((named) => !sprawls(named, cap)),
+      [],
+      'a file the line cap is switched off for stands under it now, or names ' +
+        'nothing at all, so the exemption in eslint.config.mjs claims a ' +
+        'length the tree no longer holds',
     )
   })
   it('tests every validation check by name in a test file', function() {


### PR DESCRIPTION
A line has been capped at 80 columns since the beginning; a file was capped at
nothing, and `src/grammar.js` reached 1828 lines with no checker in a position
to mention it. `max-lines` closes that, blank lines and comments counted, since
a reader scrolls past those too.

One file stands above the cap, and it is named where the cap is set rather than
carrying a disable comment of its own, so the exemptions are one list a
reviewer reads in one place:

```js
const SPRAWLING = ["src/grammar.js"];
```

Neither half can rot quietly. `conformance.test.js` asks the rule itself
whether each name on that list is still reported — so a file that shrinks back
under the cap, or is renamed, turns its own exemption red instead of
un-capping whatever takes the name next — and a second case fails when nothing
in the config caps a file at all, a rule deleted otherwise taking its
enforcement with it and leaving the list reading like a limit still in force.
Both were run against a mutation: exempting `src/logger.js` names it, and
deleting the rule fails the first case.

The cap costs one exemption today; `test/fixer.deep.test.js` at 874 lines and
`src/tokens.js` at 845 are the next two, both with room. Splitting the grammar
so the exemption can go is not this change, and is worth its own issue once
Phase 4 of #644 settles what the file has to hold.

Closes #748
