### PR TITLE
Stage the code-based linters over the expressions the validator kept

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,9 +177,9 @@ src/index.mjs             CLI entry (commander.js, ESM)
     src/linters/, document — (corpus, suppressions) => defects:
       xpath-linter.js            declarative checks/xpath/*.yaml (per file)
       corpus-linter.js           declarative checks/corpus/*.yaml (cross file)
-      *-linter.js                code-based checks/format/*.yaml (one construct each)
+      namespace, result-namespace, imports — the DOM, not an expression
     src/linters/, expression — (expressions, suppressions) => defects:
-      xpath-format-linter.js     checks/format/redundant-whitespace.yaml
+      *-linter.js                code-based checks/format/*.yaml (one construct each)
 ```
 
 What crosses that last edge is what the validator kept: the `expressionsOf`
@@ -187,6 +187,18 @@ records themselves, not the attributes they hang off, so the expression stage
 reads the derivation rather than rebuilding one from a node (#589). A pattern and
 a brace's expression reach it too, which is why `redundant-whitespace` now
 collapses the leading gap of a `match=" //spaced"`.
+
+Eleven linters cross it, not one. Ten of them scanned the whole corpus and asked
+`expressionsOf` themselves until #750, so each read the expressions the XPath
+validator had already refused and reported a second defect on the same fault —
+`select="child::"` drew an `invalid-xpath-expression` *and* an
+`unabbreviated-axis`, and `test="count(alpha) = 0 ("` drew one and a
+`count-compared-to-zero`. Withholding the fix, which is all #636 could do from
+inside `defect`, left the advice standing on text no processor accepts. One
+fault draws one defect now, and it is the staging that says so rather than a
+gate every new check has to remember: what is refused reaches no check at all.
+Four `close < 0` guards went with the gate, one per scanner — a bracket that
+never closes cannot reach a scanner reading an expression that parsed.
 
 The two stages have a directory each, and everything else in `src/` is the core
 they consume. That is not filing: it is what makes the rule below expressible,
@@ -330,10 +342,13 @@ on any difference, because a check that has drifted is not the check that fires.
   element, plus every expression an attribute value template, a 3.0 text value
   template, or a shadow attribute carries, each flagged `pattern` or not) unless
   it has a documented reason to
-  narrow — then it narrows through `selectorOf`, never a hand-written `//@name`,
-  which an ESLint `no-restricted-syntax` selector bans, and wraps what it narrowed
-  to in `wholeOf` so `defect` still receives one expression rather than a node and
-  a string paired up by hand.
+  narrow — then it narrows through `whole(found, name)`, never a hand-written
+  `//@name`, which an ESLint `no-restricted-syntax` selector bans. That helper
+  asks one question rather than two on purpose: a check taking the *name* alone
+  would start reading the `test="{boolean(x)}"` of a literal result element,
+  where stripping the wrapper prints the node instead of `true`. The linter is
+  handed the records the validator kept, so there is no corpus to scan and no
+  node to pair with its own text.
 
 Then run `npx grunt checks`, `npm test`, `npm run coverage`, and
 `npx grunt docs`.
@@ -549,19 +564,25 @@ accidentally attached fix turns red.
   `xslint-disable-line`, `xslint-disable-file`, each with optional space-separated
   rule names (`src/directives.js`); an unused directive is reported.
 - **Fix tiers**: a defect is fixable when it carries
-  `fix: {line, col, value, replacement, suggestion?}`. A code-based linter still
-  reads an expression the XPath validator refused — it takes the whole corpus,
-  not the validated part — so it still reports what it finds there, but `defect`
-  withholds the fix, because rewriting text no processor parses is how
-  `select="child::"` became `select=""` (#636). A declarative fix never passes
+  `fix: {line, col, value, replacement, suggestion?}`. A code-based linter never
+  sees an expression the XPath validator refused, since #750 stages every one of
+  them over what the validator *kept*, so there is nothing there to fix and
+  nothing to report either. `defect` held a gate of its own from #636 to then —
+  it took the whole corpus, reported what it found in refused text and withheld
+  only the fix, because rewriting text no processor parses is how
+  `select="child::"` became `select=""` — and the exclusion made that condition
+  one no call could fail. A declarative fix never passes
   through `defect` — `src/linters/xpath-linter.js` attaches it from
   `src/fixers.js` — so
   it is gated there instead, against the same `expressionsOf` derivation: no fix
   is offered on an attribute whose expression the grammar refuses, nor on the
   element carrying it, since a fixer names the attribute it wants inside itself
-  where no gate can see it (#651). Withholding every fix on such an element is
+  where no gate can see it (#651). That gate stays, because a declarative
+  selector reads the document rather than the expressions the validator kept, and
+  so can still match an attribute holding text nobody parses. Withholding every
+  fix on such an element is
   deliberate over-reach: an element holding an expression no processor parses is
-  not worth tidying. What "refuses" means moved underneath all three gates at
+  not worth tidying. What "refuses" means moved underneath every gate at
   #732 without any of them changing: `isValid` asks `src/grammar.js` at the
   version in force rather than fontoxpath at 3.1, so a `cast as` in a
   `version="1.0"` sheet now withholds the fix it used to be offered. A *safe* fix
@@ -586,13 +607,13 @@ accidentally attached fix turns red.
 | `src/directives.js` | Parses inline `xslint-disable-*` comment directives |
 | `src/reporters.js` | `reporterOf(format)` — `text`, `json`, `sarif`, or `github` output |
 | `src/validators/xsl-validator.js` | Builds the corpus; reports each non-well-formed stylesheet |
-| `src/validators/xpath-validator.js` | Splits the corpus's expressions into valid (kept) and malformed (reported), asking `refusalOf` about each record `expressionsOf` yields — the same derivation the code-based linters read, rather than a walk of its own over a list of attribute *names* got by subtracting the pattern-holding ones from `ATTRIBUTES`. That subtraction reached 286 of this repository's 453 expressions, so a `match` no grammar accepts, a `{1 +}` in an attribute value template, a 3.0 text value template and a shadow attribute were validated by nothing at all, while the code-based linters — staged over the whole corpus — read those same expressions and reported what they found in them, with only `defect`'s parse gate keeping a fix off it (#589). A pattern illegal before XSLT 3.0 comes with it, which is #631: `matched` has refused one since #723 and had nobody to say so. The defect goes through `defect` in `src/checks.js` rather than being built by hand, so it stands at the offset the refusal carries instead of at the attribute's opening quote — which the widening makes necessary rather than merely nicer, two braces of one attribute value being two expressions that would otherwise report one column |
+| `src/validators/xpath-validator.js` | Splits the corpus's expressions into valid (kept) and malformed (reported), asking `refusalOf` about each record `expressionsOf` yields — the same derivation the code-based linters read, rather than a walk of its own over a list of attribute *names* got by subtracting the pattern-holding ones from `ATTRIBUTES`. That subtraction reached 286 of this repository's 453 expressions, so a `match` no grammar accepts, a `{1 +}` in an attribute value template, a 3.0 text value template and a shadow attribute were validated by nothing at all, while the code-based linters — staged over the whole corpus — read those same expressions and reported what they found in them, with only `defect`'s parse gate keeping a fix off it (#589). What it keeps is what all eleven expression linters are staged over since #750, so a refusal reported here is the only defect that fault draws. A pattern illegal before XSLT 3.0 comes with it, which is #631: `matched` has refused one since #723 and had nobody to say so. The defect goes through `defect` in `src/checks.js` rather than being built by hand, so it stands at the offset the refusal carries instead of at the attribute's opening quote — which the widening makes necessary rather than merely nicer, two braces of one attribute value being two expressions that would otherwise report one column |
 | `src/linters/xpath-linter.js` | Loads `checks/xpath/*.yaml`; attaches any `src/fixers.js` fix, unless the node — or the element carrying it — holds an expression the grammar refuses (#651) |
 | `src/linters/corpus-linter.js` | Loads `checks/corpus/*.yaml`; cross-file rules |
 | `src/linters/*-linter.js` | Code-based `checks/format/*.yaml`, one construct each (axis, namespace, count, name, ...); see the flow diagram |
-| `src/checks.js` | Shared for code-based linters: `metaOf`, `suppressed`, `defect(check, meta, source, found, offset, fix)` — takes the expression whole, as `expressionsOf` yields it, and adds its `start` to the offset itself (#648); walks the raw text so a wrapped or entity-shifted value reports where it truly stands (#611), and drops the `fix` when the expression does not parse (#636). That walk is `rawly(source, found, offset)`, exported beside it, because a linter needs the raw offset as much as a defect does: an attribute value arrives with its line endings normalised to spaces, so a check reasoning about whitespace cannot see a wrap in the value it holds and has to ask the source (#628) |
+| `src/checks.js` | Shared for code-based linters: `metaOf`, `suppressed`, `defect(check, meta, source, found, offset, fix)` — takes the expression whole, as `expressionsOf` yields it, and adds its `start` to the offset itself (#648); walks the raw text so a wrapped or entity-shifted value reports where it truly stands (#611). It asks nothing about whether the expression parses: that gate stood here from #636 until #750 staged every code-based linter over the expressions the validator kept, which left it a condition no call could fail — a rule every caller has to remember is worse than a stage that cannot break it. That walk is `rawly(source, found, offset)`, exported beside it, because a linter needs the raw offset as much as a defect does: an attribute value arrives with its line endings normalised to spaces, so a check reasoning about whitespace cannot see a wrap in the value it holds and has to ask the source (#628) |
 | `src/source.js` | Raw-text walking shared by `checks` and `fixer`: `offsetAt`, `placeAt`, `character`, `skip` |
-| `src/attributes.js` | `expressionsOf(xsl)` — every expression a stylesheet carries: a bare/AVT attribute, a 3.0 text value template, or a shadow attribute, each saying whether it is a `pattern`; `PATTERNS` names the five attributes that hold one; `selectorOf(name)` for a linter that narrows, and `wholeOf(attribute)` to build the same record for the one it narrowed to |
+| `src/attributes.js` | `expressionsOf(xsl)` — every expression a stylesheet carries: a bare/AVT attribute, a 3.0 text value template, or a shadow attribute, each saying whether it is a `pattern`; `PATTERNS` names the five attributes that hold one; and `whole(found, name)` for a linter that narrows to one attribute out of the records it is handed. That helper replaced `selectorOf`, an XPath of this module's own over every XSLT element's attribute of a name, and `wholeOf`, which built a record from the node it selected — both of them the shape a linter needed while it scanned the corpus itself (#750). It asks two things in one call because a linter taking the name alone would read the `test="{boolean(x)}"` of a literal result element, which the old selector's namespace test excluded: an attribute's whole value is a record starting at `0`, and a template's expression never does, a brace standing at least one character in |
 | `src/xsl-version.js` | `versionOf(node)` — the version in force at a node, from the nearest ancestor's `@version` (XSLT element) or `@xsl:version` (literal result element), canonicalised as a decimal; `since(version, floor)` for a lower-bound gate; shared `MODERN`/`KNOWN`/`DECIMAL` |
 | `src/comparisons.js` | `comparedToZero` — shared scan for a call compared with `0`/`1` (count, string-length) |
 | `src/expressions.js` | `masked`/`closes` lexer helpers (node-set, double-negation, boolean-call); `enclosed` — the expressions an AVT holds in its braces. `masked` blanks every kind `OPAQUE` names, so a construct standing inside a string, a comment, or a literal that never closes is invisible to the six linters scanning above it. Beside them `lone` answers whether exactly one argument stands between a call's brackets, counting the commas at depth zero so a nested `count(f(a, b))` still reads as one. It reads the *tokens* and so takes the text as the source spells it rather than blanked, which both halves of the question need: a comma divides only as `TOKENS.COMMA`, so one inside a literal or a comment is a kind of its own and no separator, where a character walk had to be handed masked text; and a bracket holding only a literal is not an empty bracket, where masking turns `count('abc')` into a gap and no emptiness test can tell an absent argument from a blanked one — it did, and the three checks fell silent on `count('abc') = 0`, `boolean('abc')` and `not(not('abc'))`, which all three had reported. So a bracket is empty when nothing but `TRIVIA` stands in it. Where `lone` is still narrower than XPath is the binding clause, whose commas sit at depth zero inside one argument: `count(for $va in a, $vb in b return $va) = 0` goes unreported. The rule there is that a comma in front of `return` or `satisfies` binds while one behind it separates, which no bracket count can tell apart, so it waits for the tree at Phase 4 of #644 and is pinned meanwhile by `BINDINGS` in `test/expressions.test.js`, the way `GAPS` pins the grammar's own gaps. `fn:count`, `fn:not` and `fn:boolean` each take exactly one argument in every version, and the three checks reading them took whatever the brackets held as *the* argument without asking: `count()` is not a count of a node-set and `not(not())` is not a double negation, yet both were reported, and both carried a **safe**-tier fix that plain `--fix` applied — `empty()`, and for the two negation checks the empty string, so `test=""` was written and the next run reported the `invalid-xpath-expression` the last one had manufactured (#576). The parse gate in `defect` cannot supply this: it withholds a fix only where the engine refuses the expression, and fontoxpath's `compileXPathToJavaScript` resolves no signature, so every one of those calls is valid text to it. Nor can the engine be asked one call further — `evaluateXPath` does raise `XPST0017` statically, but against a registry that is not the XSLT one: 26 of 28 XSLT 3.0 functions and 14 of 29 XPath 3.1 ones are absent from it, `current()`, `key()` and `document()` among them, so a check reading that verdict would report the commonest calls in a 1.0 stylesheet as errors. Arity is per function, and each check knows its own by name |

--- a/README.md
+++ b/README.md
@@ -368,11 +368,13 @@ Checks whose correction needs real judgment (a fresh name, a more specific
 path) stay report-only. A run without `--fix` reports how many defects each
 option would fix.
 
-An expression xslint cannot parse is never rewritten. The other defects standing
-in it are still reported, with no correction offered — including the ones that
-would rewrite the attribute from the outside rather than the expression within
-it. A stylesheet whose real fault is a missing bracket comes back with that
-fault untouched, so fix the syntax and the corrections appear on the next run.
+An expression xslint cannot parse draws one defect, from the validator, and the
+checks that read expressions say nothing further about it: a stylesheet whose
+real fault is a missing bracket comes back with that fault and not with a page
+of advice about text no processor accepts. A rule that matches the attribute
+structurally rather than reading the expression can still report there, and is
+never offered a correction. Fix the syntax and the rest of the feedback appears
+on the next run.
 
 Where the expression sits no longer decides whether you are told why. A bare
 one — a `select`, a `test`, and the rest listed under
@@ -440,16 +442,17 @@ Linters:
   imported module.
 - **Formatting** checks read each XPath expression as a stream of tokens and
   flag stylistic noise — currently redundant whitespace (a doubled space, or a
-  space leading or trailing the expression). Only expressions that already
-  parse are checked, so a malformed one is reported once by the validator and
-  never nagged about its spacing.
+  space leading or trailing the expression).
 
 Every check that reads an expression reads it from an XPath or pattern attribute
 of an XSLT element (`select`, `test`, `match`, …) or from an attribute value
 template — `<div class="{count(item) = 0}"/>` is checked, and fixed, inside the
 braces. An attribute of your own output vocabulary that happens to share a name
 with an XSLT one, as in `<widget test="count(item) = 0"/>`, holds text destined
-for the result tree, so it is never read as XPath and never rewritten.
+for the result tree, so it is never read as XPath and never rewritten. And each
+of them is handed the expressions the validator kept, so a malformed one is
+reported once rather than nagged about its spacing, its axes and its
+`count(...)` calls on top of that.
 
 ## Programmatic use
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,7 +45,7 @@ const RESTRICTED = [
   {
     selector: "Literal[value=/\\/\\/@/]",
     message:
-      "Do not select attributes with a bare '//@name' XPath, which reads a literal result element as XPath; go through src/attributes.js (expressionsOf, selectorOf)"
+      "Do not select attributes with a bare '//@name' XPath, which reads a literal result element as XPath; a linter is handed the expressions the validator kept, and narrows one out of them with whole(found, name) from src/attributes.js"
   },
   {
     selector:
@@ -63,7 +63,7 @@ const RESTRICTED = [
     selector:
       "CallExpression[callee.name='defect'] MemberExpression[property.name='nodeValue']",
     message:
-      "Do not spell a node and its text as two arguments of defect (#648); hand it the {node, start, expression} record that expressionsOf yields, or wholeOf(attribute) for a narrowed one"
+      "Do not spell a node and its text as two arguments of defect (#648); hand it the {node, start, expression} record that expressionsOf yields"
   },
   {
     selector:

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -36,15 +36,25 @@ const PATTERNS = [
 ]
 
 /**
- * XPath selecting the named attribute of every XSLT element, document-wide. The
- * XSLT namespace belongs in the selector because only there does the name mean
- * an expression: an attribute the output vocabulary happens to call `test` or
- * `select` holds text destined for the result tree, not XPath.
- * @param {string} name - Name of the attribute
- * @return {string} - The Xpath selecting it
+ * Whether the expression is the whole value of an attribute of that name — the
+ * one narrowing a linter reading a single attribute needs, now that it is
+ * handed the records the validator kept rather than the corpus to scan itself
+ * (#750). It replaces an XPath of this module's own over the named attribute of
+ * every XSLT element, and asks one question where that selector asked two: the
+ * namespace test is gone rather than moved, since the derivation yields an XSLT
+ * element's attribute whole and every other one only through its braces. Both
+ * halves are one call rather than two conditions, because a linter taking the
+ * name alone would start reading the `test="{boolean(x)}"` of a literal result
+ * element, where stripping the wrapper prints the node instead of `true`. A
+ * brace stands at least one character inside a value, so an expression starting
+ * at `0` is the value itself. A shadow attribute keeps its underscore, so
+ * `_select` is not `select`, which is what the narrowing has always said.
+ * @param {{node: Node, start: number}} found - A record `expressionsOf` yielded
+ * @param {string} name - The name of the attribute a linter narrows to
+ * @return {boolean} - True when the expression is that attribute's whole value
  */
