### PR TITLE
Divide a stage cost by the whole run, not by its middle reading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,8 @@ README advertises (#755, #756). Two tiers hold it now.
 
 `test/scaling.test.js` is the per-pull-request one. It builds a corpus in
 memory, hands it to every stage at 40 stylesheets and again at 160, and asks two
-questions of each: what it **costs** beside the middle stage of the same run,
-and how it **grew** beside that stage's growth. Both are quotients taken inside
+questions of each: what **percentage of its own run** it costs, and how it
+**grew** beside the middle stage's growth. Both are quotients taken inside
 one process, which is what cancels the machine — an absolute threshold on a
 shared runner either flakes or is set so loose it catches nothing. Each stage is
 timed **directly** rather than by subtracting one run from another, since the
@@ -110,12 +110,30 @@ shape**: it left the cross-file linter's exponent where it was — 1.46 against
 growth distributions overlap, the fix reading 1.85 to 2.04 and the quadratic
 1.66 to 2.43 — and since the lowest reading is the one judged, growth does not
 merely fail to separate them, at 1.66 against 1.85 it ranks them backwards —
-while the costs have nothing between them, 9.6 to 10.4 against 16.7 to 17.1.
-Reverting `src/linters/corpus-linter.js` to its pre-#755 state fails the gate
-three times out of three at 16.2 to 17.4, against the 13 that `SHARES` allows
-it, and master passes ten times of ten idle and six of six under load. A bar
-enough to have caught that would have to separate 2.31 from 1.93, which is
-inside the noise of any machine.
+while the costs have nothing between them, the fix reading 15.1% to 15.7% of the
+run against the quadratic's 29.1% to 30.1% over three alternating pairs on one
+machine. Reverting `src/linters/corpus-linter.js` to its pre-#755 state fails the
+gate three times out of three at 27.68% to 30.85%, against the 26 that `SHARES`
+allows it, and master passes three of three under a load average of eighteen. A
+bar enough to have caught that in growth would have to separate 2.31 from 1.93,
+which is inside the noise of any machine.
+
+What a share is a share **of** is the whole run, the readings summed, and it was
+the *middle* reading of the run until #777 — on the argument that fourteen of the
+eighteen stages sit within a factor of two of each other, so their median is any
+ordinary stage's cost and no one stage can move it. Fourteen readings within a
+factor of two are fourteen that keep swapping places, and a median is the mean of
+the 9th and 10th, so whichever pair lands there sets the denominator of every
+share. Three runs on one idle machine, nothing touched between them, read the
+middle at 19.27, 16.79 and 27.86 ms — while `corpus-linter` spent 220.52, 247.30
+and 282.54 ms, which is 16.43%, 17.85% and 16.06% of its run and 11.44, 14.73 and
+10.14 of the middle. Making a *cheap* stage cheaper moved it hardest, a cheap
+stage being what the median is made of: #775 halved `node-set-linter`, one of the
+two straddling it, and lifted every other share by about a quarter, so an
+optimisation anywhere failed the gate for the cross-file linter — which had cost
+the same to the millisecond. `SLACK` cannot see that either, ratcheting only when
+a *named* stage gets cheap. The sum moves as a whole run does and nothing but a
+real change in the mix moves a share within it.
 
 What is timed is **processor time and not the wall clock**, `process.cpuUsage`
 rather than `process.hrtime`. The wall charges a stage for every slice the
@@ -135,17 +153,19 @@ charges in ticks far coarser than a cheap stage costs over the *small* corpus,
 so eight of the fourteen measure `0` there and their growth arrives `Infinity`
 or `NaN`. A growth that is not a finite number is therefore no reading and is
 dropped rather than judged — verified by quantising the clock to 6 ms here,
-which turns 2 to 4 growths of 18 non-finite and leaves the gate passing. The
-share is unaffected, being taken over the corpus four times larger: that runner
-reads `corpus-linter` at 9.30 where this machine reads 9.28 to 10.13. So a
+which turns 3 to 5 growths of 18 non-finite and leaves the gate passing. The
+share is unaffected, being taken over the corpus four times larger and against
+the whole run rather than one reading of it: under that same coarse clock
+`corpus-linter` reads 14.0% to 14.9% where a fine one reads 15.1% to 15.7%. So a
 coarse clock costs the looser of the two questions on one platform, not the
 gate.
 
 It stands down in one process and says so: `npm run coverage` runs mocha under
 c8, and V8's branch bookkeeping does not fall evenly across the stages — it
 charges `xpath-linter`, the one putting every declarative check through
-fontoxpath, 53 to 56 times the middle stage where an uninstrumented run charges
-it 30. A ceiling wide enough for both would say nothing true about either, so
+fontoxpath, 66% of the run where an uninstrumented run charges it 52% to 54%,
+and leaves `xsl-validator` at 1.85%, under the floor `SLACK` sets for its entry.
+A ceiling wide enough for both would say nothing true about either, so
 the measurement skips itself when `NODE_V8_COVERAGE` is set (in the body, with
 `this.skip()`, never by registering behind a condition) and the coverage run
 reports it pending. Nothing is lost either way: every branch it reaches is
@@ -175,21 +195,24 @@ left outside what measures it — one test asserts exactly that over the
 `src/linters/` directory, and another that no name in `SHARES` has stopped being
 a stage.
 
-`SHARES` names the four stages that legitimately cost more than the rest:
-`xpath-linter` at 55, `corpus-linter` at 13, `xpath-validator` at 9,
-`xsl-validator` at 4. Every other stage answers to one bar, `SHARE` at 2.5,
-which the fourteen of them sit far below at 0.13 to 1.27 — so a cheap stage that
-becomes an expensive one turns red, and earns either a fix or an entry. Two
+`SHARES` names the four stages that legitimately cost more of a run than the
+rest: `xpath-linter` at 75%, `corpus-linter` at 26%, `xpath-validator` at 13%,
+`xsl-validator` at 8%. Every other stage answers to one bar, `SHARE` at 5%,
+which the fourteen of them sit far below at 0.42% to 2.15% — so a cheap stage
+that becomes an expensive one turns red, and earns either a fix or an entry. Two
 things set a ceiling. Where there is a defect to catch it goes **between the two
-measured distributions**: `corpus-linter` at 13 is a quarter above what the fix
-costs and a quarter below what the quadratic costs, which is what fails it three
-times of three at 16.2 to 17.4. Everywhere else it stands about **twice** the
-local reading, on CI evidence rather than caution — a share cancels a machine's
-speed but not its character, and a first spelling four tenths above the local
-readings was refused by a macOS runner charging `xsl-validator` 1.21 of the
-middle where this machine charges 2.2 and `xpath-validator` 6.13 where it charges
-3.8. Those two came off a run since found to have a biased warm-up, so what they
-prove is that headroom is needed, not how much. The table is a
+measured distributions**: `corpus-linter` at 26 stands a tenth above the dearest
+reading the fix has given on any runner and a sixteenth below the cheapest the
+quadratic has given here, which is what fails it three times of three at 27.68%
+to 30.85%. That band is narrow, and narrow on CI evidence rather than caution —
+this is the entry a runner disagrees about most, four of them charging the fix
+14.4%, 19.1%, 22.0% and 23.5% of the run where this machine charges 15.4%, so a
+ceiling drawn halfway between the two local distributions would fail the fix on
+macOS. It is also as wide as this corpus can make it: #755 doubled the
+cross-file linter's cost over forty stylesheets where it multiplied it by 3.4
+over DocBook-XSL, which is the second tier's question rather than this one's.
+Everywhere else the ceiling stands between **half again and twice** the dearest
+reading, there being no second distribution to leave room for. The table is a
 ratchet rather than a licence, the `SPRAWLING` pattern one property over, and it
 turns red from both sides: past the ceiling, or so far under it that `SLACK`
 (four, for the same runner's sake) says the ceiling has stopped being a bar and
@@ -848,5 +871,5 @@ accidentally attached fix turns red.
 | `test/grammar-shapes.test.js` | The same acceptance diff as `grammar-corpus.test.js`, asked of 14112 expressions nobody wrote: every shape a head and one or two tails spell, spaced and glued. A corpus covers only what somebody has already written down, and every class #740 closed stood outside the repository's — so `GAPS` read empty while the grammar refused `text() + 1` and accepted `a?b`, and this sweep parted from the engine 1603 times on the same head. Both classes it was left with are closed by #742, and a generated sweep covers only what its own lists spell, which is the corpus limit one level up: the second was annotated `\? (WORDS)` over a `TAILS` naming no `+` at all, so `xs:integer+ and @b` stood outside its own net, and widening the annotation to `[?+]` uncovered `cast as xs:integer? instance of x` behind it. A predicate too broad to be a class is one failure mode, since an annotation that swallows the next defect turns nothing red; too narrow is the other, and this file was in it. What is annotated now is not a gap in the grammar at all — fontoxpath accepts a word run against the *arity* of a named function reference, where Saxon-HE 12.5 answers `abs#1div 2` with XPST0003 exactly as it answers `1div 2`. One engine's verdict is evidence and not an answer, which is why a second arbiter settles it; `net.sf.saxon.s9api`'s `XPathCompiler` judges them in well under a second, and reading its *code* rather than its exit status is what tells a syntax error from the undeclared prefix or unknown function behind one. That cost is why the fast half now answers in under two seconds rather than under one. The lists grew by four heads and three tails at #753, from 8064 shapes to 14112: a kind test carrying arguments is a head now, and the item types whose brackets hold a type are tails, so the productions that read them stand inside the net rather than beside it. The gate on the count moved with them, since a sweep that has been narrowed reads exactly like one that agrees |
 | `test/strictness.js` | `insists(xpath)` — whether fontoxpath refuses an expression over its own strictness rather than over anything malformed in it: a `namespace::` axis, ExprWhitespace around an axis separator, ExprWhitespace inside a node test (#615, #639). It is the account that replaced the respelling retry #738 deleted, and it is a test-side module because a run has no use for it — nothing in `src/` asks what one engine insists on. Read off the token stream, which is what tells the axis of `1-namespace::x` from the one name of `a-namespace::x`, the lexer having already decided which a `-` is where a lookbehind would be reading characters about a question that is about tokens; the thirteen axis kinds are borrowed from `src/tokens.js`'s `AXIS_KINDS` rather than written down a second time. What it is not is an oracle of validity — `child ::` holds a spaced separator and is no expression — so a gate reads it *beside* `parsed`, never instead of it, and `test/strictness.test.js` pins that with the class it names and refuses all the same |
 | `test/helpers.js` | The only door to a child process in the suite: `runXslint`/`xslintStatus`/`xslintStreams` run the CLI, `xcopped` runs xcop once over a directory, `cmdAvailable` answers whether a tool is there by running it, and `walkedWith(dir, kilobytes)` runs `allFilesFrom` in a process whose JavaScript stack is that small. That last one hands back the largest spread the stack allows beside the walk's own answer, because a walk that survives proves nothing unless the trap was armed and how many arguments a spread carries is V8's business — a Node that moved the number would otherwise leave the test quietly proving nothing (#758). The kilobytes are the smallest stack worth asking for rather than the stack: node needs some seventy to start here and more where a platform's frames are wider, so the ask doubles until one answers and the stack that did comes back, for a caller that has a second question to put to the same size |
-| `test/scaling.test.js` | The speed gate (see **Speed**): charges every stage its own processor time over a generated corpus at 40 stylesheets and again at 160, and fails one that costs more beside the middle stage of its run than `SHARES` allows it, or — where it has no entry there — grew more than `GROWTH` beside that stage's growth. Cost is the sharp question and growth the loose one, because #755 changed a constant and not an exponent, which is a difference the two distributions show plainly: 9.6 to 10.4 against 16.7 to 17.1 in cost, where in growth the fix reads 1.85 to 2.04 and the quadratic 1.66 to 2.43 — the lowest reading being the one judged, growth ranks them backwards. The corpus is the assertion as much as the bar is. It is copied from one committed `test/resources/scaling/stylesheet.xsl`, the way every test stylesheet here lives in a file, with the number of each file substituted into every name it holds — so no two share an expression, a declaration or a namespace, and the memo in `src/syntax.js` cannot make the larger corpus look cheaper than it is. That stylesheet holds a namespace nothing uses, an import, a literal result element and a call of every shape a linter is about, because a stage handed nothing it reads cannot be measured at all: the three per-document linters were exactly that, 0.3 ms with a spread of 358%, until it grew namespaces and imports |
+| `test/scaling.test.js` | The speed gate (see **Speed**): charges every stage its own processor time over a generated corpus at 40 stylesheets and again at 160, and fails one that spends more of its own run than `SHARES` allows it, or — where it has no entry there — grew more than `GROWTH` beside the middle stage's growth. Cost is the sharp question and growth the loose one, because #755 changed a constant and not an exponent, which is a difference the two distributions show plainly: 15.1% to 15.7% of the run against 29.1% to 30.1% in cost, where in growth the fix reads 1.85 to 2.04 and the quadratic 1.66 to 2.43 — the lowest reading being the one judged, growth ranks them backwards. What the cost is a share **of** is the whole run, the readings summed, and it was the middle reading until #777: fourteen of the eighteen stages lie within a factor of two and keep swapping places, so the pair landing 9th and 10th decided the denominator of every share, and #775 — which made one of those two cheaper and touched the cross-file linter not at all — lifted every share by about a quarter and failed the gate. Growth still divides by the median, and for the reason cost cannot: every ordinary stage grows about as the corpus does, so a median growth is any ordinary stage's growth, where an ordinary *cost* is a coin toss between two near-identical readings. The corpus is the assertion as much as the bar is. It is copied from one committed `test/resources/scaling/stylesheet.xsl`, the way every test stylesheet here lives in a file, with the number of each file substituted into every name it holds — so no two share an expression, a declaration or a namespace, and the memo in `src/syntax.js` cannot make the larger corpus look cheaper than it is. That stylesheet holds a namespace nothing uses, an import, a literal result element and a call of every shape a linter is about, because a stage handed nothing it reads cannot be measured at all: the three per-document linters were exactly that, 0.3 ms with a spread of 358%, until it grew namespaces and imports |
 | `test/xcop.deep.test.js` | Writes every pack's inline XSL to one `mkdtempSync` directory and runs xcop over it once; pending, never absent, where the tool does not run |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,13 +171,19 @@ gate.
 It stands down in one process and says so: `npm run coverage` runs mocha under
 c8, and V8's branch bookkeeping does not fall evenly across the stages — it
 charges `xpath-linter`, the one putting every declarative check through
-fontoxpath, 66% of the run where an uninstrumented run charges it 52% to 54%,
-and leaves `xsl-validator` at 1.85% to 1.96% over three runs, under the floor
-`SLACK` sets for its entry of 8, so the gate would fail from both sides at once
-on a tree nobody had touched. A ceiling wide enough for both would say nothing
-true about either, so the measurement skips itself when `NODE_V8_COVERAGE` is set (in the body, with
-`this.skip()`, never by registering behind a condition) and the coverage run
-reports it pending. Nothing is lost either way: every branch it reaches is
+fontoxpath, 65% to 69% of the run where an uninstrumented run charges it 52% to
+57%. A ceiling honest about one of those readings says nothing true about the
+other, which is the reason to stand down, and it is not the same thing as a
+breach: no ceiling here is crossed at all, 69% sitting comfortably under the 75
+that entry allows. What fires is the **floor**, and only sometimes — run alone
+under c8, `xsl-validator`'s judged reading came to 1.93%, 1.95% and 1.97%
+against the 2.00 that `SLACK` leaves an entry of 8, and the ratchet called that
+entry stale in three runs of five, where under `npm run coverage` itself it read
+2.14% to 2.34% and passed three of three. An instrumented process therefore
+answers about c8 rather than about the pipeline, intermittently red on a tree
+nobody has touched, so the measurement skips itself when `NODE_V8_COVERAGE` is
+set (in the body, with `this.skip()`, never by registering behind a condition)
+and the coverage run reports it pending. Nothing is lost either way: every branch it reaches is
 reached by the suite around it, so the 100% gate still holds without it — a
 count is deliberately not quoted here, since one goes stale on the next commit
 that adds a branch — and the gate itself still runs in `npm test`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,10 +113,10 @@ merely fail to separate them, at 1.66 against 1.85 it ranks them backwards —
 while the costs have nothing between them, the fix reading 15.1% to 15.7% of the
 run against the quadratic's 29.1% to 30.1% over three alternating pairs on one
 machine. Reverting `src/linters/corpus-linter.js` to its pre-#755 state fails the
-gate three times out of three at 27.68% to 30.85%, against the 26 that `SHARES`
-allows it, and master passes three of three under a load average of eighteen. A
-bar enough to have caught that in growth would have to separate 2.31 from 1.93,
-which is inside the noise of any machine.
+gate thirty-seven times out of thirty-seven, its judged reading ranging 26.54% to
+31.86% against the 26 that `SHARES` allows it, and master passes three of three
+under a load average of eighteen. A bar enough to have caught that in growth
+would have to separate 2.31 from 1.93, which is inside the noise of any machine.
 
 What a share is a share **of** is the whole run, the readings summed, and it was
 the *middle* reading of the run until #777 — on the argument that fourteen of the
@@ -133,16 +133,24 @@ two straddling it, and lifted every other share by about a quarter, so an
 optimisation anywhere failed the gate for the cross-file linter — which had cost
 the same to the millisecond. `SLACK` cannot see that either, ratcheting only when
 a *named* stage gets cheap. The sum moves as a whole run does and nothing but a
-real change in the mix moves a share within it.
+real change in the mix moves a share within it — with one residual, recorded
+rather than hidden: `xpath-linter` is over half the run, 52.1% to 57.0% here, so
+an optimisation **there** really would move every other share, and the whole
+table would want re-deriving rather than reading as regressions of stages nobody
+touched. What the sum buys is that a change to one of the fourteen *cheap* stages
+no longer does, which is #775 and every other optimisation landed so far.
 
 What is timed is **processor time and not the wall clock**, `process.cpuUsage`
 rather than `process.hrtime`. The wall charges a stage for every slice the
 scheduler hands to something else, so the gate it produced was unusable on a
 busy machine: under sixteen processes competing for ten cores it failed seven
-runs of eight, naming stages nothing had touched at 2.36 and 2.97 times the
-middle — indistinguishable, to whoever reads the build, from the one true
-failure — and reading `corpus-linter` itself at 0.78, which is its bar's *other*
-side and would have announced #755 as settled. Retrying does not help, because
+runs of eight, naming stages nothing had touched at 2.36 and 2.97 of the middle
+stage — indistinguishable, to whoever reads the build, from the one true
+failure — and reading `corpus-linter` itself at 0.78 of it, which is its bar's
+*other* side and would have announced #755 as settled. Those readings are in the
+unit the gate used before #777, the middle stage rather than the whole run, and
+are left in it: what they are evidence about is the clock, not the divisor.
+Retrying does not help, because
 contention lasts longer than a run and inflates the same stage in every attempt.
 Processor time is what the stage itself spent, so the same sixteen processes
 move it by a tenth, every entry staying within that of its idle reading, and the
@@ -164,9 +172,10 @@ It stands down in one process and says so: `npm run coverage` runs mocha under
 c8, and V8's branch bookkeeping does not fall evenly across the stages — it
 charges `xpath-linter`, the one putting every declarative check through
 fontoxpath, 66% of the run where an uninstrumented run charges it 52% to 54%,
-and leaves `xsl-validator` at 1.85%, under the floor `SLACK` sets for its entry.
-A ceiling wide enough for both would say nothing true about either, so
-the measurement skips itself when `NODE_V8_COVERAGE` is set (in the body, with
+and leaves `xsl-validator` at 1.85% to 1.96% over three runs, under the floor
+`SLACK` sets for its entry of 8, so the gate would fail from both sides at once
+on a tree nobody had touched. A ceiling wide enough for both would say nothing
+true about either, so the measurement skips itself when `NODE_V8_COVERAGE` is set (in the body, with
 `this.skip()`, never by registering behind a condition) and the coverage run
 reports it pending. Nothing is lost either way: every branch it reaches is
 reached by the suite around it, so the 100% gate still holds without it — a
@@ -202,15 +211,19 @@ which the fourteen of them sit far below at 0.42% to 2.15% — so a cheap stage
 that becomes an expensive one turns red, and earns either a fix or an entry. Two
 things set a ceiling. Where there is a defect to catch it goes **between the two
 measured distributions**: `corpus-linter` at 26 stands a tenth above the dearest
-reading the fix has given on any runner and a sixteenth below the cheapest the
-quadratic has given here, which is what fails it three times of three at 27.68%
-to 30.85%. That band is narrow, and narrow on CI evidence rather than caution —
-this is the entry a runner disagrees about most, four of them charging the fix
-14.4%, 19.1%, 22.0% and 23.5% of the run where this machine charges 15.4%, so a
-ceiling drawn halfway between the two local distributions would fail the fix on
-macOS. It is also as wide as this corpus can make it: #755 doubled the
-cross-file linter's cost over forty stylesheets where it multiplied it by 3.4
-over DocBook-XSL, which is the second tier's question rather than this one's.
+reading the fix has given on any runner, 23.5%, and a **fortieth** below the
+cheapest the quadratic has given here, 26.54%. That band is narrow, and narrow on
+CI evidence rather than caution — this is the entry a runner disagrees about most,
+four of them charging the fix 14.4%, 19.1%, 22.0% and 23.5% of the run where this
+machine charges 15.4%, so a ceiling drawn halfway between the two local
+distributions would fail the fix on macOS. The bar sits at the top of the band
+rather than in the middle of it for that reason: the fix's upper edge is four
+single readings from four machines where the quadratic's lower edge is
+thirty-seven from one, so the headroom goes to the side whose evidence is thinner
+and the catching side leans on 37 of 37 instead. The band is also as wide as this
+corpus can make it: #755 doubled the cross-file linter's cost over forty
+stylesheets where it multiplied it by 3.4 over DocBook-XSL, which is the second
+tier's question rather than this one's.
 Everywhere else the ceiling stands between **half again and twice** the dearest
 reading, there being no second distribution to leave room for. The table is a
 ratchet rather than a licence, the `SPRAWLING` pattern one property over, and it
@@ -871,5 +884,5 @@ accidentally attached fix turns red.
 | `test/grammar-shapes.test.js` | The same acceptance diff as `grammar-corpus.test.js`, asked of 14112 expressions nobody wrote: every shape a head and one or two tails spell, spaced and glued. A corpus covers only what somebody has already written down, and every class #740 closed stood outside the repository's — so `GAPS` read empty while the grammar refused `text() + 1` and accepted `a?b`, and this sweep parted from the engine 1603 times on the same head. Both classes it was left with are closed by #742, and a generated sweep covers only what its own lists spell, which is the corpus limit one level up: the second was annotated `\? (WORDS)` over a `TAILS` naming no `+` at all, so `xs:integer+ and @b` stood outside its own net, and widening the annotation to `[?+]` uncovered `cast as xs:integer? instance of x` behind it. A predicate too broad to be a class is one failure mode, since an annotation that swallows the next defect turns nothing red; too narrow is the other, and this file was in it. What is annotated now is not a gap in the grammar at all — fontoxpath accepts a word run against the *arity* of a named function reference, where Saxon-HE 12.5 answers `abs#1div 2` with XPST0003 exactly as it answers `1div 2`. One engine's verdict is evidence and not an answer, which is why a second arbiter settles it; `net.sf.saxon.s9api`'s `XPathCompiler` judges them in well under a second, and reading its *code* rather than its exit status is what tells a syntax error from the undeclared prefix or unknown function behind one. That cost is why the fast half now answers in under two seconds rather than under one. The lists grew by four heads and three tails at #753, from 8064 shapes to 14112: a kind test carrying arguments is a head now, and the item types whose brackets hold a type are tails, so the productions that read them stand inside the net rather than beside it. The gate on the count moved with them, since a sweep that has been narrowed reads exactly like one that agrees |
 | `test/strictness.js` | `insists(xpath)` — whether fontoxpath refuses an expression over its own strictness rather than over anything malformed in it: a `namespace::` axis, ExprWhitespace around an axis separator, ExprWhitespace inside a node test (#615, #639). It is the account that replaced the respelling retry #738 deleted, and it is a test-side module because a run has no use for it — nothing in `src/` asks what one engine insists on. Read off the token stream, which is what tells the axis of `1-namespace::x` from the one name of `a-namespace::x`, the lexer having already decided which a `-` is where a lookbehind would be reading characters about a question that is about tokens; the thirteen axis kinds are borrowed from `src/tokens.js`'s `AXIS_KINDS` rather than written down a second time. What it is not is an oracle of validity — `child ::` holds a spaced separator and is no expression — so a gate reads it *beside* `parsed`, never instead of it, and `test/strictness.test.js` pins that with the class it names and refuses all the same |
 | `test/helpers.js` | The only door to a child process in the suite: `runXslint`/`xslintStatus`/`xslintStreams` run the CLI, `xcopped` runs xcop once over a directory, `cmdAvailable` answers whether a tool is there by running it, and `walkedWith(dir, kilobytes)` runs `allFilesFrom` in a process whose JavaScript stack is that small. That last one hands back the largest spread the stack allows beside the walk's own answer, because a walk that survives proves nothing unless the trap was armed and how many arguments a spread carries is V8's business — a Node that moved the number would otherwise leave the test quietly proving nothing (#758). The kilobytes are the smallest stack worth asking for rather than the stack: node needs some seventy to start here and more where a platform's frames are wider, so the ask doubles until one answers and the stack that did comes back, for a caller that has a second question to put to the same size |
-| `test/scaling.test.js` | The speed gate (see **Speed**): charges every stage its own processor time over a generated corpus at 40 stylesheets and again at 160, and fails one that spends more of its own run than `SHARES` allows it, or — where it has no entry there — grew more than `GROWTH` beside the middle stage's growth. Cost is the sharp question and growth the loose one, because #755 changed a constant and not an exponent, which is a difference the two distributions show plainly: 15.1% to 15.7% of the run against 29.1% to 30.1% in cost, where in growth the fix reads 1.85 to 2.04 and the quadratic 1.66 to 2.43 — the lowest reading being the one judged, growth ranks them backwards. What the cost is a share **of** is the whole run, the readings summed, and it was the middle reading until #777: fourteen of the eighteen stages lie within a factor of two and keep swapping places, so the pair landing 9th and 10th decided the denominator of every share, and #775 — which made one of those two cheaper and touched the cross-file linter not at all — lifted every share by about a quarter and failed the gate. Growth still divides by the median, and for the reason cost cannot: every ordinary stage grows about as the corpus does, so a median growth is any ordinary stage's growth, where an ordinary *cost* is a coin toss between two near-identical readings. The corpus is the assertion as much as the bar is. It is copied from one committed `test/resources/scaling/stylesheet.xsl`, the way every test stylesheet here lives in a file, with the number of each file substituted into every name it holds — so no two share an expression, a declaration or a namespace, and the memo in `src/syntax.js` cannot make the larger corpus look cheaper than it is. That stylesheet holds a namespace nothing uses, an import, a literal result element and a call of every shape a linter is about, because a stage handed nothing it reads cannot be measured at all: the three per-document linters were exactly that, 0.3 ms with a spread of 358%, until it grew namespaces and imports |
+| `test/scaling.test.js` | The speed gate (see **Speed**): charges every stage its own processor time over a generated corpus at 40 stylesheets and again at 160, and fails one that spends more of its own run than `SHARES` allows it, or — where it has no entry there — grew more than `GROWTH` beside the middle stage's growth. Cost is the sharp question and growth the loose one, because #755 changed a constant and not an exponent, which is a difference the two distributions show plainly: 15.1% to 15.7% of the run against the quadratic's 26.5% to 31.9%, where in growth the fix reads 1.85 to 2.04 and the quadratic 1.66 to 2.43 — the lowest reading being the one judged, growth ranks them backwards. What the cost is a share **of** is the whole run, the readings summed, and it was the middle reading until #777: fourteen of the eighteen stages lie within a factor of two and keep swapping places, so the pair landing 9th and 10th decided the denominator of every share, and #775 — which made one of those two cheaper and touched the cross-file linter not at all — lifted every share by about a quarter and failed the gate. Growth still divides by the median, and for the reason cost cannot: every ordinary stage grows about as the corpus does, so a median growth is any ordinary stage's growth, where an ordinary *cost* is a coin toss between two near-identical readings. The corpus is the assertion as much as the bar is. It is copied from one committed `test/resources/scaling/stylesheet.xsl`, the way every test stylesheet here lives in a file, with the number of each file substituted into every name it holds — so no two share an expression, a declaration or a namespace, and the memo in `src/syntax.js` cannot make the larger corpus look cheaper than it is. That stylesheet holds a namespace nothing uses, an import, a literal result element and a call of every shape a linter is about, because a stage handed nothing it reads cannot be measured at all: the three per-document linters were exactly that, 0.3 ms with a spread of 358%, until it grew namespaces and imports |
 | `test/xcop.deep.test.js` | Writes every pack's inline XSL to one `mkdtempSync` directory and runs xcop over it once; pending, never absent, where the tool does not run |

--- a/test/scaling.test.js
+++ b/test/scaling.test.js
@@ -32,8 +32,9 @@ const STEP = 4
  * fail to separate them — at 1.66 against 1.85 it ranks them backwards. The
  * share separates them outright: over three alternating pairs on one machine,
  * the fix read 15.10%, 15.27% and 15.69% of its run where the quadratic read
- * 29.06%, 29.98% and 30.12%, and the gate fails the quadratic three times of
- * three at 27.68%, 30.84% and 30.85%.
+ * 29.06%, 29.98% and 30.12%, and over thirty-seven runs of the gate against
+ * that quadratic the judged reading ranged 26.54% to 31.86% and every one was
+ * caught.
  *
  * A share is a quotient taken inside one run, so it cancels a machine's speed
  * the way a growth ratio does, and unlike one it hardly moves when the machine
@@ -52,16 +53,28 @@ const STEP = 4
  * median is made of: #775 halved `node-set-linter`, one of the two straddling
  * it, and lifted every other share by about a quarter.
  *
+ * What a sum is not is immune outright, and the residual is worth recording
+ * rather than hiding: `xpath-linter` is over half the run, 52.1% to 57.0% here,
+ * so an optimisation *there* really would move every other share, and the
+ * entries below would want re-deriving rather than reading as regressions of
+ * stages nobody touched. What a sum buys is that a change to one of the
+ * fourteen *cheap* stages no longer does, which is every optimisation this
+ * project has landed so far and #775 exactly.
+ *
  * Two things set a ceiling. Where there is a defect to catch, it goes between
  * the two measured distributions — `corpus-linter` at 26, a tenth above the
- * dearest reading the fix has given on any runner, 23.5%, and a sixteenth below
- * the cheapest the quadratic has given here, 27.68%. That band is narrower than
- * the readings on one machine suggest, because this is the entry a runner
- * disagrees about most: the four that have reported a table charged the fix
- * 14.4%, 19.1%, 22.0% and 23.5% of the run where this machine charges 15.4%, so
- * a ceiling drawn halfway between the two distributions *here* would fail the
- * fix on macOS. It is also as wide as this corpus can make it, #755 having
- * doubled the cross-file linter's cost over forty stylesheets where it
+ * dearest reading the fix has given on any runner, 23.5%, and a *fortieth*
+ * below the cheapest the quadratic has given here, 26.54%. That band is narrow,
+ * and it is narrow because this is the entry a runner disagrees about most: the
+ * four that have reported a table charged the fix 14.4%, 19.1%, 22.0% and 23.5%
+ * of the run where this machine charges 15.4%, so a ceiling drawn halfway
+ * between the two distributions *here* would fail the fix on macOS. The bar
+ * therefore sits at the top of the band rather than in the middle of it, and
+ * deliberately: the fix's upper edge is four single readings from four machines
+ * where the quadratic's lower edge is thirty-seven from one, so the headroom is
+ * spent on the side the evidence is thinner and the catching side leans on 37
+ * of 37 instead. The band is also as wide as this corpus can make it, #755
+ * having doubled the cross-file linter's cost over forty stylesheets where it
  * multiplied it by 3.4 over DocBook-XSL, which is the second tier's question
  * rather than this one's. Everywhere else the ceiling stands between half again
  * and twice the dearest reading, there being no second distribution to leave
@@ -187,8 +200,10 @@ const corpus = function(from, files) {
  * together. Not the wall clock, which charges a stage for every slice the
  * scheduler hands to something else: under sixteen processes competing for ten
  * cores the wall failed seven runs of eight, naming stages nothing had touched
- * at 2.36 and 2.97 times the middle and reading the cross-file linter at 0.78,
- * which is its bar's other side and would have called #755 settled. The same
+ * at 2.36 and 2.97 of the middle stage and reading the cross-file linter at
+ * 0.78 of it — that being the unit the gate used before #777, so the numbers
+ * are the old one's — which is its bar's other side and would have called #755
+ * settled. The same
  * runs judged on processor time hold every reading within a tenth of what an
  * idle machine gives, because time the stage did not get is time it is not
  * charged for.
@@ -203,13 +218,16 @@ const charged = function() {
  * Whether V8 is counting branches in this process, which makes it the wrong
  * process to ask about speed. `npm run coverage` runs mocha under c8, and that
  * bookkeeping does not fall evenly across the stages: it charges `xpath-linter`
- * — the one putting every declarative check through fontoxpath — 53 to 56 times
- * the middle stage where an uninstrumented run charges it 30. A ceiling wide
- * enough for both would say nothing true about either, so the gate stands down
- * here and speaks in `npm test` and in the `build` job over six runners
- * instead. The coverage gate loses nothing by it: every branch this test
- * reaches is reached by the suite around it, so the 100% gate still holds with
- * the measurement skipped.
+ * — the one putting every declarative check through fontoxpath — 66% of the run
+ * where an uninstrumented one charges it 52% to 54%, and what it takes from
+ * every other share it takes from `xsl-validator` too, which reads 1.85% to
+ * 1.96% over three runs, under the floor `SLACK` sets for an entry of 8. So the
+ * gate would fail from both sides at once, on a tree nobody had touched. A
+ * ceiling wide enough for both would say nothing true about either, so the gate
+ * stands down here and speaks in `npm test` and in the `build` job over six
+ * runners instead. The coverage gate loses nothing by it: every branch this
+ * test reaches is reached by the suite around it, so the 100% gate still holds
+ * with the measurement skipped.
  * @return {boolean} - Whether this process is instrumented for coverage
  */
 const instrumented = function() {

--- a/test/scaling.test.js
+++ b/test/scaling.test.js
@@ -218,16 +218,21 @@ const charged = function() {
  * Whether V8 is counting branches in this process, which makes it the wrong
  * process to ask about speed. `npm run coverage` runs mocha under c8, and that
  * bookkeeping does not fall evenly across the stages: it charges `xpath-linter`
- * — the one putting every declarative check through fontoxpath — 66% of the run
- * where an uninstrumented one charges it 52% to 54%, and what it takes from
- * every other share it takes from `xsl-validator` too, which reads 1.85% to
- * 1.96% over three runs, under the floor `SLACK` sets for an entry of 8. So the
- * gate would fail from both sides at once, on a tree nobody had touched. A
- * ceiling wide enough for both would say nothing true about either, so the gate
- * stands down here and speaks in `npm test` and in the `build` job over six
- * runners instead. The coverage gate loses nothing by it: every branch this
- * test reaches is reached by the suite around it, so the 100% gate still holds
- * with the measurement skipped.
+ * — the one putting every declarative check through fontoxpath — 65% to 69% of
+ * the run where an uninstrumented one charges it 52% to 57%. A ceiling honest
+ * about one of those readings says nothing true about the other, which is the
+ * whole reason to stand down, and it is not the same thing as a breach: 69% is
+ * comfortably under the 75 that entry allows, and no ceiling here is crossed at
+ * all. What does fire is the *floor*, and only sometimes. Run alone under c8,
+ * `xsl-validator`'s judged reading came to 1.93%, 1.95% and 1.97% against the
+ * 2.00 that `SLACK` leaves an entry of 8, and the ratchet called that entry
+ * stale in three runs of five; under the parallel command above it read 2.14%
+ * to 2.34% and the gate passed three of three. So what an instrumented process
+ * gives is an answer about c8 rather than about the pipeline, intermittently
+ * red on a tree nobody has touched. The gate skips here and speaks in
+ * `npm test` and in the `build` job over six runners instead, and the coverage
+ * gate loses nothing by it: every branch this test reaches is reached by the
+ * suite around it, so the 100% gate still holds with the measurement skipped.
  * @return {boolean} - Whether this process is instrumented for coverage
  */
 const instrumented = function() {

--- a/test/scaling.test.js
+++ b/test/scaling.test.js
@@ -23,47 +23,69 @@ const SMALL = 40
 const STEP = 4
 
 /**
- * What each stage costs beside the middle stage of its own run, and the most it
- * may cost. This is the assertion the gate stands on, because the one speed
- * regression this project has actually had was a constant and not a shape: #755
- * left the cross-file linter's exponent where it was and multiplied what it
- * spent at every size. Growth cannot see that: the fix reads 1.85 to 2.04 and
- * the quadratic 1.66 to 2.43, and since the lowest reading is the one judged,
- * growth does not merely fail to separate them — at 1.66 against 1.85 it ranks
- * them backwards. The share reads 9.6 to 10.4 against 16.7 to 17.1, with
- * nothing between. A share is a quotient taken inside one run, so it cancels a
- * machine's speed the way a growth ratio does, and unlike one it hardly moves
- * when the machine is busy: sixteen processes fighting over ten cores leave
- * every entry below within a tenth of its idle reading.
+ * What percentage of its own run each stage may spend. This is the assertion
+ * the gate stands on, because the one speed regression this project has
+ * actually had was a constant and not a shape: #755 left the cross-file
+ * linter's exponent where it was and multiplied what it spent at every size.
+ * Growth cannot see that: the fix reads 1.85 to 2.04 and the quadratic 1.66 to
+ * 2.43, and since the lowest reading is the one judged, growth does not merely
+ * fail to separate them — at 1.66 against 1.85 it ranks them backwards. The
+ * share separates them outright: over three alternating pairs on one machine,
+ * the fix read 15.10%, 15.27% and 15.69% of its run where the quadratic read
+ * 29.06%, 29.98% and 30.12%, and the gate fails the quadratic three times of
+ * three at 27.68%, 30.84% and 30.85%.
+ *
+ * A share is a quotient taken inside one run, so it cancels a machine's speed
+ * the way a growth ratio does, and unlike one it hardly moves when the machine
+ * is busy: under a load average of eighteen this machine charged
+ * `corpus-linter` 15.1% to 15.7% where idle it charges 16.1% to 17.9%. What a
+ * share is *of* is the whole run, the readings summed, and that is #777: it was
+ * the middle reading of the run, on the argument that fourteen of the eighteen
+ * stages sit within a factor of two of each other so no one stage can move it.
+ * Fourteen readings within a factor of two are fourteen that keep swapping
+ * places, and the median is the mean of the 9th and 10th, so whichever pair
+ * lands there sets the denominator of every share. Three runs on one idle
+ * machine, nothing touched between them, read the middle at 19.27, 16.79 and
+ * 27.86 ms and `corpus-linter` at 11.44, 14.73 and 10.14 of it, where it spent
+ * 220.52, 247.30 and 282.54 ms and 16.43%, 17.85% and 16.06% of its run. Making
+ * a *cheap* stage cheaper moved it hardest, since a cheap stage is what the
+ * median is made of: #775 halved `node-set-linter`, one of the two straddling
+ * it, and lifted every other share by about a quarter.
  *
  * Two things set a ceiling. Where there is a defect to catch, it goes between
- * the two measured distributions — `corpus-linter` at 13, a quarter above what
- * the fix costs and a quarter below what the quadratic costs. Everywhere else
- * it stands about twice the local reading, because a share cancels a machine's
- * speed and not its character: a first spelling sat four tenths above these
- * readings and a macOS runner refused it, charging `xsl-validator` 1.21 where
- * this machine charges 2.2 and `xpath-validator` 6.13 where it charges 3.8.
- * Those two came off a run whose warm-up is now known to have biased the first
- * attempt, so what they still prove is that headroom is needed, not how much.
+ * the two measured distributions — `corpus-linter` at 26, a tenth above the
+ * dearest reading the fix has given on any runner, 23.5%, and a sixteenth below
+ * the cheapest the quadratic has given here, 27.68%. That band is narrower than
+ * the readings on one machine suggest, because this is the entry a runner
+ * disagrees about most: the four that have reported a table charged the fix
+ * 14.4%, 19.1%, 22.0% and 23.5% of the run where this machine charges 15.4%, so
+ * a ceiling drawn halfway between the two distributions *here* would fail the
+ * fix on macOS. It is also as wide as this corpus can make it, #755 having
+ * doubled the cross-file linter's cost over forty stylesheets where it
+ * multiplied it by 3.4 over DocBook-XSL, which is the second tier's question
+ * rather than this one's. Everywhere else the ceiling stands between half again
+ * and twice the dearest reading, there being no second distribution to leave
+ * room for.
  * @type {{[stage: string]: number}}
  */
 const SHARES = {
-  'xpath-linter': 55,
-  'corpus-linter': 13,
-  'xpath-validator': 9,
-  'xsl-validator': 4,
+  'xpath-linter': 75,
+  'corpus-linter': 26,
+  'xpath-validator': 13,
+  'xsl-validator': 8,
 }
 
 /**
- * What any stage not named in `SHARES` may cost beside the middle stage. The
- * fourteen of them read 0.13 to 1.27, so this is the bar a cheap stage crosses
- * by becoming an expensive one, and crossing it earns an entry above or a fix.
- * Twice what the dearest of them reads, for the same
- * reason the entries above are: a runner of another character moves a share by
- * as much as nine tenths.
+ * What percentage of the run any stage not named in `SHARES` may spend. The
+ * fourteen of them read 0.42% to 2.15% here and 0.35% to 1.82% on the runner
+ * that reported a table, so this is the bar a cheap stage crosses by becoming
+ * an expensive one, and crossing it earns an entry above or a fix. More than
+ * twice what the dearest of them reads, for the same reason the entries above
+ * are: a runner of another character moves a share, and a stage that has
+ * really become expensive lands in the tens rather than a tenth above.
  * @type {number}
  */
-const SHARE = 2.5
+const SHARE = 5
 
 /**
  * How many times its own reading a ceiling may stand above before it has
@@ -71,12 +93,12 @@ const SHARE = 2.5
  * a stage that grew past its entry fails, and so does a stage that has been
  * made so much cheaper that the entry it left behind would let the whole
  * regression back in. `SPRAWLING` in `eslint.config.mjs` is the same shape one
- * property over. Four rather than two, and a macOS runner is what set it: it
- * charged `xsl-validator` 1.21 of the middle where this machine charges 2.2,
- * so a ceiling two and a half times the local reading was more than three times
- * that one and the entry was called stale on a tree nobody had touched. What is
- * left to catch is a stage made several times cheaper, which is what #755's
- * remainder will do to the cross-file entry.
+ * property over. Four rather than two, because a share cancels a machine's
+ * speed and not its character and the runners disagree with this machine by as
+ * much as a half — `corpus-linter` at 23.5% of the run where this one charges
+ * 15.4%, and `xsl-validator` at 2.8% where it charges 3.3%. What is left to
+ * catch is a stage made several times cheaper, which is what #755's remainder
+ * will do to the cross-file entry.
  * @type {number}
  */
 const SLACK = 4
@@ -92,8 +114,8 @@ const SLACK = 4
  * really does hold a quadratic (#769) that forty stylesheets are too few to
  * show. Loose on purpose beyond that, because growth is the noisier of the two
  * questions — the cross-file linter reads 1.71 to 1.89 across runs where its
- * share reads 9.6 to 10.4 — and a bar tight enough to catch a constant fires on
- * stages nothing touched.
+ * share reads 15.1% to 15.7% — and a bar tight enough to catch a constant fires
+ * on stages nothing touched.
  * @type {number}
  */
 const GROWTH = 3.0
@@ -232,10 +254,13 @@ const measured = function(from, files) {
 }
 
 /**
- * The middle of a list of readings, which is what one stage of ordinary cost
- * reads on this machine in this run: fourteen of the eighteen stages sit within
- * a factor of two of each other, so the median is theirs and no one stage can
- * move it.
+ * The middle of a list of readings. It answers the growth question alone, where
+ * the readings are ratios rather than milliseconds: every stage of ordinary
+ * shape grows about as the corpus does, so their median is one stage's growth
+ * whichever stage happens to sit there. The median *cost* is not that and no
+ * longer decides anything (#777) — the fourteen ordinary stages keep swapping
+ * places, so the pair landing 9th and 10th moved the denominator of every share
+ * by as much as a half.
  * @param {Array.<number>} list - The readings
  * @return {number} - Their median
  */
@@ -246,11 +271,19 @@ const middle = function(list) {
 }
 
 /**
- * What each stage costs and how it grew, both as multiples of what the middle
- * stage of the same run did. Two quotients taken inside one process, which is
- * what survives a shared machine, and both divided by the middle, which is what
- * survives a different one: an absolute threshold either flakes or is set loose
- * enough to catch nothing.
+ * What percentage of its run each stage spends, and how it grew as a multiple
+ * of what the middle stage's growth did. Two quotients taken inside one
+ * process, which is what survives a shared machine, and both divided by
+ * something the whole run supplies, which is what survives a different one: an
+ * absolute threshold either flakes or is set loose enough to catch nothing.
+ *
+ * The cost is divided by the readings summed and the growth by their median,
+ * which is not an inconsistency but the two questions being different. A stage
+ * of ordinary shape grows as the corpus does, so a median growth is any
+ * ordinary stage's growth; a stage of ordinary cost does not exist in the same
+ * way, fourteen of them lying within a factor of two and swapping places run to
+ * run, so a median cost is a coin toss between two near-identical readings and
+ * dividing by it made every share depend on which way the coin fell (#777).
  * @param {number} attempt - Which attempt this is, deciding the file numbers
  * @return {Map.<string, {share: number, growth: number}>} - Cost and growth
  */
@@ -260,11 +293,11 @@ const weighed = function(attempt) {
   const ratios = new Map(
     Array.from(small, ([name, span]) => [name, large.get(name) / span]),
   )
-  const centre = middle(Array.from(large.values()))
+  const whole = Array.from(large.values()).reduce((one, two) => one + two, 0)
   const linear = middle(Array.from(ratios.values()))
   return new Map(
     Array.from(large, ([name, span]) => [name, {
-      share: span / centre,
+      share: 100 * span / whole,
       growth: ratios.get(name) / linear,
     }]),
   )
@@ -278,10 +311,12 @@ const weighed = function(attempt) {
  * all and is dropped rather than judged: Windows charges processor time in
  * ticks far coarser than a cheap stage costs over the small corpus, so eight of
  * the fourteen measured `0` there and their growth came back `Infinity` or
- * `NaN`. The share, taken over the corpus four times larger, resolves on that
- * runner as it does here — `corpus-linter` reading 9.30 against 9.28 to 10.13 —
- * so what a coarse clock costs is the looser of the two questions on one
- * platform, not the gate.
+ * `NaN`. The share is unhurt by the same clock, being taken over the corpus
+ * four times larger and against the whole run rather than one reading of it:
+ * with the clock quantised to 6 ms here, which is what turns those growths
+ * non-finite, every entry holds within a tenth of a fine clock's answer. So
+ * what a coarse clock costs is the looser of the two questions on one platform,
+ * not the gate.
  * @param {string} name - Name of the stage
  * @param {Array.<{share: number, growth: number}>} readings - Per attempt
  * @return {string} - The fault, or an empty string
@@ -296,16 +331,15 @@ const fault = function(name, readings) {
   }
   let said = ''
   if (share > ceiling) {
-    said = `${name} costs ${share.toFixed(2)} times what the middle stage of ` +
-      `its own run costs, past the ${ceiling} that test/scaling.test.js ` +
-      `allows it`
+    said = `${name} spends ${share.toFixed(2)}% of its own run, past the ` +
+      `${ceiling}% that test/scaling.test.js allows it`
   } else if (!named && growths.length > 0 && Math.min(...growths) > GROWTH) {
     said = `${name} grew ${Math.min(...growths).toFixed(2)} times what the ` +
       `middle stage grew when the corpus grew ${STEP} times, so its shape has ` +
       `changed`
   } else if (named && ceiling > SLACK * share) {
-    said = `${name} costs only ${share.toFixed(2)} times the middle where it ` +
-      `is allowed ${ceiling}, so the entry has stopped being a bar and wants ` +
+    said = `${name} spends only ${share.toFixed(2)}% of its run where it is ` +
+      `allowed ${ceiling}%, so the entry has stopped being a bar and wants ` +
       `tightening`
   }
   return said
@@ -342,7 +376,7 @@ const judged = function() {
       readings.set(name, (readings.get(name) ?? []).concat([one]))
     }
     table = Array.from(weight, ([name, one]) =>
-      `${name} ${one.share.toFixed(2)} of the middle, grew ` +
+      `${name} ${one.share.toFixed(2)}% of its run, grew ` +
       `${one.growth.toFixed(2)}`).join(', ')
     found = Array.from(readings, ([name, list]) => fault(name, list))
       .filter((said) => said !== '')


### PR DESCRIPTION
The speed gate divided each stage's cost by the *middle* reading of its own run,
on the argument that fourteen of the eighteen stages sit within a factor of two
of each other, so their median is any ordinary stage's cost and no one stage can
move it. Fourteen readings within a factor of two are fourteen that keep swapping
places, and a median is the mean of the 9th and 10th, so whichever pair lands
there sets the denominator of every share. Three runs on one idle machine,
nothing touched between them, read the middle at 19.27, 16.79 and 27.86 ms.

So the gate fires on optimisations. #775 halves `node-set-linter`, one of the two
stages straddling the median, and lifts every other share by about a quarter —
`corpus-linter` among them, which it does not touch and which costs the same to
the millisecond, past a ceiling of 13. `SLACK` cannot see that either, ratcheting
only when a *named* stage gets cheap. Master's own head fails the same way on the
macos-15 runner today, at 23.76 against that 13.

The denominator is the readings summed now, and a share is a percentage of the
run:

```js
const whole = Array.from(large.values()).reduce((one, two) => one + two, 0)
const linear = middle(Array.from(ratios.values()))
return new Map(
  Array.from(large, ([name, span]) => [name, {
    share: 100 * span / whole,
    growth: ratios.get(name) / linear,
  }]),
)
```

Growth still divides by the median, which is not an inconsistency but the two
questions being different: every stage of ordinary shape grows about as the
corpus does, so a median growth is any ordinary stage's growth, where an ordinary
*cost* is a coin toss between two near-identical readings.

Every ceiling is re-derived against the new metric, the units having changed, and
the between-the-distributions claim with them. Over three alternating pairs on
one machine the fix reads 15.10%, 15.27% and 15.69% of its run where the pre-#755
quadratic reads 29.06%, 29.98% and 30.12%; over thirty-seven runs of the gate
against that quadratic the judged reading ranges 26.54% to 31.86% and every one
is caught, against the 26 it now allows, while master passes three of three under
a load average of eighteen and #775's tree three of three. The band is narrower than one machine suggests, because this is the entry
a runner disagrees about most: four of them charge the fix 14.4%, 19.1%, 22.0%
and 23.5% where this machine charges 15.4%, so a ceiling drawn halfway between
the two local distributions would fail the fix on macOS. So the bar sits at the
top of the band rather than in the middle of it, and deliberately: the fix's
upper edge is four single readings from four machines where the quadratic's lower
edge is thirty-seven from one, so the headroom goes to the side whose evidence is
thinner and the catching side leans on 37 of 37 instead of on margin — a
fortieth, not the sixteenth an earlier draft of the docblock claimed. The band is
also as wide as this corpus can make it — #755 doubled the cross-file linter's cost over forty
stylesheets where it multiplied it by 3.4 over DocBook-XSL, which is the nightly
tier's question rather than this one's.

A coarse clock stays the growth question's problem alone. Quantised to 6 ms,
which is what turns 3 to 5 growths of 18 non-finite, `corpus-linter` reads 14.0%
to 14.9% against the 15.1% to 15.7% a fine clock gives it. Under c8 the gate
still stands down, and still has to: c8 charges `xpath-linter` 65% to 69% of the
run where an uninstrumented one charges 52% to 57%, so a ceiling honest about one
of those readings says nothing true about the other. No ceiling is crossed —
69% is under the 75 that entry allows. What fires is the floor, intermittently:
run alone under c8, `xsl-validator`'s judged reading came to 1.93%, 1.95% and
1.97% against the 2.00 `SLACK` leaves an entry of 8 and the ratchet called it
stale in three runs of five, where under `npm run coverage` itself it read 2.14%
to 2.34% and passed three of three. One residual is recorded rather than
hidden beside the ceilings: `xpath-linter` is over half the run, 52.1% to 57.0%
here, so an optimisation *there* really would move every other share and the
whole table would want re-deriving. What the sum buys is that a change to one of
the fourteen cheap stages no longer does, which is #775 exactly.

Closes #777.