-const selectorOf = function(name) {
-  return `//xsl:*/@${name}`
+const whole = function(found, name) {
+  return found.start === 0 && found.node.nodeName === name
 }
 
 /**
@@ -148,11 +158,11 @@ const wholeOf = function(attribute) {
  * @return {Array.<{node: Node, start: number, expression: string}>} - Found
  */
 const carried = function(node, bare, three) {
-  const whole = node.nodeType === 2 &&
+  const entire = node.nodeType === 2 &&
     (bare.has(node) || (three && shadow(node)))
   const braced = node.nodeType === 2 || (three && expands(node))
   let taken = []
-  if (whole) {
+  if (entire) {
     taken = [wholeOf(node)]
   } else if (braced) {
     taken = enclosed(node.nodeValue).map((brace) => Object.freeze({
@@ -190,7 +200,6 @@ const expressionsOf = function(xsl) {
 module.exports = {
   ATTRIBUTES,
   PATTERNS,
-  selectorOf,
+  whole,
   expressionsOf,
-  wholeOf,
 }

--- a/src/checks.js
+++ b/src/checks.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {isValid} = require('./xpath')
 const {kinds} = require('./resources/checks.json')
 const {offsetAt, placeAt, skip} = require('./source')
 
@@ -74,6 +73,15 @@ const rawly = function(source, found, offset) {
  * silenced from within it — no comment fits there — so a directive has to reach
  * the whole way down from above the element. Omit `fix` for report-only.
  *
+ * A fix is offered on whatever it is given, with nothing here asking whether
+ * the expression parses. That question was answered here from #636 until #750,
+ * because a code-based linter took the whole corpus and read expressions the
+ * XPath validator had already refused — so `select="child::"` was reported and
+ * a safe fix wrote it to `select=""`. Every one of those linters is staged over
+ * the expressions the validator *kept* now, so a refused one reaches no check
+ * at all and the gate had become a condition no call could fail. A rule a
+ * caller has to remember is worse than a stage that cannot break it.
+ *
  * The expression arrives whole — the node carrying it, where it starts inside
  * that node's value, and its text — as `src/attributes.js` yields it, rather
  * than as a node and a string a caller pairs up itself. Two things came of the
@@ -90,8 +98,7 @@ const rawly = function(source, found, offset) {
  * @param {{node: Node, start: number, expression: string, pattern: boolean}}
  *  found - The expression the defect stands in: its attribute, text or CDATA
  *  node, where it starts in that node's value, its own text, and whether it is
- *  a pattern. The whole record decides whether a fix may be offered, since the
- *  language it is read as and the version it is read under are both on it
+ *  a pattern
  * @param {number} offset - Offset of the defect within the expression
  * @param {?{value: string, replacement: string, suggestion?: boolean}} [fix] -
  *  The fix, or undefined for a report-only defect
@@ -103,7 +110,7 @@ const defect = function(
   const {node} = found
   const {line, pos} = placeAt(source.content, rawly(source, found, offset))
   let anchored = {}
-  if (fix !== undefined && isValid(found)) {
+  if (fix !== undefined) {
     anchored = {fix: {line: line, col: pos, ...fix}}
   }
   return {

--- a/src/comparisons.js
+++ b/src/comparisons.js
@@ -65,9 +65,6 @@ const comparedToZero = function(expression, name, decide) {
     const start = match.index + match[1].length
     const open = match.index + match[0].length - 1
     const close = closes(blanked, open)
-    if (close < 0) {
-      continue
-    }
     const argument = expression.slice(open + 1, close)
     const inner = blanked.slice(open + 1, close)
     const tail = TAIL.exec(blanked.slice(close + 1))

--- a/src/linters/count-linter.js
+++ b/src/linters/count-linter.js
@@ -6,7 +6,6 @@
 const {comparedToZero} = require('../comparisons')
 const {lone} = require('../expressions')
 const {metaOf, suppressed, defect} = require('../checks')
-const {expressionsOf} = require('../attributes')
 const {MODERN, since, versionOf} = require('../xsl-version')
 const {logger} = require('../logger')
 
@@ -103,33 +102,33 @@ const comparisons = function(expression) {
 }
 
 /**
- * Lint the corpus for `count(...)` compared with zero to test existence,
- * reporting one defect per comparison with a safe fix — `exists()`/`empty()` on
- * XSLT 2.0/3.0, and the 1.0-and-later `boolean(x)`/bare `x`/`not(x)` forms
- * otherwise, so the fix is version-appropriate on every stylesheet.
- * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
+ * Lint the valid expressions for `count(...)` compared with zero to test
+ * existence, reporting one defect per comparison with a safe fix —
+ * `exists()`/`empty()` on XSLT 2.0/3.0, and the 1.0-and-later `boolean(x)`/bare
+ * `x`/`not(x)` forms otherwise, so the fix is version-appropriate on every
+ * stylesheet.
+ * @param {Array.<{source: object, found: object}>} expressions - The valid
+ *  expressions the validator kept, each paired with the file it came from
  * @param {Array.<string>} suppressions - Array of suppressed checks
  * @return {{name: string, severity: string, message: string, file: string,
  *  line: number, pos: number, fix: object}[]} - Defects found
  */
-const lintByCount = function(corpus, suppressions = []) {
+const lintByCount = function(expressions, suppressions = []) {
   logger.debug(`Count-comparison linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const source of corpus) {
-      for (const found of expressionsOf(source.xsl)) {
-        const {node, expression} = found
-        const modern = since(versionOf(node), MODERN)
-        for (const {offset, value, test, argument} of comparisons(expression)) {
-          const whole = node.nodeName === 'test' &&
-            node.nodeValue.trim() === value
-          defects.push(
-            defect(CHECK, META, source, found, offset, {
-              value: value,
-              replacement: rewritten(test, argument, modern, whole),
-            }),
-          )
-        }
+    for (const {source, found} of expressions) {
+      const {node, expression} = found
+      const modern = since(versionOf(node), MODERN)
+      for (const {offset, value, test, argument} of comparisons(expression)) {
+        const whole = node.nodeName === 'test' &&
+          node.nodeValue.trim() === value
+        defects.push(
+          defect(CHECK, META, source, found, offset, {
+            value: value,
+            replacement: rewritten(test, argument, modern, whole),
+          }),
+        )
       }
     }
   }

--- a/src/linters/name-linter.js
+++ b/src/linters/name-linter.js
@@ -6,7 +6,6 @@
 const {masked, closes} = require('../expressions')
 const {GAP} = require('../tokens')
 const {metaOf, suppressed, defect} = require('../checks')
-const {expressionsOf} = require('../attributes')
 const {MODERN, since, versionOf} = require('../xsl-version')
 const {logger} = require('../logger')
 
@@ -98,9 +97,6 @@ const comparisons = function(expression, modern) {
     const start = match.index + match[1].length
     const open = match.index + match[0].length - 1
     const close = closes(blanked, open)
-    if (close < 0) {
-      continue
-    }
     const argument = expression.slice(open + 1, close).trim()
     if (argument !== '' && argument !== '.') {
       continue
@@ -128,33 +124,32 @@ const comparisons = function(expression, modern) {
 }
 
 /**
- * Lint the corpus for `name()`/`local-name()` compared with a string literal,
- * reporting one defect per comparison with the fix that turns it into a node
- * test when one can be built.
- * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
+ * Lint the valid expressions for `name()`/`local-name()` compared with a string
+ * literal, reporting one defect per comparison with the fix that turns it into
+ * a node test when one can be built.
+ * @param {Array.<{source: object, found: object}>} expressions - The valid
+ *  expressions the validator kept, each paired with the file it came from
  * @param {Array.<string>} suppressions - Array of suppressed checks
  * @return {{name: string, severity: string, message: string, file: string,
  *  line: number, pos: number, fix: ?object}[]} - Defects found
  */
-const lintByName = function(corpus, suppressions = []) {
+const lintByName = function(expressions, suppressions = []) {
   logger.debug(`Name-comparison linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const source of corpus) {
-      for (const found of expressionsOf(source.xsl)) {
-        const {node, expression} = found
-        const modern = since(versionOf(node), MODERN)
-        for (const {offset, value, replacement} of comparisons(
-          expression, modern,
-        )) {
-          let fix
-          if (replacement !== null) {
-            fix = {value, replacement, suggestion: true}
-          }
-          defects.push(
-            defect(CHECK, META, source, found, offset, fix),
-          )
+    for (const {source, found} of expressions) {
+      const {node, expression} = found
+      const modern = since(versionOf(node), MODERN)
+      for (const {offset, value, replacement} of comparisons(
+        expression, modern,
+      )) {
+        let fix
+        if (replacement !== null) {
+          fix = {value, replacement, suggestion: true}
         }
+        defects.push(
+          defect(CHECK, META, source, found, offset, fix),
+        )
       }
     }
   }

--- a/src/linters/node-set-linter.js
+++ b/src/linters/node-set-linter.js
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes} = require('../xpath')
 const {masked, closes} = require('../expressions')
 const {GAP} = require('../tokens')
 const {metaOf, suppressed, defect} = require('../checks')
-const {selectorOf, wholeOf} = require('../attributes')
+const {whole} = require('../attributes')
 const {MODERN, since, versionOf} = require('../xsl-version')
 const {logger} = require('../logger')
 
@@ -61,34 +60,31 @@ const wrappers = function(select) {
 }
 
 /**
- * Lint the corpus for the `node-set()` extension used in XSLT 2.0 or 3.0, where
- * a variable is already a node sequence, reporting one defect per call with the
- * fix that unwraps it. Only the `@select` of an XSLT element is read: the
- * `select` a literal result element carries is output text, and a call standing
- * in another expression attribute, or inside an attribute value template, is
- * not looked for.
- * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
+ * Lint the valid expressions for the `node-set()` extension used in XSLT 2.0 or
+ * 3.0, where a variable is already a node sequence, reporting one defect per
+ * call with the fix that unwraps it. Only the `@select` of an XSLT element is
+ * read: the `select` a literal result element carries is output text, and a
+ * call standing in another expression attribute, or inside an attribute value
+ * template, is not looked for.
+ * @param {Array.<{source: object, found: object}>} expressions - The valid
+ *  expressions the validator kept, each paired with the file it came from
  * @param {Array.<string>} suppressions - Array of suppressed checks
  * @return {{name: string, severity: string, message: string, file: string,
  *  line: number, pos: number, fix: object}[]} - Defects found
  */
-const lintByNodeSet = function(corpus, suppressions = []) {
+const lintByNodeSet = function(expressions, suppressions = []) {
   logger.debug(`Node-set linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const source of corpus) {
-      for (const attribute of nodes(source.xsl, selectorOf('select'))) {
-        if (since(versionOf(attribute), MODERN)) {
-          for (const {offset, value, replacement} of wrappers(
-            attribute.nodeValue,
-          )) {
-            defects.push(
-              defect(
-                CHECK, META, source, wholeOf(attribute), offset,
-                {value, replacement},
-              ),
-            )
-          }
+    for (const {source, found} of expressions) {
+      if (whole(found, 'select') && since(versionOf(found.node), MODERN)) {
+        for (const {offset, value, replacement} of wrappers(found.expression)) {
+          defects.push(
+            defect(
+              CHECK, META, source, found, offset,
+              {value, replacement},
+            ),
+          )
         }
       }
     }

--- a/src/linters/predicate-position-linter.js
+++ b/src/linters/predicate-position-linter.js
@@ -5,7 +5,6 @@
 
 const {tokenized, TOKENS, TRIVIA} = require('../tokens')
 const {metaOf, suppressed, defect} = require('../checks')
-const {expressionsOf} = require('../attributes')
 const {logger} = require('../logger')
 
 /**
@@ -115,29 +114,28 @@ const literals = function(expression) {
 }
 
 /**
- * Lint the corpus for a positional predicate written the long way, reporting
- * one defect per occurrence with a safe fix that rewrites the predicate to its
- * numeric or `last()` short form.
- * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
+ * Lint the valid expressions for a positional predicate written the long way,
+ * reporting one defect per occurrence with a safe fix that rewrites the
+ * predicate to its numeric or `last()` short form.
+ * @param {Array.<{source: object, found: object}>} expressions - The valid
+ *  expressions the validator kept, each paired with the file it came from
  * @param {Array.<string>} suppressions - Array of suppressed checks
  * @return {{name: string, severity: string, message: string, file: string,
  *  line: number, pos: number, fix: object}[]} - Defects found
  */
-const lintByPredicatePosition = function(corpus, suppressions = []) {
+const lintByPredicatePosition = function(expressions, suppressions = []) {
   logger.debug(`Predicate-position linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const source of corpus) {
-      for (const found of expressionsOf(source.xsl)) {
-        const {expression} = found
-        for (const {offset, value, replacement} of literals(expression)) {
-          defects.push(
-            defect(
-              CHECK, META, source, found, offset,
-              {value, replacement},
-            ),
-          )
-        }
+    for (const {source, found} of expressions) {
+      const {expression} = found
+      for (const {offset, value, replacement} of literals(expression)) {
+        defects.push(
+          defect(
+            CHECK, META, source, found, offset,
+            {value, replacement},
+          ),
+        )
       }
     }
   }

--- a/src/linters/redundant-boolean-call-linter.js
+++ b/src/linters/redundant-boolean-call-linter.js
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {nodes} = require('../xpath')
 const {masked, closes, lone} = require('../expressions')
 const {GAP} = require('../tokens')
 const {metaOf, suppressed, defect} = require('../checks')
-const {selectorOf, wholeOf} = require('../attributes')
+const {whole} = require('../attributes')
 const {logger} = require('../logger')
 
 /**
@@ -70,28 +69,29 @@ const stripped = function(test) {
 }
 
 /**
- * Lint the corpus for a whole `@test` of an XSLT element that is a single
- * `boolean(...)` call, reporting one defect per test with the safe fix that
- * strips the wrapper. Nothing outside such a test coerces the value, so neither
- * a literal result element's `test` — output text — nor the expression of an
- * attribute value template, where the wrapper decides whether `true`/`false` or
- * the node's own text is printed, is read.
- * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
+ * Lint the valid expressions for a whole `@test` of an XSLT element that is a
+ * single `boolean(...)` call, reporting one defect per test with the safe fix
+ * that strips the wrapper. Nothing outside such a test coerces the value, so
+ * neither a literal result element's `test` — output text — nor the expression
+ * of an attribute value template, where the wrapper decides whether
+ * `true`/`false` or the node's own text is printed, is read.
+ * @param {Array.<{source: object, found: object}>} expressions - The valid
+ *  expressions the validator kept, each paired with the file it came from
  * @param {Array.<string>} suppressions - Array of suppressed checks
  * @return {{name: string, severity: string, message: string, file: string,
  *  line: number, pos: number, fix: object}[]} - Defects found
  */
-const lintByBooleanCall = function(corpus, suppressions = []) {
+const lintByBooleanCall = function(expressions, suppressions = []) {
   logger.debug(`Boolean-call linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const source of corpus) {
-      for (const attribute of nodes(source.xsl, selectorOf('test'))) {
-        const strip = stripped(attribute.nodeValue)
+    for (const {source, found} of expressions) {
+      if (whole(found, 'test')) {
+        const strip = stripped(found.expression)
         if (strip) {
           defects.push(
             defect(
-              CHECK, META, source, wholeOf(attribute), strip.offset,
+              CHECK, META, source, found, strip.offset,
               {value: strip.value, replacement: strip.replacement},
             ),
           )

--- a/src/linters/redundant-double-negation-linter.js
+++ b/src/linters/redundant-double-negation-linter.js
@@ -6,7 +6,6 @@
 const {masked, closes, lone} = require('../expressions')
 const {GAP} = require('../tokens')
 const {metaOf, suppressed, defect} = require('../checks')
-const {expressionsOf} = require('../attributes')
 const {logger} = require('../logger')
 
 /**
@@ -60,9 +59,6 @@ const negations = function(expression) {
     const start = match.index + match[1].length
     const open = match.index + match[0].length - 1
     const close = closes(blanked, open)
-    if (close < 0) {
-      continue
-    }
     const inner = INNER.exec(blanked.slice(open + 1, close))
     if (!inner) {
       continue
@@ -83,36 +79,36 @@ const negations = function(expression) {
 }
 
 /**
- * Lint the corpus for `not(not(x))`, a redundant double negation, reporting one
- * defect per occurrence with a safe fix: bare `x` when the double negation is a
- * whole `@test` (which already coerces to a boolean), and `boolean(x)`
- * everywhere else, where the boolean value itself is what is wanted.
- * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
+ * Lint the valid expressions for `not(not(x))`, a redundant double negation,
+ * reporting one defect per occurrence with a safe fix: bare `x` when the double
+ * negation is a whole `@test` (which already coerces to a boolean), and
+ * `boolean(x)` everywhere else, where the boolean value itself is what is
+ * wanted.
+ * @param {Array.<{source: object, found: object}>} expressions - The valid
+ *  expressions the validator kept, each paired with the file it came from
  * @param {Array.<string>} suppressions - Array of suppressed checks
  * @return {{name: string, severity: string, message: string, file: string,
  *  line: number, pos: number, fix: object}[]} - Defects found
  */
-const lintByDoubleNegation = function(corpus, suppressions = []) {
+const lintByDoubleNegation = function(expressions, suppressions = []) {
   logger.debug(`Double-negation linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const source of corpus) {
-      for (const found of expressionsOf(source.xsl)) {
-        const {node, expression} = found
-        for (const {offset, value, argument} of negations(expression)) {
-          const bare = node.nodeName === 'test' &&
-            node.nodeValue.trim() === value
-          let replacement = `boolean(${argument})`
-          if (bare) {
-            replacement = argument
-          }
-          defects.push(
-            defect(CHECK, META, source, found, offset, {
-              value: value,
-              replacement: replacement,
-            }),
-          )
+    for (const {source, found} of expressions) {
+      const {node, expression} = found
+      for (const {offset, value, argument} of negations(expression)) {
+        const bare = node.nodeName === 'test' &&
+          node.nodeValue.trim() === value
+        let replacement = `boolean(${argument})`
+        if (bare) {
+          replacement = argument
         }
+        defects.push(
+          defect(CHECK, META, source, found, offset, {
+            value: value,
+            replacement: replacement,
+          }),
+        )
       }
     }
   }

--- a/src/linters/string-length-linter.js
+++ b/src/linters/string-length-linter.js
@@ -5,7 +5,6 @@
 
 const {comparedToZero} = require('../comparisons')
 const {metaOf, suppressed, defect} = require('../checks')
-const {expressionsOf} = require('../attributes')
 const {logger} = require('../logger')
 
 /**
@@ -107,34 +106,34 @@ const comparisons = function(expression) {
 }
 
 /**
- * Lint the corpus for `string-length(...)` compared with zero to test
- * emptiness, reporting one defect per comparison with a *suggestion* fix that
- * rewrites it to `X != ''` or `X = ''` when the argument is a simple operand.
- * It is a suggestion, not a safe fix, because `X op ''` is not a general
- * equivalent: they differ when `X` is an absent attribute or empty node-set
- * (`string-length(@x) = 0` is true, `@x = ''` is false) and when `X` is a
- * multi-node set (`string-length` reads the first node, `X != ''` any node).
- * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
+ * Lint the valid expressions for `string-length(...)` compared with zero to
+ * test emptiness, reporting one defect per comparison with a *suggestion* fix
+ * that rewrites it to `X != ''` or `X = ''` when the argument is a simple
+ * operand. It is a suggestion, not a safe fix, because `X op ''` is not a
+ * general equivalent: they differ when `X` is an absent attribute or empty
+ * node-set (`string-length(@x) = 0` is true, `@x = ''` is false) and when `X`
+ * is a multi-node set (`string-length` reads the first node, `X != ''` any
+ * node).
+ * @param {Array.<{source: object, found: object}>} expressions - The valid
+ *  expressions the validator kept, each paired with the file it came from
  * @param {Array.<string>} suppressions - Array of suppressed checks
  * @return {{name: string, severity: string, message: string, file: string,
  *  line: number, pos: number, fix: ?object}[]} - Defects found
  */
-const lintByStringLength = function(corpus, suppressions = []) {
+const lintByStringLength = function(expressions, suppressions = []) {
   logger.debug(`String-length-comparison linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const source of corpus) {
-      for (const found of expressionsOf(source.xsl)) {
-        const {expression} = found
-        for (const {offset, value, replacement} of comparisons(expression)) {
-          let fix
-          if (replacement !== null) {
-            fix = {value, replacement, suggestion: true}
-          }
-          defects.push(
-            defect(CHECK, META, source, found, offset, fix),
-          )
+    for (const {source, found} of expressions) {
+      const {expression} = found
+      for (const {offset, value, replacement} of comparisons(expression)) {
+        let fix
+        if (replacement !== null) {
+          fix = {value, replacement, suggestion: true}
         }
+        defects.push(
+          defect(CHECK, META, source, found, offset, fix),
+        )
       }
     }
   }

--- a/src/linters/translate-linter.js
+++ b/src/linters/translate-linter.js
@@ -6,7 +6,6 @@
 const {masked, closes} = require('../expressions')
 const {GAP} = require('../tokens')
 const {metaOf, suppressed, defect} = require('../checks')
-const {expressionsOf} = require('../attributes')
 const {MODERN, since, versionOf} = require('../xsl-version')
 const {logger} = require('../logger')
 
@@ -113,9 +112,6 @@ const folded = function(expression) {
     const start = match.index + match[1].length
     const open = match.index + match[0].length - 1
     const close = closes(blanked, open)
-    if (close < 0) {
-      continue
-    }
     const parts = args(expression, blanked, open + 1, close)
     if (parts.length !== 3) {
       continue
@@ -134,29 +130,28 @@ const folded = function(expression) {
 }
 
 /**
- * Lint the corpus for `translate(x, 'A..Z', 'a..z')` case folding in an XSLT
- * 2.0 or 3.0 stylesheet, reporting one defect per call with a suggestion fix
- * that rewrites it to `lower-case(x)`/`upper-case(x)`.
- * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
+ * Lint the valid expressions for `translate(x, 'A..Z', 'a..z')` case folding in
+ * an XSLT 2.0 or 3.0 stylesheet, reporting one defect per call with a
+ * suggestion fix that rewrites it to `lower-case(x)`/`upper-case(x)`.
+ * @param {Array.<{source: object, found: object}>} expressions - The valid
+ *  expressions the validator kept, each paired with the file it came from
  * @param {Array.<string>} suppressions - Array of suppressed checks
  * @return {{name: string, severity: string, message: string, file: string,
  *  line: number, pos: number, fix: object}[]} - Defects found
  */
-const lintByTranslate = function(corpus, suppressions = []) {
+const lintByTranslate = function(expressions, suppressions = []) {
   logger.debug(`Translate-case linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const source of corpus) {
-      for (const found of expressionsOf(source.xsl)) {
-        const {node, expression} = found
-        if (since(versionOf(node), MODERN)) {
-          for (const {offset, value, replacement} of folded(expression)) {
-            defects.push(
-              defect(CHECK, META, source, found, offset,
-                {value, replacement, suggestion: true},
-              ),
-            )
-          }
+    for (const {source, found} of expressions) {
+      const {node, expression} = found
+      if (since(versionOf(node), MODERN)) {
+        for (const {offset, value, replacement} of folded(expression)) {
+          defects.push(
+            defect(CHECK, META, source, found, offset,
+              {value, replacement, suggestion: true},
+            ),
+          )
         }
       }
     }

--- a/src/linters/using-namespace-axis-linter.js
+++ b/src/linters/using-namespace-axis-linter.js
@@ -5,7 +5,6 @@
 
 const {tokenized, TOKENS} = require('../tokens')
 const {metaOf, suppressed, defect} = require('../checks')
-const {expressionsOf} = require('../attributes')
 const {MODERN, since, versionOf} = require('../xsl-version')
 const {logger} = require('../logger')
 
@@ -41,28 +40,27 @@ const axes = function(expression) {
 }
 
 /**
- * Lint the corpus for the deprecated namespace:: axis in any XPath or pattern
- * attribute of an XSLT 2.0 or 3.0 stylesheet, reporting one defect per
- * occurrence. The fix is a structural rewrite to in-scope-prefixes() and
+ * Lint the valid expressions for the deprecated namespace:: axis in any XPath
+ * or pattern attribute of an XSLT 2.0 or 3.0 stylesheet, reporting one defect
+ * per occurrence. The fix is a structural rewrite to in-scope-prefixes() and
  * namespace-uri-for-prefix(), so the defect is report-only.
- * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
+ * @param {Array.<{source: object, found: object}>} expressions - The valid
+ *  expressions the validator kept, each paired with the file it came from
  * @param {Array.<string>} suppressions - Array of suppressed checks
  * @return {{name: string, severity: string, message: string, file: string,
  *  line: number, pos: number}[]} - Defects found
  */
-const lintByNamespaceAxis = function(corpus, suppressions = []) {
+const lintByNamespaceAxis = function(expressions, suppressions = []) {
   logger.debug(`Namespace axis linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const source of corpus) {
-      for (const found of expressionsOf(source.xsl)) {
-        const {node, expression} = found
-        if (since(versionOf(node), MODERN)) {
-          for (const offset of axes(expression)) {
-            defects.push(
-              defect(CHECK, META, source, found, offset),
-            )
-          }
+    for (const {source, found} of expressions) {
+      const {node, expression} = found
+      if (since(versionOf(node), MODERN)) {
+        for (const offset of axes(expression)) {
+          defects.push(
+            defect(CHECK, META, source, found, offset),
+          )
         }
       }
     }

--- a/src/linters/xpath-axis-linter.js
+++ b/src/linters/xpath-axis-linter.js
@@ -5,7 +5,6 @@
 
 const {tokenized, TOKENS} = require('../tokens')
 const {metaOf, suppressed, defect} = require('../checks')
-const {expressionsOf} = require('../attributes')
 const {MODERN, since, versionOf} = require('../xsl-version')
 const {logger} = require('../logger')
 
@@ -166,29 +165,28 @@ const abbreviable = function(expression, modern, pattern) {
 }
 
 /**
- * Lint the corpus for axis specifiers that have a shorter form, reporting one
- * defect per occurrence with the fix that abbreviates it.
- * @param {Array.<{file: string, xsl: Document}>} corpus - Parsed stylesheets
+ * Lint the valid expressions for axis specifiers that have a shorter form,
+ * reporting one defect per occurrence with the fix that abbreviates it.
+ * @param {Array.<{source: object, found: object}>} expressions - The valid
+ *  expressions the validator kept, each paired with the file it came from
  * @param {Array.<string>} suppressions - Array of suppressed checks
  * @return {{name: string, severity: string, message: string, file: string,
  *  line: number, pos: number, fix: object}[]} - Defects found
  */
-const lintByAxis = function(corpus, suppressions = []) {
+const lintByAxis = function(expressions, suppressions = []) {
   logger.debug(`Axis linting started`)
   const defects = []
   if (!suppressed(CHECK, suppressions)) {
-    for (const source of corpus) {
-      for (const found of expressionsOf(source.xsl)) {
-        const {node, expression} = found
-        for (const {offset, fix} of abbreviable(
-          expression, since(versionOf(node), MODERN), found.pattern,
-        )) {
-          defects.push(
-            defect(
-              CHECK, META, source, found, offset, fix,
-            ),
-          )
-        }
+    for (const {source, found} of expressions) {
+      const {node, expression} = found
+      for (const {offset, fix} of abbreviable(
+        expression, since(versionOf(node), MODERN), found.pattern,
+      )) {
+        defects.push(
+          defect(
+            CHECK, META, source, found, offset, fix,
+          ),
+        )
       }
     }
   }

--- a/src/validators/xpath-validator.js
+++ b/src/validators/xpath-validator.js
@@ -50,10 +50,12 @@ const UNRESOLVED = /&[A-Za-z_][\w.-]*;/
  * the walk reached 286, so a `match` no grammar accepts, an attribute value
  * template holding `{1 +}`, and a 3.0 text value template were each validated
  * by nothing at all — while a code-based linter, staged over the whole corpus,
- * read those same expressions and reported what it found in them. Only
- * `defect`'s parse gate kept a fix off that (#636). A pattern illegal before
- * XSLT 3.0 is reported with them, which is #631: `matched` has refused one
- * since #723 and had nobody to say so.
+ * read those same expressions and reported what it found in them, with only
+ * `defect`'s parse gate keeping a fix off it (#636). What this hands on is what
+ * every one of those linters is staged over since #750, so the gate is gone and
+ * a fault the report already names draws no second defect. A pattern illegal
+ * before XSLT 3.0 is reported with them, which is #631: `matched` has refused
+ * one since #723 and had nobody to say so.
  *
  * The defect stands where the fault does, not where the attribute opens, which
  * is what the offset on the refusal is for — and what the widening makes

--- a/src/xpath.js
+++ b/src/xpath.js
@@ -174,7 +174,7 @@ const ASSUMED = KNOWN[KNOWN.length - 1]
  * The offset is what a report needs, and having it is what lets the validator
  * point at the fault rather than at the attribute holding it (#589).
  * @param {{node: Node, expression: string, pattern: boolean}} found - The
- *  expression, whole, as `expressionsOf` and `wholeOf` yield it
+ *  expression, whole, as `expressionsOf` yields it
  * @return {{fault: string, at: number}} - What the grammar expected, and where
  *  in the expression it wanted it
  */
@@ -196,11 +196,13 @@ const refusalOf = function(found) {
 
 /**
  * Whether an expression is syntactically valid — `refusalOf` with nothing to
- * complain about. Most callers want the verdict alone: a fix is withheld on a
- * defect standing in text no processor parses (#636, #651), and neither gate
- * has anywhere to say why.
+ * complain about. One caller wants the verdict alone: a declarative fix is
+ * withheld on an attribute whose expression no processor parses (#651), and
+ * that gate has nowhere to say why. The other gate of that pair was in
+ * `defect`, and #750 deleted it — a code-based check is handed the expressions
+ * the validator kept, so it never reads a refused one to begin with.
  * @param {{node: Node, expression: string, pattern: boolean}} found - The
- *  expression, whole, as `expressionsOf` and `wholeOf` yield it
+ *  expression, whole, as `expressionsOf` yields it
  * @return {boolean} - True when the expression parses
  */
 const isValid = function(found) {

--- a/src/xslint.js
+++ b/src/xslint.js
@@ -47,17 +47,34 @@ const {minimatch} = require('minimatch')
 /**
  * Linters paired with the checks they own, each given the corpus of well-formed
  * stylesheets. `checks` feeds `CHECKS`, so a linter and its names stay in step.
+ * What is left here reads the document rather than the expressions it carries:
+ * the two declarative loaders, which run their selectors over it, and the three
+ * that ask about namespaces and imports.
  * @type {Array.<{run: function(Array.<{file: string, xsl: Document}>,
  *  Array.<string>): Array.<object>, checks: Array.<string>}>}
  */
 const LINTERS = [
   {run: lintByXpath, checks: xpathChecks},
   {run: lintByCorpus, checks: corpusChecks},
-  {run: lintByAxis, checks: axisChecks},
-  {run: lintByNamespaceAxis, checks: namespaceAxisChecks},
   {run: lintByNamespace, checks: namespaceChecks},
   {run: lintByResultNamespace, checks: resultNamespaceChecks},
   {run: lintByImports, checks: importChecks},
+]
+
+/**
+ * Expression linters paired with their checks, each given the valid expressions
+ * the validator kept, so a fault the validator has already reported draws one
+ * defect rather than a second one from every check that reads the same text
+ * (#750). Ten of them scanned the whole corpus and asked `expressionsOf`
+ * themselves, with `defect` withholding the fix on what the grammar refuses;
+ * the exclusion is structural now, and there is no gate for a new check to
+ * remember.
+ * @type {Array.<{run: function(Array.<{source: object, found: object}>,
+ *  Array.<string>): Array.<object>, checks: Array.<string>}>}
+ */
+const EXPRESSION_LINTERS = [
+  {run: lintByAxis, checks: axisChecks},
+  {run: lintByNamespaceAxis, checks: namespaceAxisChecks},
   {run: lintByNodeSet, checks: nodeSetChecks},
   {run: lintByCount, checks: countChecks},
   {run: lintByStringLength, checks: stringLengthChecks},
@@ -66,15 +83,6 @@ const LINTERS = [
   {run: lintByDoubleNegation, checks: doubleNegationChecks},
   {run: lintByBooleanCall, checks: booleanCallChecks},
   {run: lintByPredicatePosition, checks: predicatePositionChecks},
-]
-
-/**
- * Expression linters paired with their checks, each given the valid Xpath
- * expressions the validator kept so they never reason over malformed input.
- * @type {Array.<{run: function(Array.<{source: object, attribute: Node}>,
- *  Array.<string>): Array.<object>, checks: Array.<string>}>}
- */
-const EXPRESSION_LINTERS = [
   {run: lintByFormat, checks: formatChecks},
 ]
 

--- a/test/attributes.test.js
+++ b/test/attributes.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {expressionsOf, wholeOf} = require('../src/attributes')
+const {expressionsOf, whole} = require('../src/attributes')
 const {xml} = require('../src/helpers')
 const path = require('path')
 const fs = require('fs')
@@ -52,12 +52,16 @@ describe('attributes', function() {
       'cannot read the expressions of the stylesheet',
     )
   })
-  it('reads a narrowed attribute as the walk reads the same one', function() {
-    const whole = expressionsOf(SHEET).find((found) => found.start === 0)
-    assert.deepEqual(
-      wholeOf(whole.node),
-      whole,
-      'builds a different record for an attribute a linter narrowed to',
+  it('narrows to the whole value of an attribute of that name', function() {
+    assert.ok(
+      expressionsOf(SHEET).some((found) => whole(found, 'select')),
+      'cannot narrow to the select a linter reads alone',
+    )
+  })
+  it('cannot narrow to an expression a template encloses', function() {
+    assert.ok(
+      expressionsOf(SHEET).every((found) => !whole(found, 'label')),
+      'narrows to a template of the result tree as if it were an attribute',
     )
   })
   it('cannot read a literal result attribute as an expression', function() {

--- a/test/count-linter.test.js
+++ b/test/count-linter.test.js
@@ -4,6 +4,7 @@
  */
 
 const {lintByCount} = require('../src/linters/count-linter')
+const {validate} = require('../src/validators/xpath-validator')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')
@@ -22,7 +23,8 @@ describe('count-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} count comparisons`, function() {
-        const defects = lintByCount([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const {expressions} = validate([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const defects = lintByCount(expressions)
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/lint.test.js
+++ b/test/lint.test.js
@@ -52,21 +52,18 @@ describe('lint (programmatic API)', function() {
     const sources = [source('stylesheets/xsl-with-no-violations.xsl')]
     assert.equal(fixed(sources, lint(sources)).contents.size, 0)
   })
-  it('offers no fix on the refused axis or the refused comparison', function() {
-    assert.deepEqual(
-      lint([source('refused/refused-expressions.xsl')])
-        .filter((defect) => [9, 10].includes(defect.line) && defect.fix)
-        .map((defect) => `${defect.name} at ${defect.line}:${defect.pos}`),
-      [],
-    )
-  })
-  it('still reports the verbose axis it refused to shorten', function() {
-    assert.ok(
-      lint([source('refused/refused-expressions.xsl')]).some(
-        (defect) => defect.name === 'unabbreviated-axis' && defect.line === 9,
-      ),
-    )
-  })
+  it('draws one defect on the refused axis and the refused comparison',
+    function() {
+      assert.deepEqual(
+        lint([source('refused/refused-expressions.xsl')])
+          .filter((defect) => [9, 10].includes(defect.line))
+          .map((defect) => `${defect.name} at ${defect.line}:${defect.pos}`),
+        [
+          'invalid-xpath-expression at 9:34',
+          'invalid-xpath-expression at 10:36',
+        ],
+      )
+    })
   it('keeps the fix on the two valid axes beside the refused ones', function() {
     assert.deepEqual(
       lint([source('refused/refused-expressions.xsl')])

--- a/test/name-linter.test.js
+++ b/test/name-linter.test.js
@@ -4,6 +4,7 @@
  */
 
 const {lintByName} = require('../src/linters/name-linter')
+const {validate} = require('../src/validators/xpath-validator')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')
@@ -22,7 +23,8 @@ describe('name-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} name comparisons`, function() {
-        const defects = lintByName([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const {expressions} = validate([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const defects = lintByName(expressions)
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/node-set-linter.test.js
+++ b/test/node-set-linter.test.js
@@ -4,6 +4,7 @@
  */
 
 const {lintByNodeSet} = require('../src/linters/node-set-linter')
+const {validate} = require('../src/validators/xpath-validator')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')
@@ -22,7 +23,8 @@ describe('node-set-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} node-set extensions`, function() {
-        const defects = lintByNodeSet([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const {expressions} = validate([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const defects = lintByNodeSet(expressions)
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/predicate-position-linter.test.js
+++ b/test/predicate-position-linter.test.js
@@ -4,6 +4,7 @@
  */
 
 const {lintByPredicatePosition} = require('../src/linters/predicate-position-linter')
+const {validate} = require('../src/validators/xpath-validator')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')
@@ -22,7 +23,8 @@ describe('predicate-position-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} positional predicates`, function() {
-        const defects = lintByPredicatePosition([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const {expressions} = validate([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const defects = lintByPredicatePosition(expressions)
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/redundant-boolean-call-linter.test.js
+++ b/test/redundant-boolean-call-linter.test.js
@@ -4,6 +4,7 @@
  */
 
 const {lintByBooleanCall} = require('../src/linters/redundant-boolean-call-linter')
+const {validate} = require('../src/validators/xpath-validator')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')
@@ -22,7 +23,8 @@ describe('redundant-boolean-call-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} redundant boolean calls`, function() {
-        const defects = lintByBooleanCall([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const {expressions} = validate([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const defects = lintByBooleanCall(expressions)
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/redundant-double-negation-linter.test.js
+++ b/test/redundant-double-negation-linter.test.js
@@ -4,6 +4,7 @@
  */
 
 const {lintByDoubleNegation} = require('../src/linters/redundant-double-negation-linter')
+const {validate} = require('../src/validators/xpath-validator')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')
@@ -22,7 +23,8 @@ describe('redundant-double-negation-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} double negations`, function() {
-        const defects = lintByDoubleNegation([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const {expressions} = validate([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const defects = lintByDoubleNegation(expressions)
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/resources/node-set-packs/node-set-in-result-attribute.yaml
+++ b/test/resources/node-set-packs/node-set-in-result-attribute.yaml
@@ -11,5 +11,6 @@ input: |-
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
     <xsl:template match="/">
       <widget select="exsl:node-set($v)/x"/>
+      <gadget select="{exsl:node-set($v)/x}"/>
     </xsl:template>
   </xsl:stylesheet>

--- a/test/resources/redundant-boolean-call-packs/boolean-call-in-result-attribute.yaml
+++ b/test/resources/redundant-boolean-call-packs/boolean-call-in-result-attribute.yaml
@@ -11,5 +11,6 @@ input: |-
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" id="s">
     <xsl:template match="/">
       <widget test="boolean(@x)" label="{boolean(@x)}"/>
+      <gadget test="{boolean(@x)}"/>
     </xsl:template>
   </xsl:stylesheet>

--- a/test/string-length-linter.test.js
+++ b/test/string-length-linter.test.js
@@ -4,6 +4,7 @@
  */
 
 const {lintByStringLength} = require('../src/linters/string-length-linter')
+const {validate} = require('../src/validators/xpath-validator')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')
@@ -23,7 +24,8 @@ describe('string-length-linter', function() {
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} string-length comparisons`,
         function() {
-          const defects = lintByStringLength([{file: 'test.xsl', content: yml.input, xsl: input}])
+          const {expressions} = validate([{file: 'test.xsl', content: yml.input, xsl: input}])
+          const defects = lintByStringLength(expressions)
           assert.equal(defects.length, yml.found.amount)
           yml.found.positions.forEach((pos, index) => {
             assert.equal(defects[index].line, pos[0])

--- a/test/translate-linter.test.js
+++ b/test/translate-linter.test.js
@@ -4,6 +4,7 @@
  */
 
 const {lintByTranslate} = require('../src/linters/translate-linter')
+const {validate} = require('../src/validators/xpath-validator')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')
@@ -22,7 +23,8 @@ describe('translate-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} translate case folds`, function() {
-        const defects = lintByTranslate([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const {expressions} = validate([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const defects = lintByTranslate(expressions)
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/using-namespace-axis-linter.test.js
+++ b/test/using-namespace-axis-linter.test.js
@@ -4,6 +4,7 @@
  */
 
 const {lintByNamespaceAxis} = require('../src/linters/using-namespace-axis-linter')
+const {validate} = require('../src/validators/xpath-validator')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')
@@ -22,7 +23,8 @@ describe('using-namespace-axis-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} namespace axes`, function() {
-        const defects = lintByNamespaceAxis([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const {expressions} = validate([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const defects = lintByNamespaceAxis(expressions)
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])

--- a/test/xpath-axis-linter.test.js
+++ b/test/xpath-axis-linter.test.js
@@ -4,6 +4,7 @@
  */
 
 const {lintByAxis} = require('../src/linters/xpath-axis-linter')
+const {validate} = require('../src/validators/xpath-validator')
 const {allFilesFrom, xml, yaml} = require('../src/helpers')
 const path = require('path')
 const assert = require('assert')
@@ -22,7 +23,8 @@ describe('xpath-axis-linter', function() {
     const input = xml.parsedFromString(yml.input)
     describe(`testing ${path.basename(pack)} pack`, function() {
       it(`should find ${yml.found.amount} unabbreviated axes`, function() {
-        const defects = lintByAxis([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const {expressions} = validate([{file: 'test.xsl', content: yml.input, xsl: input}])
+        const defects = lintByAxis(expressions)
         assert.equal(defects.length, yml.found.amount)
         yml.found.positions.forEach((pos, index) => {
           assert.equal(defects[index].line, pos[0])


### PR DESCRIPTION
Ten of the fifteen linters scanned the whole corpus and asked `expressionsOf`
themselves, so each of them read expressions the XPath validator had already
refused and reported a second defect on the same fault. `select="child::"` came
back as an `invalid-xpath-expression` *and* an `unabbreviated-axis`;
`test="count(alpha) = 0 ("` came back as one and a `count-compared-to-zero`.
Withholding the fix was all `defect` could do about it from #636, which left the
advice standing on text no processor accepts.

They are staged over what the validator kept now, the same records
`xpath-format-linter` has taken since #589:

```js
const EXPRESSION_LINTERS = [
  {run: lintByAxis, checks: axisChecks},
  ...
  for (const {source, found} of expressions) {
```

So the exclusion is structural rather than a rule each new check has to
remember, and `defect`'s gate became a condition no call could fail — deleted
here, along with four `close < 0` guards, one per scanner, that no expression
which parsed can reach.

The two linters reading a single attribute went through `selectorOf('select')`
and `nodes()`. They narrow out of the records with a new `whole(found, name)` in
`src/attributes.js`, which asks for the whole value as well as the name: a check
taking the name alone would start reading the `test="{boolean(x)}"` of a literal
result element, where stripping the wrapper prints the node instead of `true`.
That is what the old selector's XSLT-namespace test bought, so both packs grew
the row that pins it. `selectorOf` and the `wholeOf` export go with them.

Verification, over the 455 expressions this repository's 119 parseable fixtures
carry: the full JSON report loses exactly four defects and gains none — the
`unabbreviated-axis` on two refused expressions in
`refused-by-a-declarative-fix.xsl`, and the axis and the `count(...)` comparison
in `refused-expressions.xsl`, each of which the validator already reports at the
offset of its fault. `--fix --fix-suggestions` over every fixture writes a
byte-identical tree, and the announcements differ by those same four lines.
1393 fast and 476 deep tests pass, coverage is back to 100% on all four counts,
and xcop is green over 271 fixtures.

Closes #750.
